### PR TITLE
fix: address marketplace review findings

### DIFF
--- a/plugins/plugin-marketplace/src/client/plugin.tsx
+++ b/plugins/plugin-marketplace/src/client/plugin.tsx
@@ -829,7 +829,7 @@ function MarketplaceSurface({ bridge, locale, translate, view }: {
             </div>
             {snapshot === null || pending && snapshot.catalog.length === 0 ? (
               <div className="oh-marketplace-empty">{t('loading-catalog')}</div>
-            ) : snapshot.auth.status !== 'ready' ? (
+            ) : snapshot.auth.status !== 'ready' && snapshot.catalog.length === 0 ? (
               <div className="oh-marketplace-empty">
                 <div>
                   <strong>{t('github-auth-required')}</strong><br />

--- a/plugins/plugin-marketplace/src/host/platform.ts
+++ b/plugins/plugin-marketplace/src/host/platform.ts
@@ -40,6 +40,7 @@ export interface ProductionMarketplacePlatformOptions {
   cliEntry: string
   cwd: string
   env: NodeJS.ProcessEnv
+  fetch?: typeof globalThis.fetch
   nodeBinary: string
   onLog?: (message: string) => void
 }
@@ -239,7 +240,6 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
   }
 
   async loadCatalog(): Promise<unknown> {
-    const gh = this.requireGitHubCli()
     const locator = this.#options.env.OH_DSH_MARKETPLACE_CATALOG
       ?? `${MARKETPLACE_CATALOG_REPOSITORY}/${MARKETPLACE_CATALOG_PATH}`
     const match = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/(.+)$/.exec(locator)
@@ -249,13 +249,37 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
     validateRepository(match[1] ?? '')
     const path = match[2] ?? ''
     const contentPath = repositoryContentPath(match[1] ?? '', path)
-    const result = await runCommand(gh, [
-      'api',
-      contentPath,
-      '--jq',
-      '.content',
-    ], { env: this.#options.env, timeoutMs: 30_000 })
-    return JSON.parse(Buffer.from(result.stdout.replaceAll(/\s/g, ''), 'base64').toString('utf8')) as unknown
+    const request = this.#options.fetch ?? globalThis.fetch
+    let publicError: unknown
+    try {
+      const response = await request(`https://api.github.com/${contentPath}`, {
+        headers: {
+          accept: 'application/vnd.github.raw+json',
+          'user-agent': 'oh-dsh-desktop',
+        },
+        signal: AbortSignal.timeout(30_000),
+      })
+      if (!response.ok) throw new Error(`GitHub public catalog request failed with HTTP ${String(response.status)}`)
+      return JSON.parse(await response.text()) as unknown
+    } catch (error) {
+      publicError = error
+    }
+    if (this.#ghPath !== null) {
+      try {
+        const result = await runCommand(this.#ghPath, [
+          'api',
+          contentPath,
+          '--jq',
+          '.content',
+        ], { env: this.#options.env, timeoutMs: 30_000 })
+        return JSON.parse(Buffer.from(result.stdout.replaceAll(/\s/g, ''), 'base64').toString('utf8')) as unknown
+      } catch (authenticatedError) {
+        throw new Error(
+          `failed to load marketplace catalog anonymously (${String(publicError)}) or with GitHub CLI (${String(authenticatedError)})`,
+        )
+      }
+    }
+    throw new Error(`failed to load public marketplace catalog: ${String(publicError)}`)
   }
 
   async resolveCommit(repository: string): Promise<string> {

--- a/plugins/plugin-marketplace/src/host/transaction-manager.ts
+++ b/plugins/plugin-marketplace/src/host/transaction-manager.ts
@@ -186,8 +186,16 @@ function sourceReview(
   lock: MarketplaceSourceLock | undefined,
   input: Pick<MarketplacePlan,
     'manifestHash' | 'mechanism' | 'packageName' | 'pluginId' | 'repository' | 'resolvedCommit'>,
+  installed?: MarketplaceInstalledPlugin,
 ): MarketplaceSourceReview {
-  if (lock === undefined) return 'first-use'
+  if (lock === undefined) {
+    if (installed === undefined) return 'first-use'
+    return repositoryFromSource(installed.source) === input.repository
+      && installed.mechanism === input.mechanism
+      && installed.packageName === input.packageName
+      ? 'matched'
+      : 'changed'
+  }
   if (lock.resolvedCommit === input.resolvedCommit
     && lock.manifestHash !== input.manifestHash) {
     throw new Error(`${input.pluginId} changed content at pinned commit ${input.resolvedCommit}`)
@@ -630,11 +638,6 @@ export class PluginMarketplaceManager {
 
   private async refresh(): Promise<void> {
     this.#auth = await this.#options.platform.authStatus()
-    if (this.#auth.status !== 'ready') {
-      this.#catalog = []
-      this.#catalogGeneratedAt = null
-      return
-    }
     const installed = readMarketplaceState(this.#profileDir).entries
     const catalog = parseMarketplaceCatalog(await this.#options.platform.loadCatalog(), installed)
     this.#catalog = catalog.plugins
@@ -787,6 +790,7 @@ export class PluginMarketplaceManager {
         repository: catalogPlugin.repository,
         resolvedCommit: commit,
       },
+      current,
     )
     const scripts = buildScripts(manifest)
     const risk = assessRisk({
@@ -844,17 +848,12 @@ export class PluginMarketplaceManager {
           resolvedCommit: plan.resolvedCommit,
           source: plan.source,
         }
+        if (existing?.mechanism === 'bundle'
+          && (plan.mechanism !== 'bundle' || existing.packageName !== plan.packageName)) {
+          await this.removeBundle(candidateHome, candidateProfile, root, existing)
+        }
         if (plan.mechanism === 'bundle') {
           if (plan.packageName === null) throw new Error('bundle plan is missing its package name')
-          if (existing?.mechanism === 'bundle'
-            && existing.packageName !== null
-            && existing.packageName !== plan.packageName) {
-            await this.#options.platform.runDsh({
-              args: ['plugin', '--profile', this.#options.profile, 'remove', existing.packageName],
-              dshHome: candidateHome,
-              sandboxRoot: root,
-            })
-          }
           const sources = join(candidateProfile, MANAGED_DIRECTORY, 'sources')
           if (existsSync(sources)) {
             for (const entry of readdirSync(sources)) {
@@ -905,18 +904,7 @@ export class PluginMarketplaceManager {
         const installed = existing
         if (installed === undefined) throw new Error(`${plan.pluginId} is no longer installed`)
         if (installed.mechanism === 'bundle') {
-          if (installed.packageName === null) throw new Error('installed bundle is missing its package name')
-          await this.#options.platform.runDsh({
-            args: ['plugin', '--profile', this.#options.profile, 'remove', installed.packageName],
-            dshHome: candidateHome,
-            sandboxRoot: root,
-          })
-          const sources = join(candidateProfile, MANAGED_DIRECTORY, 'sources')
-          if (existsSync(sources)) {
-            for (const entry of readdirSync(sources)) {
-              if (entry.startsWith(`${plan.pluginId}-`)) removeWithin(sources, join(sources, entry))
-            }
-          }
+          await this.removeBundle(candidateHome, candidateProfile, root, installed)
         }
         updateRepositoryPatch(candidateProfile, remaining)
         writeMarketplaceState(candidateProfile, {
@@ -966,6 +954,25 @@ export class PluginMarketplaceManager {
       await this.#options.runtime.stopPreview().catch(() => {})
       removeWithin(this.#previewsRoot, root)
       throw error
+    }
+  }
+
+  private async removeBundle(
+    candidateHome: string,
+    candidateProfile: string,
+    sandboxRoot: string,
+    installed: MarketplaceInstalledPlugin,
+  ): Promise<void> {
+    if (installed.packageName === null) throw new Error('installed bundle is missing its package name')
+    await this.#options.platform.runDsh({
+      args: ['plugin', '--profile', this.#options.profile, 'remove', installed.packageName],
+      dshHome: candidateHome,
+      sandboxRoot,
+    })
+    const sources = join(candidateProfile, MANAGED_DIRECTORY, 'sources')
+    if (!existsSync(sources)) return
+    for (const entry of readdirSync(sources)) {
+      if (entry.startsWith(`${installed.pluginId}-`)) removeWithin(sources, join(sources, entry))
     }
   }
 

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -9,7 +9,11 @@ import type {
   MarketplaceAuthResult,
   MarketplacePlatform,
 } from '../plugins/plugin-marketplace/src/host/platform.ts'
-import { findGitHubCli, withGitHubCredentials } from '../plugins/plugin-marketplace/src/host/platform.ts'
+import {
+  findGitHubCli,
+  ProductionMarketplacePlatform,
+  withGitHubCredentials,
+} from '../plugins/plugin-marketplace/src/host/platform.ts'
 import {
   PluginMarketplaceManager,
   type MarketplacePreviewRuntimeInput,
@@ -280,6 +284,49 @@ test('GitHub CLI discovery follows Windows PATH syntax and executable names', ()
   }
 })
 
+test('public catalogs load anonymously without GitHub CLI', async () => {
+  let requested = ''
+  const platform = new ProductionMarketplacePlatform({
+    cliEntry: '/unused/dsh.mjs',
+    cwd: tmpdir(),
+    env: {
+      OH_DSH_MARKETPLACE_CATALOG: 'public-owner/public-catalog/data/plugins.json',
+      PATH: '',
+    },
+    fetch: async (input): Promise<Response> => {
+      requested = String(input)
+      return new Response(JSON.stringify(catalogDocument()), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      })
+    },
+    nodeBinary: process.execPath,
+  })
+
+  assert.notEqual((await platform.authStatus()).status, 'ready')
+  assert.deepEqual(await platform.loadCatalog(), catalogDocument())
+  assert.equal(
+    requested,
+    'https://api.github.com/repos/public-owner/public-catalog/contents/data/plugins.json',
+  )
+})
+
+test('refresh keeps public catalogs available when GitHub CLI is unavailable', async () => {
+  const setup = fixture()
+  try {
+    setup.platform.authStatus = async (): Promise<MarketplaceAuthResult> => ({
+      detail: 'GitHub CLI is unavailable',
+      status: 'missing-cli',
+    })
+    const snapshot = await setup.manager.dispatch({ type: 'refresh' })
+    assert.equal(snapshot.auth.status, 'missing-cli')
+    assert.equal(snapshot.catalog.length, 6)
+    assert.equal(snapshot.error, null)
+  } finally {
+    setup.cleanup()
+  }
+})
+
 test('a client reconnect during apply does not leave a sticky busy error', async () => {
   const setup = fixture()
   try {
@@ -375,6 +422,7 @@ test('marketplace navigation reserves room for Settings in short windows', () =>
   assert.match(client, /\['disabled', t\('disabled'\)\]/)
   assert.match(client, /type: 'prepare'/)
   assert.match(client, /confirmations\.includes\(requirement\)/)
+  assert.match(client, /snapshot\.auth\.status !== 'ready' && snapshot\.catalog\.length === 0/)
   assert.match(client, /source-review\.\$\{plan\.sourceReview\}/)
   assert.match(client, /risk-level\.\$\{plan\.riskLevel\}/)
   assert.match(messages, /installed: '已安装'/)
@@ -800,6 +848,127 @@ test('legacy dsh-external repository receipts remain manageable', async () => {
     assert.ok(snapshot.plan?.requirements.includes('accept-high-risk'))
     snapshot = await setup.manager.dispatch({ type: 'preview', confirmations: ['accept-high-risk'] })
     assert.equal(snapshot.preview?.pluginId, 'legacy-plugin')
+  } finally {
+    setup.cleanup()
+  }
+})
+
+test('legacy receipts require confirmation before changing repository identity', async () => {
+  const setup = fixture()
+  try {
+    const source = `github:dsh-external/legacy-plugin#${COMMIT}&path:/.dsh-plugin`
+    mkdirSync(join(setup.profileDir, '.oh-dsh'), { recursive: true })
+    writeFileSync(join(setup.profileDir, '.oh-dsh', 'marketplace.json'), JSON.stringify({
+      version: 1,
+      entries: [{
+        installedAt: '2026-08-12T00:00:00Z',
+        mechanism: 'repository',
+        packageName: '@legacy/plugin',
+        pluginId: 'legacy-plugin',
+        resolvedCommit: COMMIT,
+        source,
+      }],
+    }))
+    writeFileSync(join(setup.profileDir, 'cordis.patch.yml'), [
+      '# >>> Oh-DSH-Desktop plugin marketplace',
+      '- id: repository-plugins',
+      '  config:',
+      '    repositories:',
+      `      - '${source}'`,
+      '# <<< Oh-DSH-Desktop plugin marketplace',
+      '',
+    ].join('\n'))
+    setup.platform.latestCommit = UPDATED_COMMIT
+    setup.platform.readRepositoryFile = async (_repository, path): Promise<string | null> =>
+      path === '.dsh-plugin/package.json'
+        ? JSON.stringify({ name: '@legacy/plugin' })
+        : null
+    const repositoryCatalog = (repository: string): unknown => ({
+      schema: 'omdsh-registry/v1',
+      entries: [{
+        id: 'legacy-plugin',
+        displayName: 'Legacy plugin',
+        description: 'Legacy plugin',
+        kind: 'plugin',
+        source: { repository },
+        install: { mode: 'repository-plugin' },
+        listing: { state: 'reviewed' },
+      }],
+    })
+
+    setup.platform.loadCatalog = async (): Promise<unknown> => repositoryCatalog('dsh-external/legacy-plugin')
+    await setup.manager.dispatch({ type: 'refresh' })
+    let snapshot = await setup.manager.dispatch({ type: 'inspect', action: 'update', pluginId: 'legacy-plugin' })
+    assert.equal(snapshot.plan?.sourceReview, 'matched')
+    assert.ok(!snapshot.plan?.requirements.includes('accept-source-change'))
+
+    setup.platform.loadCatalog = async (): Promise<unknown> => repositoryCatalog('vlln/legacy-plugin')
+    await setup.manager.dispatch({ type: 'refresh' })
+    snapshot = await setup.manager.dispatch({ type: 'inspect', action: 'update', pluginId: 'legacy-plugin' })
+    assert.equal(snapshot.plan?.sourceReview, 'changed')
+    assert.ok(snapshot.plan?.requirements.includes('accept-source-change'))
+  } finally {
+    setup.cleanup()
+  }
+})
+
+test('discover updates remove an old bundle before switching to a repository plugin', async () => {
+  const setup = fixture()
+  try {
+    let repositoryMode = false
+    setup.platform.bundleName = '@example/changing-plugin'
+    setup.platform.loadCatalog = async (): Promise<unknown> => ({
+      _meta: { schema_version: '1.0', generated_at: '2026-08-14T00:00:00Z' },
+      plugins: [{
+        id: 'changing-plugin',
+        name: 'Changing plugin',
+        repo: 'omdsh-dev/changing-plugin',
+        category: 'plugin',
+        description: { en: 'Changing plugin' },
+      }],
+    })
+    setup.platform.readRepositoryFile = async (_repository, path): Promise<string | null> => {
+      if (!repositoryMode && path === 'package.json') {
+        return JSON.stringify({
+          name: '@example/changing-plugin',
+          dsh: { bundle: { patch: './cordis.patch.yml' } },
+        })
+      }
+      if (repositoryMode && path === '.dsh-plugin/package.json') {
+        return JSON.stringify({ name: '@example/changing-plugin' })
+      }
+      return null
+    }
+
+    await setup.manager.dispatch({ type: 'refresh' })
+    await setup.manager.dispatch({ type: 'prepare', action: 'install', pluginId: 'changing-plugin' })
+    let snapshot = await setup.manager.dispatch({ type: 'apply' })
+    assert.equal(snapshot.installed[0]?.mechanism, 'bundle')
+    let manifest = JSON.parse(readFileSync(join(setup.profileDir, 'package.json'), 'utf8'))
+    assert.equal(typeof manifest.dependencies['@example/changing-plugin'], 'string')
+
+    repositoryMode = true
+    setup.platform.latestCommit = UPDATED_COMMIT
+    await setup.manager.dispatch({ type: 'refresh' })
+    snapshot = await setup.manager.dispatch({ type: 'inspect', action: 'update', pluginId: 'changing-plugin' })
+    assert.equal(snapshot.plan?.mechanism, 'repository')
+    assert.ok(snapshot.plan?.requirements.includes('accept-source-change'))
+    await setup.manager.dispatch({
+      type: 'preview',
+      confirmations: ['accept-high-risk', 'accept-source-change'],
+    })
+    snapshot = await setup.manager.dispatch({ type: 'apply' })
+
+    assert.equal(snapshot.installed[0]?.mechanism, 'repository')
+    manifest = JSON.parse(readFileSync(join(setup.profileDir, 'package.json'), 'utf8'))
+    assert.equal(manifest.dependencies['@example/changing-plugin'], undefined)
+    assert.ok(!manifest.dsh.profile.bundles.includes('@example/changing-plugin'))
+    assert.match(
+      readFileSync(join(setup.profileDir, 'cordis.patch.yml'), 'utf8'),
+      /github:omdsh-dev\/changing-plugin/,
+    )
+    assert.ok(setup.platform.commands.some(command =>
+      command.args.join(' ') === 'plugin --profile desktop remove @example/changing-plugin'))
   } finally {
     setup.cleanup()
   }


### PR DESCRIPTION
## Summary

- load public marketplace catalogs anonymously and use authenticated `gh api` only as a fallback
- keep public catalog results visible when GitHub CLI is missing or signed out
- derive legacy receipt identity from the installed source before allowing repository or mechanism changes
- remove stale bundle dependencies and managed checkouts during bundle-to-repository migrations

## Verification

- `pnpm test` (61 passed)
- `pnpm run typecheck`
- `pnpm run build`

## Review follow-up

Addresses the three findings from #17:

- https://github.com/hust-open-atom-club/oh-dsh/pull/17#discussion_r3777436663
- https://github.com/hust-open-atom-club/oh-dsh/pull/17#discussion_r3777436670
- https://github.com/hust-open-atom-club/oh-dsh/pull/17#discussion_r3777436674