### PR TITLE
ci: add core repository checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core:
+    name: Core checks
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.20.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm run typecheck
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm run build

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { test } from 'node:test'
@@ -233,13 +233,15 @@ test('GitHub credentials use an app-owned config without command-line pairs', ()
 
 test('GitHub CLI discovery follows Windows PATH syntax and executable names', () => {
   const root = mkdtempSync(join(tmpdir(), 'oh-dsh-gh-path-'))
+  const binary = win32.join(root, 'gh.exe')
   try {
-    const binary = join(root, 'gh.exe')
     writeFileSync(binary, '')
+    chmodSync(binary, 0o755)
     assert.equal(findGitHubCli({
       Path: `${root};C:\\Program Files\\GitHub CLI`,
     }, 'win32'), win32.join(root, 'gh.exe'))
   } finally {
+    rmSync(binary, { force: true })
     rmSync(root, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary

- add a macOS arm64 GitHub Actions workflow for pushes and pull requests targeting `main`
- install pinned pnpm dependencies, then run type checking, tests, and the desktop build
- add read-only permissions, dependency caching, concurrency cancellation, and a job timeout
- fix the Windows GitHub CLI discovery fixture so it remains executable on POSIX CI hosts

Release packaging is intentionally excluded from this workflow. A later tag-triggered workflow can build DMG/ZIP artifacts without running on every commit or pull request.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm test` (54 passed)
- `pnpm run build`
- workflow YAML parse
- `git diff --check`

Closes #3