### PR TITLE
build: fetch sidebar submodule over public HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "upstream/DSH-better-sidebar"]
 	path = upstream/DSH-better-sidebar
-	url = git@github.com:dsh-external/DSH-better-sidebar.git
+	url = https://github.com/omdsh-dev/DSH-better-sidebar.git
 	branch = main

--- a/README.en.md
+++ b/README.en.md
@@ -91,9 +91,10 @@ pnpm run build:dsh
 pnpm start
 ```
 
-The Better Sidebar Host is pinned as a Git submodule. Source builds need
-SSH/`gh` access to that private repository. Published DMG and ZIP artifacts
-already contain the compiled output and require no repository access.
+The Better Sidebar Host is pinned as a Git submodule and fetched from a public
+HTTPS repository; initializing it requires neither SSH nor GitHub CLI
+authentication. The pinned DSH source is acquired separately and can also be
+provided through the `DSH_SOURCE` override described below.
 
 Release builds pin DSH `0.0.1-rc.2` at:
 
@@ -166,10 +167,10 @@ Third-party plugins remain managed by the DSH Profile and Loader.
 | Plugin | Upstream relationship | Oh-DSH adaptation |
 | --- | --- | --- |
 | `@oh-dsh/desktop` | Original Oh-DSH component | Unified desktop entry, Electron bridge, native menus, windows, Agent capabilities, and bundled plugin order |
-| `@oh-dsh/better-sidebar-runtime` | Pinned [`DSH-better-sidebar`](https://github.com/dsh-external/DSH-better-sidebar) submodule | Compiles the upstream Host only for PTY, Files, Git, history, and commit diff; the upstream UI is not loaded |
+| `@oh-dsh/better-sidebar-runtime` | Pinned [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) submodule | Compiles the upstream Host only for PTY, Files, Git, history, and commit diff; the upstream UI is not loaded |
 | `@oh-dsh/panel-controls` | Downstream adaptation of [`dsh-web-panel`](https://github.com/dsh-external/dsh-web-panel) | Keeps the Oh-DSH Terminal dock, themes, localization, and Session state on the shared PTY Host; no separate Web Terminal installation |
 | `@oh-dsh/pinned-summary` | Original Oh-DSH component | Active Session summary, half-height card, and conversation gutter |
-| `@oh-dsh/desktop-sidebar` | Oh-DSH UI downstream of [`DSH-better-sidebar`](https://github.com/dsh-external/DSH-better-sidebar) | Uses the shared Host for Session tabs, viewers, Files, Git Review, line comments, and Agent composer references while retaining the current layout, icons, and themes |
+| `@oh-dsh/desktop-sidebar` | Oh-DSH UI downstream of [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) | Uses the shared Host for Session tabs, viewers, Files, Git Review, line comments, and Agent composer references while retaining the current layout, icons, and themes |
 | `@oh-dsh/plugin-marketplace` | Distills [`plugin-registry`](https://github.com/dsh-external/plugin-registry) and [`dsh-hub`](https://github.com/dsh-external/dsh-hub) | Unifies isolated preview, risk review, TOFU source locks, apply, and recovery with desktop navigation and bilingual UI |
 | `@oh-dsh/desktop-skins` | Downstream adaptation of [`dsh-skins`](https://github.com/dsh-external/dsh-skins) | Retains the ThemeService extension model but redesigns skins, Settings UI, and Host persistence |
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ pnpm run build:dsh
 pnpm start
 ```
 
-Better Sidebar Host 以固定 Git submodule 跟踪。源码构建需要该私有仓库的
-SSH/`gh` 访问权限；已发布的 DMG 和 ZIP 已包含编译产物，不需要仓库权限。
+Better Sidebar Host 以固定 Git submodule 跟踪，并通过公开 HTTPS 仓库获取；
+初始化该 submodule 不需要 SSH 或 GitHub CLI 认证。固定的 DSH 源码单独获取，
+也可以通过下述 `DSH_SOURCE` 指向已有 checkout。
 
 发行构建固定使用 DSH `0.0.1-rc.2`：
 
