### PR TITLE
fix: make DSH sources and marketplace portable

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -53,7 +53,7 @@ and ThemeService contracts.
 
 ## Interface preview
 
-**Plugin marketplace**: browse the `dsh-external` catalog and preview changes
+**Plugin marketplace**: browse a public DSH community catalog and preview changes
 in an isolated environment.
 
 <p align="center">
@@ -72,12 +72,10 @@ persisted by the Host.
 ### Install a test build
 
 Download from
-[GitHub Releases](https://github.com/dsh-external/oh-dsh-desktop/releases):
+[GitHub Releases](https://github.com/hust-open-atom-club/oh-dsh-desktop/releases):
 
-- `Oh-DSH-Desktop-0.1.2-arm64.dmg`
-- `Oh-DSH-Desktop-0.1.2-arm64.zip`
-- `Oh-DSH-Desktop-0.1.2-x86_64.AppImage`
-- `Oh-DSH-Desktop-0.1.2-amd64.deb`
+- `Oh-DSH-Desktop-0.1.1-arm64.dmg`
+- `Oh-DSH-Desktop-0.1.1-arm64.zip`
 
 Open the DMG and drag `Oh-DSH-Desktop.app` into `Applications`. The current
 test build has no Developer ID signature or notarization. On first launch,
@@ -89,21 +87,11 @@ open it again. Replace the example DMG path with the file's actual download
 path:
 
 ```sh
-xattr -d com.apple.quarantine ~/Downloads/Oh-DSH-Desktop-0.1.2-arm64.dmg
+xattr -d com.apple.quarantine ~/Downloads/Oh-DSH-Desktop-0.1.1-arm64.dmg
 ```
 
-On Linux, make the AppImage executable and run it:
-
-```sh
-chmod +x Oh-DSH-Desktop-0.1.2-x86_64.AppImage
-./Oh-DSH-Desktop-0.1.2-x86_64.AppImage
-```
-
-Or install the deb package with apt:
-
-```sh
-sudo apt install ./Oh-DSH-Desktop-0.1.2-amd64.deb
-```
+Linux x64 source builds are supported, but the first AppImage / deb release
+has not been published yet. It will appear on the same Releases page.
 
 ### Run from source
 
@@ -126,7 +114,8 @@ ZIP, AppImage, and deb artifacts already contain the compiled output and
 require no repository access.
 
 Release builds pin DSH `0.1.0-rc.5` (the npm `0.1.0-rc.6` package is the
-publicly published version number of this same code) at:
+publicly published version number of this same code) from the official public
+repository at:
 
 ```text
 47f943859bef60e4160492346772ded9b24f765a
@@ -199,11 +188,11 @@ Third-party plugins remain managed by the DSH Profile and Loader.
 | --- | --- | --- |
 | `@oh-dsh/desktop` | Original Oh-DSH component | Unified desktop entry, Electron bridge, native menus, windows, Agent capabilities, and bundled plugin order |
 | `@oh-dsh/better-sidebar-runtime` | Pinned [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) submodule | Compiles the upstream Host only for PTY, Files, Git, history, and commit diff; the upstream UI is not loaded |
-| `@oh-dsh/panel-controls` | Downstream adaptation of [`dsh-web-panel`](https://github.com/dsh-external/dsh-web-panel) | Keeps the Oh-DSH Terminal dock, themes, localization, and Session state on the shared PTY Host; no separate Web Terminal installation |
+| `@oh-dsh/panel-controls` | Downstream reimplementation of the early dsh-web-panel interaction model | Keeps the Oh-DSH Terminal dock, themes, localization, and Session state on the shared PTY Host; no separate Web Terminal installation |
 | `@oh-dsh/pinned-summary` | Original Oh-DSH component | Active Session summary, half-height card, and conversation gutter |
 | `@oh-dsh/desktop-sidebar` | Oh-DSH UI downstream of [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) | Uses the shared Host for Session tabs, viewers, Files, Git Review, line comments, and Agent composer references while retaining the current layout, icons, and themes |
-| `@oh-dsh/plugin-marketplace` | Distills [`plugin-registry`](https://github.com/dsh-external/plugin-registry) and [`dsh-hub`](https://github.com/dsh-external/dsh-hub) | Unifies isolated preview, risk review, TOFU source locks, apply, and recovery with desktop navigation and bilingual UI |
-| `@oh-dsh/desktop-skins` | Downstream adaptation of [`dsh-skins`](https://github.com/dsh-external/dsh-skins) | Retains the ThemeService extension model but redesigns skins, Settings UI, and Host persistence |
+| `@oh-dsh/plugin-marketplace` | Supports [`plugin-registry`](https://github.com/vlln/plugin-registry), [`dsh-hub`](https://github.com/omdsh-dev/dsh-hub), and the public [`dsh-suite`](https://github.com/whyihaveyou/dsh-suite) catalog | Unifies isolated preview, risk review, TOFU source locks, apply, and recovery with desktop navigation and bilingual UI |
+| `@oh-dsh/desktop-skins` | Downstream reimplementation of the early dsh-skins ThemeService extension model | Retains the ThemeService extension model but redesigns skins, Settings UI, and Host persistence |
 
 Plugins marked as downstream adaptations or distilled designs are reviewed
 against upstream releases and features regularly. Compatible features are
@@ -215,9 +204,10 @@ details.
 
 ## Plugin marketplace
 
-The **Plugins** page browses the `dsh-external` catalog. Install, update,
-enable, disable, and uninstall operations first create an isolated candidate
-Profile:
+The **Plugins** page defaults to the public
+`whyihaveyou/dsh-suite/data/plugins.json` catalog and preserves each entry's
+canonical `owner/repo` identity. Install, update, enable, disable, and
+uninstall operations first create an isolated candidate Profile:
 
 ```text
 verify the source and exact commit
@@ -236,6 +226,10 @@ DSH Loader. Private repositories authenticate through GitHub CLI:
 ```sh
 gh auth login
 ```
+
+Set `OH_DSH_MARKETPLACE_CATALOG=owner/repository/path/to/catalog.json` to use
+a compatible `dsh-external-hub/v0.1`, `omdsh-registry/v1`, or `dsh-suite` 1.0
+catalog.
 
 ## Security boundaries
 
@@ -263,8 +257,8 @@ macOS artifacts are written to `release/`:
 
 ```text
 release/
-├── Oh-DSH-Desktop-0.1.2-arm64.dmg
-├── Oh-DSH-Desktop-0.1.2-arm64.zip
+├── Oh-DSH-Desktop-0.1.1-arm64.dmg
+├── Oh-DSH-Desktop-0.1.1-arm64.zip
 └── mac-arm64/Oh-DSH-Desktop.app
 ```
 
@@ -272,8 +266,8 @@ Linux artifacts are written to the same directory:
 
 ```text
 release/
-├── Oh-DSH-Desktop-0.1.2-x86_64.AppImage
-├── Oh-DSH-Desktop-0.1.2-amd64.deb
+├── Oh-DSH-Desktop-0.1.1-x86_64.AppImage
+├── Oh-DSH-Desktop-0.1.1-amd64.deb
 └── linux-unpacked/oh-dsh-desktop
 ```
 
@@ -291,7 +285,7 @@ pnpm run dist:mac
 pnpm run smoke:app
 codesign --verify --deep --strict \
   release/mac-arm64/Oh-DSH-Desktop.app
-hdiutil verify release/Oh-DSH-Desktop-0.1.2-arm64.dmg
+hdiutil verify release/Oh-DSH-Desktop-0.1.1-arm64.dmg
 ```
 
 On Linux, verify with:
@@ -303,16 +297,17 @@ pnpm run dist:linux
 pnpm run smoke:app:linux
 ```
 
-After verification, create the Release manually. For an existing Release,
-use `gh release upload --clobber` to replace the artifacts.
+The package metadata, download instructions, and public release now all use
+`v0.1.1`. For the next release, update every workspace package first, then use
+that same version for the tag and Release.
 
 ```sh
-gh release create v0.1.2 \
-  release/Oh-DSH-Desktop-0.1.2-arm64.dmg \
-  release/Oh-DSH-Desktop-0.1.2-arm64.zip \
-  release/Oh-DSH-Desktop-0.1.2-x86_64.AppImage \
-  release/Oh-DSH-Desktop-0.1.2-amd64.deb \
-  --title "Oh-DSH-Desktop 0.1.2" \
+gh release create vNEXT \
+  release/Oh-DSH-Desktop-NEXT-arm64.dmg \
+  release/Oh-DSH-Desktop-NEXT-arm64.zip \
+  release/Oh-DSH-Desktop-NEXT-x86_64.AppImage \
+  release/Oh-DSH-Desktop-NEXT-amd64.deb \
+  --title "Oh-DSH-Desktop NEXT" \
   --generate-notes
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Loader、locale、settings 和 ThemeService 契约。
 
 ## 界面预览
 
-**插件市场**：浏览 `dsh-external` 目录，并在隔离环境中预览变更。
+**插件市场**：浏览公共 DSH 社区目录，并在隔离环境中预览变更。
 
 <p align="center">
   <img src="./assets/oh-dsh-plugin-marketplace.png" alt="Oh-DSH 插件市场" width="100%">
@@ -66,11 +66,11 @@ Loader、locale、settings 和 ThemeService 契约。
 
 ### 安装测试包
 
-从 [GitHub Releases](https://github.com/dsh-external/oh-dsh-desktop/releases)
+从 [GitHub Releases](https://github.com/hust-open-atom-club/oh-dsh-desktop/releases)
 下载：
 
-- `Oh-DSH-Desktop-0.1.2-arm64.dmg`
-- `Oh-DSH-Desktop-0.1.2-arm64.zip`
+- `Oh-DSH-Desktop-0.1.1-arm64.dmg`
+- `Oh-DSH-Desktop-0.1.1-arm64.zip`
 
 打开 DMG，把 `Oh-DSH-Desktop.app` 拖入 `Applications`。当前测试包没有
 Developer ID 和 notarization，首次启动时可在 Finder 中右键应用并选择
@@ -81,30 +81,13 @@ Developer ID 和 notarization，首次启动时可在 Finder 中右键应用并�
 文件的实际下载路径：
 
 ```sh
-xattr -d com.apple.quarantine ~/Downloads/Oh-DSH-Desktop-0.1.2-arm64.dmg
+xattr -d com.apple.quarantine ~/Downloads/Oh-DSH-Desktop-0.1.1-arm64.dmg
 ```
 
 #### Linux
 
-从 [GitHub Releases](https://github.com/dsh-external/oh-dsh-desktop/releases)
-下载：
-
-- `Oh-DSH-Desktop-0.1.2-x86_64.AppImage`
-- `Oh-DSH-Desktop-0.1.2-amd64.deb`
-
-AppImage 只需赋予执行权限后直接运行：
-
-```sh
-chmod +x Oh-DSH-Desktop-0.1.2-x86_64.AppImage
-./Oh-DSH-Desktop-0.1.2-x86_64.AppImage
-```
-
-也可以安装 deb 包（需要 apt）：
-
-```sh
-sudo apt install ./Oh-DSH-Desktop-0.1.2-amd64.deb
-```
-
+Linux x64 已支持从源码构建；首个 AppImage / deb 尚未发布。发布后会出现在
+[GitHub Releases](https://github.com/hust-open-atom-club/oh-dsh-desktop/releases)。
 Linux 运行数据位于 `~/.config/Oh-DSH-Desktop/dsh`，DeepSeek API key 可以
 在 DSH 设置页配置，也可以写入该目录下的 `.env`。
 
@@ -127,7 +110,7 @@ Better Sidebar Host 以固定 Git submodule 跟踪，并通过公开 HTTPS 仓�
 和 deb 已包含编译产物，不需要仓库权限。
 
 发行构建固定使用 DSH `0.1.0-rc.5`（npm 上的 `0.1.0-rc.6` 即同一份代码的
-公开发布版本号）：
+公开发布版本号），源码来自官方公共仓库：
 
 ```text
 47f943859bef60e4160492346772ded9b24f765a
@@ -198,11 +181,11 @@ Profile 和 Loader 管理。
 | --- | --- | --- |
 | `@oh-dsh/desktop` | Oh-DSH 自研 | 统一桌面入口、Electron bridge、原生菜单、窗口、Agent 能力与内置 plugin 注册顺序 |
 | `@oh-dsh/better-sidebar-runtime` | 固定跟踪 [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) submodule | 仅编译上游 Host，提供 PTY、Files、Git、history 和 commit diff；不加载上游 UI |
-| `@oh-dsh/panel-controls` | 基于 [`dsh-web-panel`](https://github.com/dsh-external/dsh-web-panel) 的下游改造 | 保留 Oh-DSH Terminal dock、主题、双语和 Session 状态，复用统一 PTY Host；不再安装独立 Web Terminal |
+| `@oh-dsh/panel-controls` | 对早期 dsh-web-panel 交互模型的下游重实现 | 保留 Oh-DSH Terminal dock、主题、双语和 Session 状态，复用统一 PTY Host；不再安装独立 Web Terminal |
 | `@oh-dsh/pinned-summary` | Oh-DSH 自研 | 当前 Session 摘要、半高卡片和正文 gutter 管理 |
 | `@oh-dsh/desktop-sidebar` | [`DSH-better-sidebar`](https://github.com/omdsh-dev/DSH-better-sidebar) 的 Oh-DSH UI 下游 | 复用统一 Host，提供 Session tabs、viewer、Files、Git Review、逐行评论和 Agent composer 引用，保留现有布局、图标与主题 |
-| `@oh-dsh/plugin-marketplace` | 炼化 [`plugin-registry`](https://github.com/dsh-external/plugin-registry) 与 [`dsh-hub`](https://github.com/dsh-external/dsh-hub) | 统一隔离预览、风险确认、TOFU 来源锁、应用与恢复流程，并适配桌面导航和双语 UI |
-| `@oh-dsh/desktop-skins` | 基于 [`dsh-skins`](https://github.com/dsh-external/dsh-skins) 的下游改造 | 沿用 ThemeService 扩展思路，重做皮肤、设置 UI 和 Host 持久化 |
+| `@oh-dsh/plugin-marketplace` | 兼容 [`plugin-registry`](https://github.com/vlln/plugin-registry)、[`dsh-hub`](https://github.com/omdsh-dev/dsh-hub) 与公共 [`dsh-suite`](https://github.com/whyihaveyou/dsh-suite) 目录 | 统一隔离预览、风险确认、TOFU 来源锁、应用与恢复流程，并适配桌面导航和双语 UI |
+| `@oh-dsh/desktop-skins` | 对早期 dsh-skins ThemeService 扩展模型的下游重实现 | 沿用 ThemeService 扩展思路，重做皮肤、设置 UI 和 Host 持久化 |
 
 标记为“下游改造”或“炼化”的 plugin 会定期检查上游 release 和 feature，选择
 与当前 DSH 契约兼容的能力同步。同步以 feature 为单位重新适配，不直接覆盖
@@ -213,7 +196,8 @@ Oh-DSH 的 UI、主题和桌面交互。
 
 ## 插件市场
 
-左侧 **Plugins** 页面浏览 `dsh-external` 目录。安装、更新、启用、停用和卸载
+左侧 **Plugins** 页面默认读取公开的 `whyihaveyou/dsh-suite/data/plugins.json`
+目录，并保留条目中的规范 `owner/repo` 身份。安装、更新、启用、停用和卸载
 都会先生成隔离 candidate Profile：
 
 ```text
@@ -232,6 +216,10 @@ Agent 也可以通过对话进入同一流程。应用和恢复仍需要人类�
 ```sh
 gh auth login
 ```
+
+可通过 `OH_DSH_MARKETPLACE_CATALOG=owner/repository/path/to/catalog.json`
+切换到兼容的 `dsh-external-hub/v0.1`、`omdsh-registry/v1` 或
+`dsh-suite` 1.0 目录。
 
 ## 安全边界
 
@@ -257,8 +245,8 @@ macOS 产物位于 `release/`：
 
 ```text
 release/
-├── Oh-DSH-Desktop-0.1.2-arm64.dmg
-├── Oh-DSH-Desktop-0.1.2-arm64.zip
+├── Oh-DSH-Desktop-0.1.1-arm64.dmg
+├── Oh-DSH-Desktop-0.1.1-arm64.zip
 └── mac-arm64/Oh-DSH-Desktop.app
 ```
 
@@ -266,8 +254,8 @@ Linux 产物同样位于 `release/`：
 
 ```text
 release/
-├── Oh-DSH-Desktop-0.1.2-x86_64.AppImage
-├── Oh-DSH-Desktop-0.1.2-amd64.deb
+├── Oh-DSH-Desktop-0.1.1-x86_64.AppImage
+├── Oh-DSH-Desktop-0.1.1-amd64.deb
 └── linux-unpacked/oh-dsh-desktop
 ```
 
@@ -284,7 +272,7 @@ pnpm run dist:mac
 pnpm run smoke:app
 codesign --verify --deep --strict \
   release/mac-arm64/Oh-DSH-Desktop.app
-hdiutil verify release/Oh-DSH-Desktop-0.1.2-arm64.dmg
+hdiutil verify release/Oh-DSH-Desktop-0.1.1-arm64.dmg
 ```
 
 Linux 上对应验证：
@@ -296,16 +284,16 @@ pnpm run dist:linux
 pnpm run smoke:app:linux
 ```
 
-验证通过后手动创建 Release，已有 Release 则使用 `gh release upload
---clobber` 更新产物：
+当前 package、下载说明和公开 Release 均为 `v0.1.1`。准备下一个版本时，
+先统一更新 workspace package 版本，再使用同一版本创建 tag 与 Release：
 
 ```sh
-gh release create v0.1.2 \
-  release/Oh-DSH-Desktop-0.1.2-arm64.dmg \
-  release/Oh-DSH-Desktop-0.1.2-arm64.zip \
-  release/Oh-DSH-Desktop-0.1.2-x86_64.AppImage \
-  release/Oh-DSH-Desktop-0.1.2-amd64.deb \
-  --title "Oh-DSH-Desktop 0.1.2" \
+gh release create vNEXT \
+  release/Oh-DSH-Desktop-NEXT-arm64.dmg \
+  release/Oh-DSH-Desktop-NEXT-arm64.zip \
+  release/Oh-DSH-Desktop-NEXT-x86_64.AppImage \
+  release/Oh-DSH-Desktop-NEXT-amd64.deb \
+  --title "Oh-DSH-Desktop NEXT" \
   --generate-notes
 ```
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,8 +10,7 @@ submodule. Upstream releases and features are reviewed regularly.
 
 ## dsh-web-panel
 
-- Project: <https://github.com/dsh-external/dsh-web-panel>
-- Declared license: BSD 3-Clause
+- Historical project: dsh-web-panel (its previous public locator is no longer available)
 - Oh-DSH component: `@oh-dsh/panel-controls`
 
 Oh-DSH adapts the Terminal dock for its desktop layout, session model, themes,
@@ -35,9 +34,10 @@ thank the maintainers and review upstream features regularly.
 
 ## plugin-registry and dsh-hub
 
-- Projects: <https://github.com/dsh-external/plugin-registry> and
-  <https://github.com/dsh-external/dsh-hub>
-- Declared licenses: BSD 3-Clause and MIT
+- Projects: <https://github.com/vlln/plugin-registry>,
+  <https://github.com/omdsh-dev/dsh-hub>, and
+  <https://github.com/whyihaveyou/dsh-suite>
+- Declared licenses: MIT
 - Oh-DSH component: `@oh-dsh/plugin-marketplace`
 
 Oh-DSH distills source locking, trust review, installed/enabled state,
@@ -47,8 +47,7 @@ repository.
 
 ## dsh-skins
 
-- Project: <https://github.com/dsh-external/dsh-skins>
-- Declared license: MIT
+- Historical project: dsh-skins (its previous public locator is no longer available)
 - Oh-DSH component: `@oh-dsh/desktop-skins`
 
 Oh-DSH follows the ThemeService extension model while providing original

--- a/dsh-source.json
+++ b/dsh-source.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/deepseek-ai/deepseek-harness.git",
-  "ref": "master",
+  "ref": "47f943859bef60e4160492346772ded9b24f765a",
   "revision": "47f943859bef60e4160492346772ded9b24f765a",
   "version": "0.1.0-rc.5"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH-Desktop",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "An extensible DeepSeek Harness plugin collection and Electron desktop distribution",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",

--- a/plugins/better-sidebar-runtime/package.json
+++ b/plugins/better-sidebar-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-dsh/better-sidebar-runtime",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Host-only Better Sidebar capability provider for Oh-DSH-Desktop",
   "private": true,
   "type": "module",

--- a/plugins/desktop-sidebar/package.json
+++ b/plugins/desktop-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-dsh/desktop-sidebar",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Extensible Oh-DSH side panel with workspace and desktop tools",
   "private": true,
   "type": "module",

--- a/plugins/desktop-skins/package.json
+++ b/plugins/desktop-skins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-dsh/desktop-skins",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Built-in Oh-DSH-Desktop skin gallery and theme adapter",
   "private": true,
   "type": "module",

--- a/plugins/panel-controls/package.json
+++ b/plugins/panel-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-dsh/panel-controls",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Sidebar and resizable bottom-panel controls for Oh-DSH-Desktop",
   "private": true,
   "type": "module",

--- a/plugins/pinned-summary/package.json
+++ b/plugins/pinned-summary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-dsh/pinned-summary",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Layout-reserving current-session summary panel for Oh-DSH-Desktop",
   "private": true,
   "type": "module",

--- a/plugins/plugin-marketplace/package.json
+++ b/plugins/plugin-marketplace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/plugin-marketplace",
-  "version": "0.1.2",
-  "description": "Transactional dsh-external plugin marketplace for Oh-DSH-Desktop",
+  "version": "0.1.1",
+  "description": "Transactional public DSH plugin marketplace for Oh-DSH-Desktop",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-marketplace/src/catalog.ts
+++ b/plugins/plugin-marketplace/src/catalog.ts
@@ -5,7 +5,6 @@ import type {
 } from './protocol.ts'
 import {
   isProtectedMarketplacePlugin,
-  MARKETPLACE_ORGANIZATION,
 } from './protocol.ts'
 
 export interface MarketplaceCatalog {
@@ -23,7 +22,22 @@ interface CatalogRepository {
   note?: unknown
   pushedAt?: unknown
   repository?: unknown
+  repo?: unknown
+  url?: unknown
   tags?: unknown
+}
+
+interface NormalizedCatalogRow {
+  category: string
+  description: string
+  id: string
+  mechanism: MarketplaceMechanism
+  pushedAt: string | null
+  repository: string
+  tags: string[]
+  title: string
+  trust: MarketplacePlugin['trust']
+  url: string
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -42,53 +56,137 @@ function mechanism(row: CatalogRepository): MarketplaceMechanism {
 
 function runtimeRisk(value: MarketplaceMechanism): MarketplacePlugin['runtimeRisk'] {
   if (value === 'bundle') return 'profile-bundle'
-  if (value === 'repository') return 'trusted-host'
+  if (value === 'repository' || value === 'discover') return 'trusted-host'
   return 'guided'
 }
 
-function validRepositoryName(value: string): boolean {
+function validRepositoryPart(value: string): boolean {
   return /^[A-Za-z0-9_.-]{1,100}$/.test(value)
 }
 
-/** Parse the organization catalog without trusting paths or URLs from it. */
+function repositoryName(value: unknown): string | null {
+  const text = cleanString(value)
+  if (text === null) return null
+  const match = /^(?:https:\/\/github\.com\/)?([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/.exec(text)
+  if (match === null || !validRepositoryPart(match[1] ?? '') || !validRepositoryPart(match[2] ?? '')) {
+    return null
+  }
+  return `${match[1]}/${match[2]}`
+}
+
+function tags(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.flatMap(tag => cleanString(tag) === null ? [] : [cleanString(tag) as string]).slice(0, 16)
+    : []
+}
+
+function legacyRows(value: Record<string, unknown>): NormalizedCatalogRow[] | null {
+  if (value.schema !== 'dsh-external-hub/v0.1' || !Array.isArray(value.repos)) return null
+  return value.repos.flatMap(candidate => {
+    if (!isRecord(candidate)) return []
+    const row = candidate as CatalogRepository
+    const id = cleanString(row.name)
+    if (id === null || !validRepositoryPart(id) || row.hide === true || row.empty === true) return []
+    const repository = repositoryName(row.repo) ?? repositoryName(row.url) ?? `dsh-external/${id}`
+    return [{
+      category: cleanString(row.category) ?? 'other',
+      description: cleanString(row.note) ?? cleanString(row.description) ?? 'No description provided.',
+      id,
+      mechanism: mechanism(row),
+      pushedAt: cleanString(row.pushedAt),
+      repository,
+      tags: tags(row.tags),
+      title: id,
+      trust: repository.startsWith('dsh-external/') ? 'organization' : 'community',
+      url: `https://github.com/${repository}`,
+    }]
+  })
+}
+
+function registryRows(value: Record<string, unknown>): NormalizedCatalogRow[] | null {
+  if (value.schema !== 'omdsh-registry/v1' || !Array.isArray(value.entries)) return null
+  return value.entries.flatMap(candidate => {
+    if (!isRecord(candidate) || !isRecord(candidate.source)) return []
+    const id = cleanString(candidate.id)
+    const repository = repositoryName(candidate.source.repository)
+    if (id === null || !validRepositoryPart(id) || repository === null) return []
+    const install = isRecord(candidate.install) ? candidate.install : {}
+    const mode = install.mode
+    const installMechanism: MarketplaceMechanism = mode === 'profile-bundle'
+      ? 'bundle'
+      : mode === 'repository-plugin' ? 'repository' : 'unsupported'
+    return [{
+      category: cleanString(candidate.kind) ?? 'other',
+      description: cleanString(candidate.description) ?? 'No description provided.',
+      id,
+      mechanism: installMechanism,
+      pushedAt: null,
+      repository,
+      tags: tags(candidate.tags),
+      title: cleanString(candidate.displayName) ?? id,
+      trust: isRecord(candidate.listing) && candidate.listing.state === 'reviewed'
+        ? 'organization'
+        : 'community',
+      url: `https://github.com/${repository}`,
+    }]
+  })
+}
+
+function communityRows(value: Record<string, unknown>): NormalizedCatalogRow[] | null {
+  if (!isRecord(value._meta) || value._meta.schema_version !== '1.0' || !Array.isArray(value.plugins)) {
+    return null
+  }
+  return value.plugins.flatMap(candidate => {
+    if (!isRecord(candidate)) return []
+    const id = cleanString(candidate.id)
+    const repository = repositoryName(candidate.repo) ?? repositoryName(candidate.url)
+    if (id === null || !validRepositoryPart(id) || repository === null) return []
+    const description = isRecord(candidate.description)
+      ? cleanString(candidate.description.en) ?? cleanString(candidate.description.zh)
+      : cleanString(candidate.description)
+    return [{
+      category: cleanString(candidate.category) ?? 'other',
+      description: description ?? 'No description provided.',
+      id,
+      mechanism: 'discover',
+      pushedAt: null,
+      repository,
+      tags: tags(candidate.tags),
+      title: cleanString(candidate.name) ?? id,
+      trust: 'community',
+      url: `https://github.com/${repository}`,
+    }]
+  })
+}
+
+/** Parse supported public catalog schemas without trusting their source paths. */
 export function parseMarketplaceCatalog(
   value: unknown,
   installed: readonly MarketplaceInstalledPlugin[] = [],
 ): MarketplaceCatalog {
-  if (!isRecord(value) || value.schema !== 'dsh-external-hub/v0.1'
-    || !Array.isArray(value.repos)) {
-    throw new Error('unsupported dsh-external plugin catalog')
-  }
+  if (!isRecord(value)) throw new Error('unsupported plugin catalog')
+  const rows = legacyRows(value) ?? registryRows(value) ?? communityRows(value)
+  if (rows === null) throw new Error('unsupported plugin catalog')
   const installedIds = new Set(installed.map(entry => entry.pluginId))
-  const plugins: MarketplacePlugin[] = []
-  for (const candidate of value.repos) {
-    if (!isRecord(candidate)) continue
-    const row = candidate as CatalogRepository
-    const id = cleanString(row.name)
-    if (id === null || !validRepositoryName(id) || row.hide === true || row.empty === true) continue
-    const tags = Array.isArray(row.tags)
-      ? row.tags.flatMap(tag => cleanString(tag) === null ? [] : [cleanString(tag) as string]).slice(0, 16)
-      : []
-    const installMechanism = mechanism(row)
-    plugins.push({
-      category: cleanString(row.category) ?? 'other',
+  const plugins: MarketplacePlugin[] = rows.map(row => ({
+      category: row.category,
       currentCommit: null,
-      description: cleanString(row.note) ?? cleanString(row.description) ?? 'No description provided.',
+      description: row.description,
       enabled: false,
-      id,
-      installed: installedIds.has(id),
+      id: row.id,
+      installed: installedIds.has(row.id),
       latestCommit: null,
-      mechanism: installMechanism,
-      protected: isProtectedMarketplacePlugin(id),
-      pushedAt: cleanString(row.pushedAt),
-      runtimeRisk: runtimeRisk(installMechanism),
-      tags,
-      title: id,
-      trust: 'organization',
+      mechanism: row.mechanism,
+      protected: isProtectedMarketplacePlugin(row.id),
+      pushedAt: row.pushedAt,
+      repository: row.repository,
+      runtimeRisk: runtimeRisk(row.mechanism),
+      tags: row.tags,
+      title: row.title,
+      trust: row.trust,
       updateAvailable: false,
-      url: `https://github.com/${MARKETPLACE_ORGANIZATION}/${id}`,
-    })
-  }
+      url: row.url,
+    }))
   plugins.sort((left, right) => {
     if (left.installed !== right.installed) return left.installed ? -1 : 1
     if (left.mechanism === 'unsupported' && right.mechanism !== 'unsupported') return 1
@@ -96,7 +194,8 @@ export function parseMarketplaceCatalog(
     return left.title.localeCompare(right.title)
   })
   return {
-    generatedAt: cleanString(value.generated),
+    generatedAt: cleanString(value.generated) ?? cleanString(value.generatedAt)
+      ?? (isRecord(value._meta) ? cleanString(value._meta.generated_at) : null),
     plugins,
   }
 }

--- a/plugins/plugin-marketplace/src/client/i18n.ts
+++ b/plugins/plugin-marketplace/src/client/i18n.ts
@@ -14,6 +14,7 @@ export type MarketplaceMessage =
   | 'all-categories'
   | 'mechanism.repository'
   | 'mechanism.bundle'
+  | 'mechanism.discover'
   | 'mechanism.unsupported'
   | 'details'
   | 'category'
@@ -97,7 +98,7 @@ export type MarketplaceMessage =
 export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
   en: {
     plugins: 'Plugins',
-    subtitle: 'dsh-external · isolated preview before every change',
+    subtitle: 'Public DSH catalog · isolated preview before every change',
     installed: 'Installed',
     enabled: 'Enabled',
     disabled: 'Disabled',
@@ -109,6 +110,7 @@ export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
     'all-categories': 'All categories',
     'mechanism.repository': 'Repository',
     'mechanism.bundle': 'Bundle',
+    'mechanism.discover': 'Auto-detect',
     'mechanism.unsupported': 'Browse only',
     details: '{plugin} details',
     category: 'Category',
@@ -117,7 +119,7 @@ export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
     unknown: 'Unknown',
     repository: 'Repository',
     trust: 'Source trust',
-    'trust.organization': 'Verified organization · dsh-external',
+    'trust.organization': 'Registry reviewed source',
     'trust.community': 'Community source',
     'trust.untrusted': 'Untrusted source',
     'runtime-boundary': 'Runtime boundary',
@@ -177,13 +179,13 @@ export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
     'installation-status': 'Installation status',
     'plugin-category': 'Plugin category',
     'plugin-count': '{count} plugins',
-    'loading-catalog': 'Loading the organization catalog…',
+    'loading-catalog': 'Loading the plugin catalog…',
     'github-auth-required': 'GitHub authentication required',
     'no-match': 'No plugins match this view.',
     'auth.install-gh': 'Install GitHub CLI and run `gh auth login` to browse private organization plugins.',
     'auth.ready': 'Authenticated with GitHub CLI.',
     'auth.not-refreshed': 'Plugin catalog has not been refreshed yet.',
-    'notice.loaded': 'Loaded {count} organization plugins.',
+    'notice.loaded': 'Loaded {count} catalog plugins.',
     'notice.preview-ready': 'Isolated {action} preview is ready for {plugin}.',
     'notice.discarded': 'Discarded the {plugin} preview without changing the desktop profile.',
     'notice.applied': 'Applied {plugin}; the previous profile remains available for Undo.',
@@ -191,7 +193,7 @@ export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
   },
   zh: {
     plugins: '插件',
-    subtitle: 'dsh-external · 每次变更前均进行隔离预览',
+    subtitle: '公开 DSH 目录 · 每次变更前均进行隔离预览',
     installed: '已安装',
     enabled: '已启用',
     disabled: '已停用',
@@ -203,6 +205,7 @@ export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
     'all-categories': '全部分类',
     'mechanism.repository': '仓库插件',
     'mechanism.bundle': '插件包',
+    'mechanism.discover': '自动检测',
     'mechanism.unsupported': '仅浏览',
     details: '{plugin} 详情',
     category: '分类',
@@ -211,7 +214,7 @@ export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
     unknown: '未知',
     repository: '仓库',
     trust: '来源信任',
-    'trust.organization': '已验证组织 · dsh-external',
+    'trust.organization': 'Registry 已审核来源',
     'trust.community': '社区来源',
     'trust.untrusted': '不受信任来源',
     'runtime-boundary': '运行边界',
@@ -277,7 +280,7 @@ export const MARKETPLACE_MESSAGES: LocaleMessages<MarketplaceMessage> = {
     'auth.install-gh': '请安装 GitHub CLI 并运行 `gh auth login`，以浏览组织的私有插件。',
     'auth.ready': '已通过 GitHub CLI 完成身份验证。',
     'auth.not-refreshed': '插件目录尚未刷新。',
-    'notice.loaded': '已加载 {count} 个组织插件。',
+    'notice.loaded': '已加载 {count} 个目录插件。',
     'notice.preview-ready': '{plugin} 的隔离{action}预览已就绪。',
     'notice.discarded': '已放弃 {plugin} 的预览，桌面端配置未发生更改。',
     'notice.applied': '已应用 {plugin}；之前的配置仍可撤销恢复。',

--- a/plugins/plugin-marketplace/src/client/plugin.tsx
+++ b/plugins/plugin-marketplace/src/client/plugin.tsx
@@ -626,7 +626,7 @@ function localizedHostMessage(
   message: string,
   t: Translate<MarketplaceMessage>,
 ): string {
-  let match = /^Loaded (\d+) organization plugins\.$/.exec(message)
+  let match = /^Loaded (\d+) catalog plugins\.$/.exec(message)
   if (match !== null) return t('notice.loaded', { count: match[1] })
   match = /^Isolated (install|update|enable|disable|uninstall) preview is ready for (.+)\.$/.exec(message)
   if (match !== null) {

--- a/plugins/plugin-marketplace/src/host/platform.ts
+++ b/plugins/plugin-marketplace/src/host/platform.ts
@@ -11,8 +11,8 @@ import { tmpdir } from 'node:os'
 import { dirname, join, posix, win32 } from 'node:path'
 import type { MarketplaceAuthStatus } from '../protocol.ts'
 import {
+  MARKETPLACE_CATALOG_PATH,
   MARKETPLACE_CATALOG_REPOSITORY,
-  MARKETPLACE_ORGANIZATION,
 } from '../protocol.ts'
 
 export interface MarketplaceAuthResult {
@@ -29,10 +29,10 @@ export interface DshCommandInput {
 /** Privileged operations consumed by the marketplace transaction module. */
 export interface MarketplacePlatform {
   authStatus(): Promise<MarketplaceAuthResult>
-  cloneRepository(pluginId: string, commit: string, target: string): Promise<void>
+  cloneRepository(repository: string, commit: string, target: string): Promise<void>
   loadCatalog(): Promise<unknown>
-  readRepositoryFile(pluginId: string, path: string, commit: string): Promise<string | null>
-  resolveCommit(pluginId: string): Promise<string>
+  readRepositoryFile(repository: string, path: string, commit: string): Promise<string | null>
+  resolveCommit(repository: string): Promise<string>
   runDsh(input: DshCommandInput): Promise<void>
 }
 
@@ -52,19 +52,19 @@ interface CommandOptions {
 
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
 
-function validatePluginId(pluginId: string): void {
-  if (!/^[A-Za-z0-9_.-]{1,100}$/.test(pluginId)) {
-    throw new Error(`invalid marketplace plugin id: ${JSON.stringify(pluginId)}`)
+function validateRepository(repository: string): void {
+  if (!/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/.test(repository)) {
+    throw new Error(`invalid marketplace repository: ${JSON.stringify(repository)}`)
   }
 }
 
-function repositoryContentPath(pluginId: string, path: string): string {
-  validatePluginId(pluginId)
+function repositoryContentPath(repository: string, path: string): string {
+  validateRepository(repository)
   const segments = path.split('/').filter(Boolean)
   if (segments.length === 0 || segments.some(segment => segment === '.' || segment === '..')) {
     throw new Error(`invalid repository file path: ${JSON.stringify(path)}`)
   }
-  return `repos/${MARKETPLACE_ORGANIZATION}/${pluginId}/contents/${segments.map(encodeURIComponent).join('/')}`
+  return `repos/${repository}/contents/${segments.map(encodeURIComponent).join('/')}`
 }
 
 function commandError(command: string, args: readonly string[], stderr: string, stdout: string): Error {
@@ -133,9 +133,10 @@ function executable(path: string): boolean {
 export function findGitHubCli(
   environment: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
+  isExecutable: (path: string) => boolean = executable,
 ): string | null {
   const explicit = environment.DSH_DESKTOP_GH_PATH
-  if (explicit !== undefined && executable(explicit)) return explicit
+  if (explicit !== undefined && isExecutable(explicit)) return explicit
   const paths = platform === 'win32' ? win32 : posix
   const executableNames = platform === 'win32' ? ['gh.exe', 'gh.cmd', 'gh'] : ['gh']
   const candidates = [
@@ -146,7 +147,7 @@ export function findGitHubCli(
     ...(platform === 'darwin' ? ['/opt/homebrew/bin/gh', '/usr/local/bin/gh'] : []),
     ...(platform === 'linux' ? ['/usr/local/bin/gh', '/usr/bin/gh'] : []),
   ]
-  return candidates.find((candidate, index) => candidates.indexOf(candidate) === index && executable(candidate)) ?? null
+  return candidates.find((candidate, index) => candidates.indexOf(candidate) === index && isExecutable(candidate)) ?? null
 }
 
 function withoutCommandLineGitConfig(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -239,36 +240,45 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
 
   async loadCatalog(): Promise<unknown> {
     const gh = this.requireGitHubCli()
+    const locator = this.#options.env.OH_DSH_MARKETPLACE_CATALOG
+      ?? `${MARKETPLACE_CATALOG_REPOSITORY}/${MARKETPLACE_CATALOG_PATH}`
+    const match = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/(.+)$/.exec(locator)
+    if (match === null) {
+      throw new Error('OH_DSH_MARKETPLACE_CATALOG must be owner/repository/path')
+    }
+    validateRepository(match[1] ?? '')
+    const path = match[2] ?? ''
+    const contentPath = repositoryContentPath(match[1] ?? '', path)
     const result = await runCommand(gh, [
       'api',
-      `repos/${MARKETPLACE_ORGANIZATION}/${MARKETPLACE_CATALOG_REPOSITORY}/contents/catalog.json`,
+      contentPath,
       '--jq',
       '.content',
     ], { env: this.#options.env, timeoutMs: 30_000 })
     return JSON.parse(Buffer.from(result.stdout.replaceAll(/\s/g, ''), 'base64').toString('utf8')) as unknown
   }
 
-  async resolveCommit(pluginId: string): Promise<string> {
-    validatePluginId(pluginId)
+  async resolveCommit(repository: string): Promise<string> {
+    validateRepository(repository)
     const gh = this.requireGitHubCli()
     const result = await runCommand(gh, [
       'api',
-      `repos/${MARKETPLACE_ORGANIZATION}/${pluginId}/commits/HEAD`,
+      `repos/${repository}/commits/HEAD`,
       '--jq',
       '.sha',
     ], { env: this.#options.env, timeoutMs: 30_000 })
     const commit = result.stdout.trim()
-    if (!/^[0-9a-f]{40}$/.test(commit)) throw new Error(`GitHub returned an invalid commit for ${pluginId}`)
+    if (!/^[0-9a-f]{40}$/.test(commit)) throw new Error(`GitHub returned an invalid commit for ${repository}`)
     return commit
   }
 
-  async readRepositoryFile(pluginId: string, path: string, commit: string): Promise<string | null> {
+  async readRepositoryFile(repository: string, path: string, commit: string): Promise<string | null> {
     if (!/^[0-9a-f]{40}$/.test(commit)) throw new Error('repository commit must be a full SHA')
     const gh = this.requireGitHubCli()
     try {
       const result = await runCommand(gh, [
         'api',
-        `${repositoryContentPath(pluginId, path)}?ref=${commit}`,
+        `${repositoryContentPath(repository, path)}?ref=${commit}`,
         '--jq',
         '.content',
       ], { env: this.#options.env, timeoutMs: 30_000 })
@@ -279,15 +289,15 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
     }
   }
 
-  async cloneRepository(pluginId: string, commit: string, target: string): Promise<void> {
-    validatePluginId(pluginId)
+  async cloneRepository(repository: string, commit: string, target: string): Promise<void> {
+    validateRepository(repository)
     if (!/^[0-9a-f]{40}$/.test(commit)) throw new Error('repository commit must be a full SHA')
     const gh = this.requireGitHubCli()
     mkdirSync(dirname(target), { recursive: true, mode: 0o700 })
     await runCommand(gh, [
       'repo',
       'clone',
-      `${MARKETPLACE_ORGANIZATION}/${pluginId}`,
+      repository,
       target,
       '--',
       '--filter=blob:none',

--- a/plugins/plugin-marketplace/src/host/transaction-manager.ts
+++ b/plugins/plugin-marketplace/src/host/transaction-manager.ts
@@ -27,7 +27,6 @@ import type {
 } from '../protocol.ts'
 import {
   isProtectedMarketplacePlugin,
-  MARKETPLACE_ORGANIZATION,
 } from '../protocol.ts'
 import type { MarketplacePlatform } from './platform.ts'
 
@@ -179,21 +178,21 @@ function manifestHash(text: string): string {
   return createHash('sha256').update(text).digest('hex')
 }
 
-function canonicalSource(pluginId: string): string {
-  return `github:${MARKETPLACE_ORGANIZATION}/${pluginId}`
+function canonicalSource(repository: string): string {
+  return `github:${repository}`
 }
 
 function sourceReview(
   lock: MarketplaceSourceLock | undefined,
   input: Pick<MarketplacePlan,
-    'manifestHash' | 'mechanism' | 'packageName' | 'pluginId' | 'resolvedCommit'>,
+    'manifestHash' | 'mechanism' | 'packageName' | 'pluginId' | 'repository' | 'resolvedCommit'>,
 ): MarketplaceSourceReview {
   if (lock === undefined) return 'first-use'
   if (lock.resolvedCommit === input.resolvedCommit
     && lock.manifestHash !== input.manifestHash) {
     throw new Error(`${input.pluginId} changed content at pinned commit ${input.resolvedCommit}`)
   }
-  return lock.canonicalSource === canonicalSource(input.pluginId)
+  return lock.canonicalSource === canonicalSource(input.repository)
     && lock.mechanism === input.mechanism
     && lock.packageName === input.packageName
     ? 'matched'
@@ -248,7 +247,7 @@ function sourceLockFromPlan(
 ): MarketplaceSourceLock {
   if (plan.packageName === null) throw new Error('source lock requires a package name')
   return {
-    canonicalSource: canonicalSource(plan.pluginId),
+    canonicalSource: canonicalSource(plan.repository),
     firstSeenCommit: previous?.firstSeenCommit ?? plan.resolvedCommit,
     manifestHash: plan.manifestHash,
     mechanism: plan.mechanism,
@@ -342,8 +341,8 @@ function repositorySources(text: string): string[] {
   return [...result]
 }
 
-function repositoryPluginId(source: string): string | null {
-  const match = /^github:dsh-external\/([A-Za-z0-9_.-]+)#/.exec(source)
+function repositoryFromSource(source: string): string | null {
+  const match = /^github:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#/.exec(source)
   return match?.[1] ?? null
 }
 
@@ -353,8 +352,7 @@ function repositoryEnabled(
 ): boolean {
   const path = join(profileDir, 'cordis.patch.yml')
   const patch = existsSync(path) ? readFileSync(path, 'utf8') : ''
-  return repositorySources(patch)
-    .some(source => repositoryPluginId(source) === entry.pluginId)
+  return repositorySources(patch).includes(entry.source)
 }
 
 function installedEntryEnabled(
@@ -388,12 +386,11 @@ function updateRepositoryPatch(
   const path = join(profileDir, 'cordis.patch.yml')
   const original = existsSync(path) ? readFileSync(path, 'utf8') : '[]\n'
   const withoutManaged = removeMarkedBlock(original, PATCH_BEGIN, PATCH_END)
-  const enabledPluginIds = new Set(repositorySources(original)
-    .flatMap(source => repositoryPluginId(source) ?? []))
+  const enabledSources = new Set(repositorySources(original))
   const marketplaceSources = entries
     .filter(entry => entry.mechanism === 'repository')
     .filter(entry => enabledOverrides.get(entry.pluginId)
-      ?? enabledPluginIds.has(entry.pluginId))
+      ?? enabledSources.has(entry.source))
     .map(entry => entry.source)
   if (marketplaceSources.length === 0) {
     writeFileSync(path, patchWithRootList(withoutManaged, false), { mode: 0o600 })
@@ -643,22 +640,22 @@ export class PluginMarketplaceManager {
     this.#catalog = catalog.plugins
     this.#catalogGeneratedAt = catalog.generatedAt
     this.#latestCommits.clear()
-    const available = new Set(catalog.plugins
+    const available = new Map(catalog.plugins
       .filter(plugin => plugin.mechanism !== 'unsupported')
-      .map(plugin => plugin.id))
+      .map(plugin => [plugin.id, plugin.repository]))
     await Promise.all(installed
       .filter(entry => available.has(entry.pluginId))
       .map(async entry => {
         try {
           this.#latestCommits.set(
             entry.pluginId,
-            await this.#options.platform.resolveCommit(entry.pluginId),
+            await this.#options.platform.resolveCommit(available.get(entry.pluginId) as string),
           )
         } catch {
           // A failed update check must not hide the installed plugin catalog.
         }
       }))
-    this.#lastAction = `Loaded ${String(catalog.plugins.length)} organization plugins.`
+    this.#lastAction = `Loaded ${String(catalog.plugins.length)} catalog plugins.`
   }
 
   private async prepare(action: MarketplaceAction, pluginId: string): Promise<void> {
@@ -702,6 +699,8 @@ export class PluginMarketplaceManager {
         pluginId,
         manifestHash: state.locks.find(lock => lock.pluginId === pluginId)?.manifestHash ?? '',
         requirements: risk.requirements,
+        repository: catalogPlugin?.repository ?? repositoryFromSource(current.source)
+          ?? (() => { throw new Error(`${pluginId} has an invalid repository source`) })(),
         resolvedCommit: current.resolvedCommit,
         riskLevel: risk.riskLevel,
         riskReasons: risk.riskReasons,
@@ -720,34 +719,72 @@ export class PluginMarketplaceManager {
     if (catalogPlugin.mechanism === 'unsupported') {
       throw new Error(`${pluginId} does not use a preview-safe bundle or repository package`)
     }
-    const commit = await this.#options.platform.resolveCommit(pluginId)
+    const commit = await this.#options.platform.resolveCommit(catalogPlugin.repository)
     this.#latestCommits.set(pluginId, commit)
     if (action === 'update' && current?.resolvedCommit === commit) {
       throw new Error(`${pluginId} is already at the latest commit`)
     }
-    const manifestPath = catalogPlugin.mechanism === 'repository'
+    let resolvedMechanism: MarketplacePlan['mechanism'] | null =
+      catalogPlugin.mechanism === 'bundle' || catalogPlugin.mechanism === 'repository'
+        ? catalogPlugin.mechanism
+        : null
+    let manifestPath = resolvedMechanism === 'repository'
       ? '.dsh-plugin/package.json'
       : 'package.json'
-    const manifestText = await this.#options.platform.readRepositoryFile(pluginId, manifestPath, commit)
+    let manifestText = await this.#options.platform.readRepositoryFile(
+      catalogPlugin.repository,
+      manifestPath,
+      commit,
+    )
+    if (catalogPlugin.mechanism === 'discover') {
+      const bundleText = manifestText
+      if (bundleText !== null) {
+        const bundleManifest = parsePackageManifest(bundleText, `${pluginId}/package.json`)
+        if (isRecord(bundleManifest.dsh) && isRecord(bundleManifest.dsh.bundle)
+          && typeof bundleManifest.dsh.bundle.patch === 'string') {
+          resolvedMechanism = 'bundle'
+        } else {
+          manifestPath = '.dsh-plugin/package.json'
+          manifestText = await this.#options.platform.readRepositoryFile(
+            catalogPlugin.repository,
+            manifestPath,
+            commit,
+          )
+          resolvedMechanism = manifestText === null ? null : 'repository'
+        }
+      } else {
+        manifestPath = '.dsh-plugin/package.json'
+        manifestText = await this.#options.platform.readRepositoryFile(
+          catalogPlugin.repository,
+          manifestPath,
+          commit,
+        )
+        resolvedMechanism = manifestText === null ? null : 'repository'
+      }
+    }
+    if (resolvedMechanism === null) {
+      throw new Error(`${pluginId} has no DSH bundle or .dsh-plugin manifest at ${commit}`)
+    }
     if (manifestText === null) throw new Error(`${pluginId} is missing ${manifestPath} at ${commit}`)
     const manifest = parsePackageManifest(manifestText, `${pluginId}/${manifestPath}`)
     const resolvedPackage = packageName(manifest, manifestPath)
-    if (catalogPlugin.mechanism === 'bundle'
+    if (resolvedMechanism === 'bundle'
       && (!isRecord(manifest.dsh) || !isRecord(manifest.dsh.bundle)
         || typeof manifest.dsh.bundle.patch !== 'string')) {
       throw new Error(`${pluginId} does not declare dsh.bundle.patch`)
     }
-    const source = catalogPlugin.mechanism === 'repository'
-      ? `github:${MARKETPLACE_ORGANIZATION}/${pluginId}#${commit}&path:/.dsh-plugin`
-      : `github:${MARKETPLACE_ORGANIZATION}/${pluginId}#${commit}`
+    const source = resolvedMechanism === 'repository'
+      ? `github:${catalogPlugin.repository}#${commit}&path:/.dsh-plugin`
+      : `github:${catalogPlugin.repository}#${commit}`
     const hash = manifestHash(manifestText)
     const review = sourceReview(
       state.locks.find(lock => lock.pluginId === pluginId),
       {
         manifestHash: hash,
-        mechanism: catalogPlugin.mechanism,
+        mechanism: resolvedMechanism,
         packageName: resolvedPackage,
         pluginId,
+        repository: catalogPlugin.repository,
         resolvedCommit: commit,
       },
     )
@@ -755,7 +792,7 @@ export class PluginMarketplaceManager {
     const risk = assessRisk({
       action,
       buildScripts: scripts,
-      mechanism: catalogPlugin.mechanism,
+      mechanism: resolvedMechanism,
       protectedPlugin: catalogPlugin.protected,
       sourceReview: review,
     })
@@ -764,10 +801,11 @@ export class PluginMarketplaceManager {
       buildScripts: scripts,
       description: catalogPlugin.description,
       manifestHash: hash,
-      mechanism: catalogPlugin.mechanism,
+      mechanism: resolvedMechanism,
       packageName: resolvedPackage,
       pluginId,
       requirements: risk.requirements,
+      repository: catalogPlugin.repository,
       resolvedCommit: commit,
       riskLevel: risk.riskLevel,
       riskReasons: risk.riskReasons,
@@ -826,7 +864,7 @@ export class PluginMarketplaceManager {
             }
           }
           const checkout = join(sources, `${plan.pluginId}-${plan.resolvedCommit.slice(0, 12)}`)
-          await this.#options.platform.cloneRepository(plan.pluginId, plan.resolvedCommit, checkout)
+          await this.#options.platform.cloneRepository(plan.repository, plan.resolvedCommit, checkout)
           if (Object.keys(plan.buildScripts).length > 0) allowBuild(candidateProfile, plan.packageName)
           await this.#options.platform.runDsh({
             args: ['plugin', '--profile', this.#options.profile, 'add', checkout],

--- a/plugins/plugin-marketplace/src/index.ts
+++ b/plugins/plugin-marketplace/src/index.ts
@@ -6,13 +6,13 @@ export const name = 'oh-dsh-plugin-marketplace'
 
 /** Facts other Host plugins can inspect without receiving Electron access. */
 export interface PluginMarketplaceHost {
-  catalog: 'dsh-external/hub'
+  catalog: 'public-dsh-catalog'
   preview: 'isolated-profile'
 }
 
 export function apply(ctx: HostContext): void {
   ctx.provide('pluginMarketplaceHost', Object.freeze({
-    catalog: 'dsh-external/hub',
+    catalog: 'public-dsh-catalog',
     preview: 'isolated-profile',
   } satisfies PluginMarketplaceHost))
 }

--- a/plugins/plugin-marketplace/src/protocol.ts
+++ b/plugins/plugin-marketplace/src/protocol.ts
@@ -1,8 +1,9 @@
-export const MARKETPLACE_ORGANIZATION = 'dsh-external'
-export const MARKETPLACE_CATALOG_REPOSITORY = 'hub'
+export const MARKETPLACE_CATALOG_REPOSITORY = 'whyihaveyou/dsh-suite'
+export const MARKETPLACE_CATALOG_PATH = 'data/plugins.json'
 
 export type MarketplaceAuthStatus = 'ready' | 'missing-cli' | 'signed-out' | 'error'
-export type MarketplaceMechanism = 'bundle' | 'repository' | 'unsupported'
+export type MarketplaceMechanism = 'bundle' | 'repository' | 'discover' | 'unsupported'
+export type MarketplaceInstallMechanism = 'bundle' | 'repository'
 export type MarketplaceAction = 'install' | 'update' | 'enable' | 'disable' | 'uninstall'
 export type MarketplaceRuntimeRisk = 'profile-bundle' | 'trusted-host' | 'guided'
 export type MarketplaceTrust = 'organization' | 'community' | 'untrusted'
@@ -45,6 +46,7 @@ export interface MarketplacePlugin {
   mechanism: MarketplaceMechanism
   protected: boolean
   pushedAt: string | null
+  repository: string
   runtimeRisk: MarketplaceRuntimeRisk
   tags: string[]
   title: string
@@ -55,7 +57,7 @@ export interface MarketplacePlugin {
 
 export interface MarketplaceInstalledPlugin {
   installedAt: string
-  mechanism: Exclude<MarketplaceMechanism, 'unsupported'>
+  mechanism: MarketplaceInstallMechanism
   packageName: string | null
   pluginId: string
   resolvedCommit: string
@@ -66,7 +68,7 @@ export interface MarketplaceSourceLock {
   canonicalSource: string
   firstSeenCommit: string
   manifestHash: string
-  mechanism: Exclude<MarketplaceMechanism, 'unsupported'>
+  mechanism: MarketplaceInstallMechanism
   packageName: string
   pluginId: string
   recordedAt: string
@@ -77,11 +79,12 @@ export interface MarketplacePlan {
   action: MarketplaceAction
   buildScripts: Record<string, string>
   description: string
-  mechanism: Exclude<MarketplaceMechanism, 'unsupported'>
+  mechanism: MarketplaceInstallMechanism
   packageName: string | null
   pluginId: string
   manifestHash: string
   requirements: MarketplaceConfirmation[]
+  repository: string
   resolvedCommit: string
   riskLevel: MarketplaceRiskLevel
   riskReasons: MarketplaceRiskReason[]

--- a/plugins/shared/package.json
+++ b/plugins/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-dsh/shared",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Shared client contracts for bundled Oh-DSH plugins",
   "private": true,
   "type": "module",

--- a/scripts/dsh-source.mjs
+++ b/scripts/dsh-source.mjs
@@ -69,24 +69,33 @@ function validateSource(source, expectedRevision) {
 
 function acquirePinnedSource(target) {
   const temporary = `${target}.clone-${String(process.pid)}`
-  rmSync(target, { recursive: true, force: true })
   rmSync(temporary, { recursive: true, force: true })
   try {
+    run('git', ['init', temporary])
+    run('git', ['-C', temporary, 'remote', 'add', 'origin', DSH_SOURCE_SPEC.repository])
     run('git', [
-      'clone',
+      '-C', temporary,
+      'fetch',
+      '--depth=1',
       '--filter=blob:none',
       '--no-tags',
-      '--branch', DSH_SOURCE_SPEC.ref,
-      DSH_SOURCE_SPEC.repository,
-      temporary,
+      'origin',
+      DSH_SOURCE_SPEC.revision,
     ])
+    run('git', ['-C', temporary, 'checkout', '--detach', DSH_SOURCE_SPEC.revision])
     const actual = capture('git', ['rev-parse', 'HEAD'], temporary)
     if (actual !== DSH_SOURCE_SPEC.revision) {
       throw new Error(
         `DSH ref moved: expected ${DSH_SOURCE_SPEC.revision}, received ${actual}`,
       )
     }
-    renameSync(temporary, target)
+    try {
+      renameSync(temporary, target)
+    } catch (error) {
+      if (!existsSync(join(target, '.git'))) throw error
+      validateSource(target, DSH_SOURCE_SPEC.revision)
+      rmSync(temporary, { recursive: true, force: true })
+    }
   } catch (error) {
     rmSync(temporary, { recursive: true, force: true })
     throw error

--- a/src/marketplace-tools.ts
+++ b/src/marketplace-tools.ts
@@ -102,6 +102,7 @@ function pluginView(plugin: MarketplacePlugin): Record<string, unknown> {
     installed: plugin.installed,
     mechanism: plugin.mechanism,
     protected: plugin.protected,
+    repository: plugin.repository,
     risk: plugin.runtimeRisk,
     trust: plugin.trust,
     updateAvailable: plugin.updateAvailable,
@@ -153,8 +154,15 @@ async function snapshot(
     ? { type: 'snapshot' }
     : { type: 'dispatch', command })
   if (response.snapshot === undefined) throw new Error('marketplace gateway omitted its snapshot')
-  if (response.snapshot.error !== null) throw new Error(response.snapshot.error)
-  return response.snapshot
+  return requireHealthyMarketplaceSnapshot(response.snapshot)
+}
+
+/** Preserve the distinction between an unavailable catalog and a valid empty search. */
+export function requireHealthyMarketplaceSnapshot(
+  value: MarketplaceSnapshot,
+): MarketplaceSnapshot {
+  if (value.error !== null) throw new Error(value.error)
+  return value
 }
 
 function marketplaceTool(
@@ -206,7 +214,7 @@ export function mountMarketplaceAgentTools(
 
   ctx.tools.register(marketplaceTool({
     name: 'desktop_plugin_search',
-    description: 'Search dsh-external plugins visible to Oh-DSH-Desktop. Filter by install state or category. This is read-only.',
+    description: 'Search public DSH plugins visible to Oh-DSH-Desktop. Filter by install state or category. This is read-only.',
     parameters: {
       query: { type: 'string', description: 'Case-insensitive plugin name, description, category, or tag query.' },
       status: {
@@ -239,7 +247,7 @@ export function mountMarketplaceAgentTools(
     name: 'desktop_plugin_status',
     description: 'Inspect installed, enabled, update, preview, source-lock, and recovery state for desktop plugins. This is read-only.',
     parameters: {
-      pluginId: { type: 'string', description: 'Optional exact dsh-external repository id.' },
+      pluginId: { type: 'string', description: 'Optional exact marketplace plugin id.' },
     },
     async execute(args) {
       const info = await snapshot(credentials)
@@ -267,7 +275,7 @@ export function mountMarketplaceAgentTools(
         required: true,
         enum: ['install', 'update', 'enable', 'disable', 'uninstall'],
       },
-      pluginId: { type: 'string', required: true, description: 'Exact dsh-external repository id.' },
+      pluginId: { type: 'string', required: true, description: 'Exact marketplace plugin id.' },
     },
     async execute(args) {
       const pluginId = requireString(args, 'pluginId')

--- a/tests/dsh-source.test.ts
+++ b/tests/dsh-source.test.ts
@@ -7,8 +7,10 @@ import { DSH_SOURCE_SPEC, resolveDshSource } from '../scripts/dsh-source.mjs'
 
 test('desktop release source pins a full DSH commit', () => {
   assert.equal(DSH_SOURCE_SPEC.version, '0.1.0-rc.5')
-  assert.equal(DSH_SOURCE_SPEC.ref, 'master')
+  assert.equal(DSH_SOURCE_SPEC.repository, 'https://github.com/deepseek-ai/deepseek-harness.git')
+  assert.match(DSH_SOURCE_SPEC.ref, /^[0-9a-f]{40}$/)
   assert.match(DSH_SOURCE_SPEC.revision, /^[0-9a-f]{40}$/)
+  assert.equal(DSH_SOURCE_SPEC.ref, DSH_SOURCE_SPEC.revision)
 })
 
 test('DSH source override must match the pinned package version', () => {

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { test } from 'node:test'
@@ -27,6 +27,7 @@ function catalogDocument(): unknown {
     repos: [
       {
         name: 'bundle-demo',
+        repo: 'dsh-external/bundle-demo',
         category: 'plugin',
         description: 'Bundle demo',
         bundle: true,
@@ -36,6 +37,7 @@ function catalogDocument(): unknown {
       },
       {
         name: 'safe-demo',
+        repo: 'omdsh-dev/safe-demo',
         category: 'plugin',
         description: 'Safe bundle demo',
         bundle: true,
@@ -44,6 +46,7 @@ function catalogDocument(): unknown {
       },
       {
         name: 'repository-demo',
+        repo: 'vlln/repository-demo',
         category: 'skill',
         note: 'Repository demo',
         bundle: false,
@@ -73,7 +76,7 @@ class FakePlatform implements MarketplacePlatform {
     return { detail: 'test auth', status: 'ready' }
   }
 
-  async cloneRepository(_pluginId: string, _commit: string, target: string): Promise<void> {
+  async cloneRepository(_repository: string, _commit: string, target: string): Promise<void> {
     mkdirSync(target, { recursive: true })
   }
 
@@ -81,7 +84,8 @@ class FakePlatform implements MarketplacePlatform {
     return catalogDocument()
   }
 
-  async readRepositoryFile(pluginId: string, path: string): Promise<string | null> {
+  async readRepositoryFile(repository: string, path: string): Promise<string | null> {
+    const pluginId = repository.split('/').at(-1) ?? repository
     if (pluginId === 'bundle-demo' && path === 'package.json') {
       return JSON.stringify({
         name: this.bundleName,
@@ -108,7 +112,7 @@ class FakePlatform implements MarketplacePlatform {
     return null
   }
 
-  async resolveCommit(): Promise<string> {
+  async resolveCommit(_repository: string): Promise<string> {
     return this.latestCommit
   }
 
@@ -203,7 +207,40 @@ test('catalog parser keeps safe entries and labels unsupported managers', () => 
     catalog.plugins.find(plugin => plugin.id === 'repository-demo')?.description,
     'Repository demo',
   )
+  assert.equal(
+    catalog.plugins.find(plugin => plugin.id === 'repository-demo')?.repository,
+    'vlln/repository-demo',
+  )
   assert.equal(catalog.plugins[0]?.url, 'https://github.com/dsh-external/bundle-demo')
+})
+
+test('community and registry catalogs preserve repositories across owners', () => {
+  const community = parseMarketplaceCatalog({
+    _meta: { schema_version: '1.0', generated_at: '2026-08-14T00:00:00Z' },
+    plugins: [
+      { id: 'alpha-plugin', name: 'Alpha', repo: 'omdsh-dev/alpha-plugin', category: 'plugin', description: { en: 'Alpha plugin' } },
+      { id: 'beta-plugin', name: 'Beta', repo: 'vlln/beta-plugin', category: 'skill', description: { en: 'Beta plugin' } },
+    ],
+  })
+  assert.deepEqual(community.plugins.map(plugin => [plugin.id, plugin.repository, plugin.mechanism]), [
+    ['alpha-plugin', 'omdsh-dev/alpha-plugin', 'discover'],
+    ['beta-plugin', 'vlln/beta-plugin', 'discover'],
+  ])
+
+  const registry = parseMarketplaceCatalog({
+    schema: 'omdsh-registry/v1',
+    entries: [{
+      id: 'registry-plugin',
+      displayName: 'Registry plugin',
+      description: 'Registry plugin',
+      kind: 'plugin',
+      source: { repository: 'whyihaveyou/registry-plugin' },
+      install: { mode: 'repository-plugin' },
+      listing: { state: 'reviewed' },
+    }],
+  })
+  assert.equal(registry.plugins[0]?.repository, 'whyihaveyou/registry-plugin')
+  assert.equal(registry.plugins[0]?.mechanism, 'repository')
 })
 
 test('GitHub credentials use an app-owned config without command-line pairs', () => {
@@ -231,17 +268,14 @@ test('GitHub credentials use an app-owned config without command-line pairs', ()
   }
 })
 
-test('GitHub CLI discovery follows Windows PATH syntax and executable names', { skip: process.platform !== 'win32' }, () => {
+test('GitHub CLI discovery follows Windows PATH syntax and executable names', () => {
   const root = mkdtempSync(join(tmpdir(), 'oh-dsh-gh-path-'))
-  const binary = win32.join(root, 'gh.exe')
   try {
-    writeFileSync(binary, '')
-    chmodSync(binary, 0o755)
+    const expected = win32.join(root, 'gh.exe')
     assert.equal(findGitHubCli({
       Path: `${root};C:\\Program Files\\GitHub CLI`,
-    }, 'win32'), win32.join(root, 'gh.exe'))
+    }, 'win32', candidate => candidate === expected), expected)
   } finally {
-    rmSync(binary, { force: true })
     rmSync(root, { recursive: true, force: true })
   }
 })
@@ -704,7 +738,7 @@ test('repository plugins can be disabled without losing their install receipt', 
     assert.equal(plugin?.enabled, false)
     assert.doesNotMatch(
       readFileSync(join(setup.profileDir, 'cordis.patch.yml'), 'utf8'),
-      /github:dsh-external\/repository-demo/,
+      /github:vlln\/repository-demo/,
     )
 
     await setup.manager.dispatch({
@@ -721,8 +755,51 @@ test('repository plugins can be disabled without losing their install receipt', 
     assert.equal(plugin?.enabled, true)
     assert.match(
       readFileSync(join(setup.profileDir, 'cordis.patch.yml'), 'utf8'),
-      /github:dsh-external\/repository-demo/,
+      /github:vlln\/repository-demo/,
     )
+  } finally {
+    setup.cleanup()
+  }
+})
+
+test('legacy dsh-external repository receipts remain manageable', async () => {
+  const setup = fixture()
+  try {
+    const source = `github:dsh-external/legacy-plugin#${COMMIT}&path:/.dsh-plugin`
+    mkdirSync(join(setup.profileDir, '.oh-dsh'), { recursive: true })
+    writeFileSync(join(setup.profileDir, '.oh-dsh', 'marketplace.json'), JSON.stringify({
+      version: 1,
+      entries: [{
+        installedAt: '2026-08-12T00:00:00Z',
+        mechanism: 'repository',
+        packageName: '@legacy/plugin',
+        pluginId: 'legacy-plugin',
+        resolvedCommit: COMMIT,
+        source,
+      }],
+    }))
+    writeFileSync(join(setup.profileDir, 'cordis.patch.yml'), [
+      '# >>> Oh-DSH-Desktop plugin marketplace',
+      '- id: repository-plugins',
+      '  config:',
+      '    repositories:',
+      `      - '${source}'`,
+      '# <<< Oh-DSH-Desktop plugin marketplace',
+      '',
+    ].join('\n'))
+
+    let snapshot = setup.manager.getSnapshot()
+    assert.equal(snapshot.installed[0]?.pluginId, 'legacy-plugin')
+    assert.equal(snapshot.installed[0]?.source, source)
+    snapshot = await setup.manager.dispatch({ type: 'prepare', action: 'disable', pluginId: 'legacy-plugin' })
+    assert.equal(snapshot.preview?.pluginId, 'legacy-plugin')
+    snapshot = await setup.manager.dispatch({ type: 'apply' })
+    assert.doesNotMatch(readFileSync(join(setup.profileDir, 'cordis.patch.yml'), 'utf8'), /legacy-plugin/)
+    snapshot = await setup.manager.dispatch({ type: 'prepare', action: 'enable', pluginId: 'legacy-plugin' })
+    assert.equal(snapshot.preview, null)
+    assert.ok(snapshot.plan?.requirements.includes('accept-high-risk'))
+    snapshot = await setup.manager.dispatch({ type: 'preview', confirmations: ['accept-high-risk'] })
+    assert.equal(snapshot.preview?.pluginId, 'legacy-plugin')
   } finally {
     setup.cleanup()
   }

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 import { apply } from '../src/plugin.ts'
-import { mountMarketplaceAgentTools } from '../src/marketplace-tools.ts'
+import {
+  mountMarketplaceAgentTools,
+  requireHealthyMarketplaceSnapshot,
+} from '../src/marketplace-tools.ts'
 
 test('desktop client replaces the hero title and keeps the Preview badge', () => {
   const client = readFileSync(new URL('../src/client.ts', import.meta.url), 'utf8')
@@ -209,4 +212,25 @@ test('desktop Agent tools share the guarded marketplace transaction owner', asyn
     await policy({ name: 'desktop_plugin_search' }, async () => ({ kind: 'allow' })),
     { kind: 'allow' },
   )
+})
+
+test('desktop Agent tools reject marketplace failures instead of reporting an empty catalog', () => {
+  assert.throws(() => requireHealthyMarketplaceSnapshot({
+    auth: { detail: 'catalog unavailable', status: 'error' },
+    busy: false,
+    catalog: [],
+    catalogGeneratedAt: null,
+    error: 'GitHub returned 404 for the configured catalog',
+    installed: [],
+    lastAction: null,
+    lifecycle: {
+      candidate: null,
+      current: { profile: 'desktop', state: 'live' },
+      previous: null,
+    },
+    plan: null,
+    preview: null,
+    sourceLocks: [],
+    undoAvailable: false,
+  }), /404/)
 })


### PR DESCRIPTION
## Summary

- pin DSH 0.1.0-rc.5 to the official public `deepseek-ai/deepseek-harness` commit and acquire it with a shallow immutable fetch
- replace the inaccessible marketplace locator with a configurable public catalog, support legacy, `omdsh-registry/v1`, and dsh-suite schemas, and preserve canonical `owner/repo` identity through inspect/clone/receipts/TOFU locks
- keep legacy `github:dsh-external/...` installs manageable, surface backend errors to Agent tools, and make the Windows `gh` discovery test host-independent
- repair canonical source/release documentation and align package/download references with the published v0.1.1 release while retaining the new Linux build path

## Verification

- `pnpm run typecheck`
- `pnpm test` (57 passed)
- `pnpm run build`
- `pnpm run build:dsh` against official DSH 0.1.0-rc.5
- `pnpm run stage:dsh`
- verified the public dsh-suite 1.0 catalog (167 entries, multiple owners) and every documented canonical GitHub repository

Closes #13
Fixes #1
Fixes #9