### PR TITLE
fix: restore response copy button

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {
 } from '../plugins/plugin-marketplace/src/host/platform.ts'
 import { parseMarketplaceCommand } from '../plugins/plugin-marketplace/src/protocol.ts'
 import type { DesktopCommand, DesktopInfo, DesktopRuntimeSnapshot } from './contracts.ts'
+import { allowsRuntimeClipboardWrite, originOf } from './permissions.ts'
 import { BUNDLED_DESKTOP_PLUGINS, DESKTOP_PROFILE, ensureDesktopProfile } from './profile.ts'
 import { DshRuntimeSupervisor, runDshCommand, type DshRuntimeOptions, type RuntimeExit } from './runtime.ts'
 
@@ -712,8 +713,28 @@ async function bootstrap(): Promise<void> {
     onError: error => { appendLog('desktop', `[marketplace-agent] ${String(error)}`) },
   })
   installIpc()
-  session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => { callback(false) })
-  session.defaultSession.setPermissionCheckHandler(() => false)
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+    callback(allowsRuntimeClipboardWrite({
+      isMainFrame: details.isMainFrame,
+      permission,
+      requestingOrigin: details.requestingUrl === undefined
+        ? originOf(webContents.getURL())
+        : originOf(details.requestingUrl),
+      ...(details.requestingUrl === undefined ? {} : { requestingUrl: details.requestingUrl }),
+      runtimeOrigin,
+      webContentsIsMainWindow: webContents === mainWindow?.webContents,
+    }))
+  })
+  session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin, details) => {
+    return allowsRuntimeClipboardWrite({
+      isMainFrame: details.isMainFrame,
+      permission,
+      requestingOrigin,
+      ...(details.requestingUrl === undefined ? {} : { requestingUrl: details.requestingUrl }),
+      runtimeOrigin,
+      webContentsIsMainWindow: webContents === mainWindow?.webContents,
+    })
+  })
   const browserSession = session.fromPartition('persist:oh-dsh-browser')
   browserSession.setPermissionRequestHandler((_webContents, _permission, callback) => { callback(false) })
   browserSession.setPermissionCheckHandler(() => false)

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,25 @@
+export function originOf(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+  try {
+    return new URL(value).origin
+  } catch {
+    return undefined
+  }
+}
+
+/** Allow only clipboard writes from the live DSH document in the main window. */
+export function allowsRuntimeClipboardWrite(input: {
+  isMainFrame: boolean
+  permission: string
+  requestingOrigin: string | undefined
+  requestingUrl?: string
+  runtimeOrigin: string | undefined
+  webContentsIsMainWindow: boolean
+}): boolean {
+  if (input.permission !== 'clipboard-sanitized-write') return false
+  if (!input.webContentsIsMainWindow || !input.isMainFrame) return false
+  if (input.runtimeOrigin === undefined || originOf(input.requestingOrigin) !== input.runtimeOrigin) return false
+
+  const requestingUrlOrigin = originOf(input.requestingUrl)
+  return input.requestingUrl === undefined || requestingUrlOrigin === input.runtimeOrigin
+}

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { allowsRuntimeClipboardWrite, originOf } from '../src/permissions.ts'
+
+const runtimeOrigin = 'http://127.0.0.1:43210'
+
+function request(overrides: Partial<Parameters<typeof allowsRuntimeClipboardWrite>[0]> = {}) {
+  return {
+    isMainFrame: true,
+    permission: 'clipboard-sanitized-write',
+    requestingOrigin: runtimeOrigin,
+    runtimeOrigin,
+    webContentsIsMainWindow: true,
+    ...overrides,
+  }
+}
+
+test('allows clipboard writes from the live DSH main frame', () => {
+  assert.equal(allowsRuntimeClipboardWrite(request({
+    requestingUrl: `${runtimeOrigin}/conversation`,
+  })), true)
+  assert.equal(allowsRuntimeClipboardWrite(request({
+    requestingOrigin: `${runtimeOrigin}/`,
+  })), true)
+})
+
+test('normalizes valid origins and fails closed for invalid URLs', () => {
+  assert.equal(originOf(`${runtimeOrigin}/conversation`), runtimeOrigin)
+  assert.equal(originOf('not a url'), undefined)
+  assert.equal(originOf(undefined), undefined)
+})
+
+test('rejects clipboard reads and every non-DSH permission', () => {
+  assert.equal(allowsRuntimeClipboardWrite(request({ permission: 'clipboard-read' })), false)
+  assert.equal(allowsRuntimeClipboardWrite(request({ permission: 'notifications' })), false)
+})
+
+test('rejects clipboard writes from untrusted frames and windows', () => {
+  assert.equal(allowsRuntimeClipboardWrite(request({ isMainFrame: false })), false)
+  assert.equal(allowsRuntimeClipboardWrite(request({ webContentsIsMainWindow: false })), false)
+  assert.equal(allowsRuntimeClipboardWrite(request({ requestingOrigin: 'https://example.com' })), false)
+  assert.equal(allowsRuntimeClipboardWrite(request({ requestingUrl: 'https://example.com/steal' })), false)
+  assert.equal(allowsRuntimeClipboardWrite(request({ requestingUrl: 'not a url' })), false)
+})


### PR DESCRIPTION
## Summary
- permit sanitized clipboard writes only from the live DSH main frame
- retain denial of clipboard reads, iframe writes, preview writes, and unrelated permissions
- cover allowed and rejected permission cases

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm run build`
- Electron clipboard smoke test

Closes #15