@@ -159,10 +160,10 @@ Profile 和 Loader 管理。
 | Plugin | 来源关系 | Oh-DSH 改造 |
 | --- | --- | --- |
 | `@oh-dsh/desktop` | Oh-DSH 自研 | 统一桌面入口、Electron bridge、原生菜单、窗口、Agent 能力与内置 plugin 注册顺序 |
-| `@oh-dsh/better-sidebar-runtime` | 固定跟踪 [`DSH-better-sidebar`](https://github.com/dsh-external/DSH-better-sidebar) submodule | 仅编译上游 Host，提供 PTY、Files、Git、history 和 commit diff；不加载上游 UI |
+| `@oh-dsh/better-sidebar-runtime` | 固定跟踪 [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) submodule | 仅编译上游 Host，提供 PTY、Files、Git、history 和 commit diff；不加载上游 UI |
 | `@oh-dsh/panel-controls` | 基于 [`dsh-web-panel`](https://github.com/dsh-external/dsh-web-panel) 的下游改造 | 保留 Oh-DSH Terminal dock、主题、双语和 Session 状态，复用统一 PTY Host；不再安装独立 Web Terminal |
 | `@oh-dsh/pinned-summary` | Oh-DSH 自研 | 当前 Session 摘要、半高卡片和正文 gutter 管理 |
-| `@oh-dsh/desktop-sidebar` | [`DSH-better-sidebar`](https://github.com/dsh-external/DSH-better-sidebar) 的 Oh-DSH UI 下游 | 复用统一 Host，提供 Session tabs、viewer、Files、Git Review、逐行评论和 Agent composer 引用，保留现有布局、图标与主题 |
+| `@oh-dsh/desktop-sidebar` | [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) 的 Oh-DSH UI 下游 | 复用统一 Host，提供 Session tabs、viewer、Files、Git Review、逐行评论和 Agent composer 引用，保留现有布局、图标与主题 |
 | `@oh-dsh/plugin-marketplace` | 炼化 [`plugin-registry`](https://github.com/dsh-external/plugin-registry) 与 [`dsh-hub`](https://github.com/dsh-external/dsh-hub) | 统一隔离预览、风险确认、TOFU 来源锁、应用与恢复流程，并适配桌面导航和双语 UI |
 | `@oh-dsh/desktop-skins` | 基于 [`dsh-skins`](https://github.com/dsh-external/dsh-skins) 的下游改造 | 沿用 ThemeService 扩展思路，重做皮肤、设置 UI 和 Host 持久化 |
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -20,7 +20,7 @@ separate Web Terminal or shell plugin is required.
 
 ## DSH-better-sidebar
 
-- Project: <https://github.com/dsh-external/DSH-better-sidebar>
+- Project: <https://github.com/omdsh-dev/DSH-better-sidebar>
 - Pinned release: `v0.9.0`
 - Pinned revision: `2e9db44a71bb75c9fa1185330541dce2582deee3`
 - Declared license: MIT


### PR DESCRIPTION
## Summary

- fetch the pinned Better Sidebar submodule from its public `omdsh-dev` HTTPS repository
- keep the existing v0.9.0 gitlink revision unchanged
- update the bilingual build documentation and third-party notice

## Why

The previous SSH URL required GitHub credentials before contributors or CI could initialize the submodule. The upstream project is now publicly available at `omdsh-dev/DSH-better-sidebar`, including the pinned `2e9db44a71bb75c9fa1185330541dce2582deee3` revision.

This intentionally does not change the separately pinned DSH source acquisition in `dsh-source.json`.

## Validation

- initialized the submodule from an empty checkout through the new HTTPS URL
- verified the checked-out revision is `2e9db44a71bb75c9fa1185330541dce2582deee3`
- `git diff --check`