### PR TITLE
runtime: resolve bundled tools across platforms

### DIFF
--- a/plugins/plugin-marketplace/src/host/platform.ts
+++ b/plugins/plugin-marketplace/src/host/platform.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, posix, win32 } from 'node:path'
 import type { MarketplaceAuthStatus } from '../protocol.ts'
 import {
   MARKETPLACE_CATALOG_REPOSITORY,
@@ -130,13 +130,21 @@ function executable(path: string): boolean {
 }
 
 /** Resolve gh without invoking a shell or changing the user's Git config. */
-export function findGitHubCli(environment: NodeJS.ProcessEnv = process.env): string | null {
+export function findGitHubCli(
+  environment: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
   const explicit = environment.DSH_DESKTOP_GH_PATH
   if (explicit !== undefined && executable(explicit)) return explicit
+  const paths = platform === 'win32' ? win32 : posix
+  const executableNames = platform === 'win32' ? ['gh.exe', 'gh.cmd', 'gh'] : ['gh']
   const candidates = [
-    ...(environment.PATH ?? '').split(':').filter(Boolean).map(directory => join(directory, 'gh')),
-    '/opt/homebrew/bin/gh',
-    '/usr/local/bin/gh',
+    ...(environment.PATH ?? (platform === 'win32' ? environment.Path : undefined) ?? '')
+      .split(paths.delimiter)
+      .filter(Boolean)
+      .flatMap(directory => executableNames.map(name => paths.join(directory, name))),
+    ...(platform === 'darwin' ? ['/opt/homebrew/bin/gh', '/usr/local/bin/gh'] : []),
+    ...(platform === 'linux' ? ['/usr/local/bin/gh', '/usr/bin/gh'] : []),
   ]
   return candidates.find((candidate, index) => candidates.indexOf(candidate) === index && executable(candidate)) ?? null
 }
@@ -285,7 +293,7 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
       '--filter=blob:none',
       '--no-checkout',
     ], { env: this.#options.env, timeoutMs: 120_000 })
-    await runCommand('/usr/bin/git', ['-C', target, 'checkout', '--detach', commit], {
+    await runCommand('git', ['-C', target, 'checkout', '--detach', commit], {
       env: withGitHubCredentials(this.#options.env, gh),
       timeoutMs: 60_000,
     })

--- a/scripts/smoke-runtime.mjs
+++ b/scripts/smoke-runtime.mjs
@@ -13,6 +13,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import electronBinary from 'electron'
+import { bundledRuntimePaths, runtimeSearchPath } from '../src/runtime-paths.ts'
 import {
   BUNDLED_DESKTOP_CLIENT_PLUGINS,
   BUNDLED_DESKTOP_HOST_PLUGINS,
@@ -21,8 +22,8 @@ import {
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const resources = resolve(process.argv[2] ?? join(root, '.stage'))
-const nodeBinary = join(resources, 'node-runtime', 'bin', 'node')
-const cliEntry = join(resources, 'dsh-runtime', 'lib', 'bin.js')
+const paths = bundledRuntimePaths(resources)
+const { cliEntry, nodeBinary } = paths
 const smokeRoot = mkdtempSync(join(tmpdir(), 'oh-dsh-desktop-smoke-'))
 const dshHome = join(smokeRoot, 'dsh-home')
 const lines = []
@@ -48,7 +49,7 @@ const runtimeEnvironment = {
   DSH_DESKTOP_PROFILE: 'desktop',
   DSH_DESKTOP_VERSION: 'smoke',
   DSH_HOME: dshHome,
-  PATH: `${dirname(nodeBinary)}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+  PATH: runtimeSearchPath(paths),
 }
 
 const pluginRoot = join(smokeRoot, 'smoke-plugin')

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import { parseMarketplaceCommand } from '../plugins/plugin-marketplace/src/proto
 import type { DesktopCommand, DesktopInfo, DesktopRuntimeSnapshot } from './contracts.ts'
 import { BUNDLED_DESKTOP_PLUGINS, DESKTOP_PROFILE, ensureDesktopProfile } from './profile.ts'
 import { DshRuntimeSupervisor, runDshCommand, type DshRuntimeOptions, type RuntimeExit } from './runtime.ts'
+import { bundledRuntimePaths, runtimeSearchPath, type BundledRuntimePaths } from './runtime-paths.ts'
 
 const PRODUCT_NAME = 'Oh-DSH-Desktop'
 const DEFAULT_UI_ZOOM_FACTOR = 1.12
@@ -66,14 +67,8 @@ function resourcesRoot(): string {
   return app.isPackaged ? process.resourcesPath : join(currentDir, '..', '.stage')
 }
 
-function runtimePaths(): { cliEntry: string; nodeBinary: string; runtimeRoot: string } {
-  const root = resourcesRoot()
-  const runtimeRoot = join(root, 'dsh-runtime')
-  return {
-    cliEntry: join(runtimeRoot, 'lib', 'bin.js'),
-    nodeBinary: join(root, 'node-runtime', 'bin', 'node'),
-    runtimeRoot,
-  }
+function runtimePaths(): BundledRuntimePaths {
+  return bundledRuntimePaths(resourcesRoot())
 }
 
 function desktopInfo(preview: DesktopInfo['preview'] = null): DesktopInfo {
@@ -103,14 +98,6 @@ function runtimeEnvironment(
   overrides: { appDataPath?: string; dshHome?: string; preview?: { pluginId: string; transactionId: string } } = {},
 ): NodeJS.ProcessEnv {
   const info = desktopInfo(overrides.preview ?? null)
-  const inheritedPath = process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin'
-  const path = [
-    dirname(paths.nodeBinary),
-    join(paths.runtimeRoot, 'node_modules', '.bin'),
-    '/opt/homebrew/bin',
-    '/usr/local/bin',
-    inheritedPath,
-  ].join(':')
   const environment: NodeJS.ProcessEnv = {
     ...process.env,
     DSH_DESKTOP: '1',
@@ -119,7 +106,7 @@ function runtimeEnvironment(
     DSH_DESKTOP_VERSION: info.version,
     DSH_HOME: overrides.dshHome ?? info.dshHome,
     NODE_USE_ENV_PROXY: '1',
-    PATH: path,
+    PATH: runtimeSearchPath(paths),
   }
   if (overrides.preview !== undefined) {
     environment.DSH_DESKTOP_PREVIEW = '1'

--- a/src/runtime-paths.ts
+++ b/src/runtime-paths.ts
@@ -1,0 +1,52 @@
+import { posix, win32 } from 'node:path'
+
+/** Files bundled beside the packaged Electron application. */
+export interface BundledRuntimePaths {
+  cliEntry: string
+  nodeBinary: string
+  nodeBinDirectory: string
+  pnpmBinary: string
+  runtimeRoot: string
+}
+
+function pathApi(platform: NodeJS.Platform): typeof posix | typeof win32 {
+  return platform === 'win32' ? win32 : posix
+}
+
+/** Resolve the bundled DSH and Node entry points for one target platform. */
+export function bundledRuntimePaths(
+  resourcesRoot: string,
+  platform: NodeJS.Platform = process.platform,
+): BundledRuntimePaths {
+  const paths = pathApi(platform)
+  const runtimeRoot = paths.join(resourcesRoot, 'dsh-runtime')
+  const nodeRoot = paths.join(resourcesRoot, 'node-runtime')
+  const nodeBinDirectory = platform === 'win32'
+    ? nodeRoot
+    : paths.join(nodeRoot, 'bin')
+  return {
+    cliEntry: paths.join(runtimeRoot, 'lib', 'bin.js'),
+    nodeBinary: paths.join(nodeBinDirectory, platform === 'win32' ? 'node.exe' : 'node'),
+    nodeBinDirectory,
+    pnpmBinary: paths.join(nodeBinDirectory, platform === 'win32' ? 'pnpm.cmd' : 'pnpm'),
+    runtimeRoot,
+  }
+}
+
+/** Put bundled commands first without applying POSIX PATH rules on Windows. */
+export function runtimeSearchPath(
+  paths: BundledRuntimePaths,
+  environment: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const path = pathApi(platform)
+  const inherited = environment.PATH
+    ?? (platform === 'win32' ? environment.Path : undefined)
+    ?? (platform === 'win32' ? '' : '/usr/bin:/bin:/usr/sbin:/sbin')
+  return [
+    paths.nodeBinDirectory,
+    path.join(paths.runtimeRoot, 'node_modules', '.bin'),
+    ...(platform === 'darwin' ? ['/opt/homebrew/bin', '/usr/local/bin'] : []),
+    inherited,
+  ].filter(entry => entry !== '').join(path.delimiter)
+}

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, win32 } from 'node:path'
 import { test } from 'node:test'
 import { parseMarketplaceCatalog } from '../plugins/plugin-marketplace/src/catalog.ts'
 import type {
@@ -9,7 +9,7 @@ import type {
   MarketplaceAuthResult,
   MarketplacePlatform,
 } from '../plugins/plugin-marketplace/src/host/platform.ts'
-import { withGitHubCredentials } from '../plugins/plugin-marketplace/src/host/platform.ts'
+import { findGitHubCli, withGitHubCredentials } from '../plugins/plugin-marketplace/src/host/platform.ts'
 import {
   PluginMarketplaceManager,
   type MarketplacePreviewRuntimeInput,
@@ -228,6 +228,19 @@ test('GitHub credentials use an app-owned config without command-line pairs', ()
     assert.doesNotMatch(config, /token|unsafe/i)
   } finally {
     rmSync(appDataPath, { recursive: true, force: true })
+  }
+})
+
+test('GitHub CLI discovery follows Windows PATH syntax and executable names', () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-gh-path-'))
+  try {
+    const binary = join(root, 'gh.exe')
+    writeFileSync(binary, '')
+    assert.equal(findGitHubCli({
+      Path: `${root};C:\\Program Files\\GitHub CLI`,
+    }, 'win32'), win32.join(root, 'gh.exe'))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
   }
 })
 

--- a/tests/runtime-paths.test.ts
+++ b/tests/runtime-paths.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { bundledRuntimePaths, runtimeSearchPath } from '../src/runtime-paths.ts'
+
+test('bundled runtime paths use POSIX layouts on macOS and Linux', () => {
+  const mac = bundledRuntimePaths('/Applications/Oh.app/Contents/Resources', 'darwin')
+  assert.equal(mac.nodeBinary, '/Applications/Oh.app/Contents/Resources/node-runtime/bin/node')
+  assert.equal(mac.pnpmBinary, '/Applications/Oh.app/Contents/Resources/node-runtime/bin/pnpm')
+  assert.equal(mac.cliEntry, '/Applications/Oh.app/Contents/Resources/dsh-runtime/lib/bin.js')
+  assert.equal(runtimeSearchPath(mac, { PATH: '/custom/bin' }, 'darwin'), [
+    '/Applications/Oh.app/Contents/Resources/node-runtime/bin',
+    '/Applications/Oh.app/Contents/Resources/dsh-runtime/node_modules/.bin',
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/custom/bin',
+  ].join(':'))
+
+  const linux = bundledRuntimePaths('/opt/oh-dsh/resources', 'linux')
+  assert.equal(linux.nodeBinary, '/opt/oh-dsh/resources/node-runtime/bin/node')
+  assert.equal(runtimeSearchPath(linux, { PATH: '/usr/local/sbin:/usr/bin' }, 'linux'), [
+    '/opt/oh-dsh/resources/node-runtime/bin',
+    '/opt/oh-dsh/resources/dsh-runtime/node_modules/.bin',
+    '/usr/local/sbin:/usr/bin',
+  ].join(':'))
+})
+
+test('bundled runtime paths use Windows executables and PATH separators', () => {
+  const windows = bundledRuntimePaths('C:\\Program Files\\Oh-DSH\\resources', 'win32')
+  assert.equal(windows.nodeBinary, 'C:\\Program Files\\Oh-DSH\\resources\\node-runtime\\node.exe')
+  assert.equal(windows.pnpmBinary, 'C:\\Program Files\\Oh-DSH\\resources\\node-runtime\\pnpm.cmd')
+  assert.equal(windows.cliEntry, 'C:\\Program Files\\Oh-DSH\\resources\\dsh-runtime\\lib\\bin.js')
+  assert.equal(runtimeSearchPath(windows, { Path: 'C:\\Windows\\System32;D:\\Git\\cmd' }, 'win32'), [
+    'C:\\Program Files\\Oh-DSH\\resources\\node-runtime',
+    'C:\\Program Files\\Oh-DSH\\resources\\dsh-runtime\\node_modules\\.bin',
+    'C:\\Windows\\System32;D:\\Git\\cmd',
+  ].join(';'))
+})

--- a/tests/workspace-tools.test.ts
+++ b/tests/workspace-tools.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { test } from 'node:test'
 import {
   mutateWorkspace,
@@ -31,7 +31,7 @@ test('workspace extension provides repository facts and branch creation', async 
     git(workspace, ['commit', '-m', 'initial'])
     const facts = await readWorkspaceFacts(workspace)
     assert.equal(facts.kind, 'repository')
-    assert.equal(facts.name, workspace.split('/').pop())
+    assert.equal(facts.name, basename(workspace))
     assert.equal(facts.hasRemote, false)
 
     const branched = await mutateWorkspace(workspace, { action: 'create-branch', branch: 'panel-test' })


### PR DESCRIPTION
## Summary

- resolve bundled Node, pnpm, and DSH entry paths for macOS, Linux, and Windows layouts
- build runtime PATH values with the target platform delimiter and keep macOS-only fallback directories scoped to macOS
- discover GitHub CLI from Windows PATH/Path and executable names, and invoke Git through PATH instead of /usr/bin/git
- cover POSIX and Windows path behavior with tests

## Validation

- pnpm run typecheck
- pnpm test (54 tests passed)
- pnpm run build

## Scope

This prepares runtime consumers for Linux and Windows packages. Downloading/staging platform-specific runtime archives and adding the packaging matrix are intentionally left for follow-up PRs.