### PR TITLE
docs: add unsigned DMG quarantine guidance

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -79,6 +79,15 @@ Open the DMG and drag `Oh-DSH-Desktop.app` into `Applications`. The current
 test build has no Developer ID signature or notarization. On first launch,
 right-click the application in Finder and choose **Open** if required.
 
+If macOS prevents the DMG from opening, first verify that it was downloaded
+from this project's GitHub Release, then remove its quarantine attribute and
+open it again. Replace the example DMG path with the file's actual download
+path:
+
+```sh
+xattr -d com.apple.quarantine ~/Downloads/Oh-DSH-Desktop-0.1.2-arm64.dmg
+```
+
 ### Run from source
 
 Requirements: macOS 12+, Apple Silicon, Node.js 24+, pnpm 11+, and Xcode

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Loader、locale、settings 和 ThemeService 契约。
 Developer ID 和 notarization，首次启动时可在 Finder 中右键应用并选择
 “打开”。
 
+如果 macOS 阻止打开 DMG，请先确认文件下载自本项目的 GitHub Release，
+再移除该 DMG 的 quarantine 属性并重新打开。请将示例中的 DMG 路径替换为
+文件的实际下载路径：
+
+```sh
+xattr -d com.apple.quarantine ~/Downloads/Oh-DSH-Desktop-0.1.2-arm64.dmg
+```
+
 ### 从源码运行
 
 要求 macOS 12+、Apple Silicon、Node.js 24+、pnpm 11+ 和 Xcode Command


### PR DESCRIPTION
## Summary

- document how to remove the macOS quarantine attribute when an unsigned test DMG is blocked
- remind users to verify that the DMG came from the project GitHub Release
- explicitly require replacing the example DMG path with the actual download path
- keep the Chinese and English installation instructions aligned

## Verification

- `git diff --check`