### PR TITLE
fix: close Plugins page on session navigation

### DIFF
--- a/plugins/plugin-marketplace/src/client/plugin.tsx
+++ b/plugins/plugin-marketplace/src/client/plugin.tsx
@@ -19,6 +19,12 @@ import type {
 } from '../protocol.ts'
 import { MARKETPLACE_MESSAGES, type MarketplaceMessage } from './i18n.ts'
 import marketplaceCss from './marketplace.css'
+import {
+  initialSessionNavigationState,
+  transitionSessionNavigation,
+  type SessionListSnapshot,
+  type SessionNavigationState,
+} from './session-navigation.ts'
 
 interface ClientContext {
   effect(effect: () => (() => void) | void, label?: string): void
@@ -30,6 +36,15 @@ interface ClientContext {
 
 interface MarketplaceViewState {
   open: boolean
+}
+
+interface ObservableSnapshot<T> {
+  getSnapshot(): T
+  subscribe(listener: () => void): () => void
+}
+
+interface SessionsService {
+  list: ObservableSnapshot<SessionListSnapshot>
 }
 
 export interface PluginMarketplaceView {
@@ -45,7 +60,7 @@ declare global {
   }
 }
 
-export const inject = ['locale']
+export const inject = ['locale', 'sessions']
 
 const OPEN_KEY = 'oh-dsh-desktop.plugin-marketplace.open'
 const SIDEBAR_BOTTOM_INSET = 8
@@ -156,6 +171,7 @@ class PluginMarketplaceViewService implements PluginMarketplaceView {
   readonly #bridge: DesktopBridge
   readonly #locale: LocaleService
   readonly #t: Translate<MarketplaceMessage>
+  readonly #sessions: SessionsService
   readonly #listeners = new Set<() => void>()
   #state: MarketplaceViewState = { open: readOpen() }
   #element: HTMLDivElement | null = null
@@ -167,6 +183,8 @@ class PluginMarketplaceViewService implements PluginMarketplaceView {
   #placementFrame: number | null = null
   #sidebarRoot: HTMLElement | null = null
   #unsubscribeLocale: (() => void) | null = null
+  #unsubscribeSessions: (() => void) | null = null
+  #sessionNavigationState: SessionNavigationState = initialSessionNavigationState()
   readonly #handleResize = (): void => { this.schedulePlacement() }
   readonly #handleDocumentClick = (event: MouseEvent): void => {
     if (!this.#state.open || !(event.target instanceof Element)) return
@@ -178,10 +196,12 @@ class PluginMarketplaceViewService implements PluginMarketplaceView {
     bridge: DesktopBridge,
     locale: LocaleService,
     t: Translate<MarketplaceMessage>,
+    sessions: SessionsService,
   ) {
     this.#bridge = bridge
     this.#locale = locale
     this.#t = t
+    this.#sessions = sessions
   }
 
   getSnapshot = (): MarketplaceViewState => this.#state
@@ -204,6 +224,7 @@ class PluginMarketplaceViewService implements PluginMarketplaceView {
   toggle(): void { this.setOpen(!this.#state.open) }
 
   mount(): void {
+    this.#sessionNavigationState = initialSessionNavigationState()
     this.#style = document.createElement('style')
     this.#style.dataset.ohDshPluginMarketplaceStyles = 'true'
     this.#style.textContent = marketplaceCss
@@ -233,6 +254,16 @@ class PluginMarketplaceViewService implements PluginMarketplaceView {
     this.#unsubscribeLocale = this.#locale.subscribe(() => {
       this.renderEntryLabel()
     })
+    const syncSessionNavigation = (): void => {
+      const transition = transitionSessionNavigation(
+        this.#sessionNavigationState,
+        this.#sessions.list.getSnapshot(),
+      )
+      this.#sessionNavigationState = transition.state
+      if (transition.close) this.setOpen(false)
+    }
+    this.#unsubscribeSessions = this.#sessions.list.subscribe(syncSessionNavigation)
+    syncSessionNavigation()
     this.applyOpenState()
     this.schedulePlacement()
   }
@@ -242,6 +273,8 @@ class PluginMarketplaceViewService implements PluginMarketplaceView {
     window.removeEventListener('resize', this.#handleResize)
     this.#unsubscribeLocale?.()
     this.#unsubscribeLocale = null
+    this.#unsubscribeSessions?.()
+    this.#unsubscribeSessions = null
     if (this.#placementFrame !== null) cancelAnimationFrame(this.#placementFrame)
     this.#observer?.disconnect()
     this.#resizeObserver?.disconnect()
@@ -874,8 +907,9 @@ export function apply(ctx: ClientContext): void {
   const bridge = window.dshDesktop
   if (bridge === undefined) throw new Error('plugin-marketplace: Electron bridge is unavailable')
   const locale = ctx.get('locale') as LocaleService
+  const sessions = ctx.get('sessions') as SessionsService
   const t: Translate<MarketplaceMessage> = locale.bind('oh-dsh.plugin-marketplace')
-  const view = new PluginMarketplaceViewService(bridge, locale, t)
+  const view = new PluginMarketplaceViewService(bridge, locale, t, sessions)
   ctx.effect(
     () => locale.register('oh-dsh.plugin-marketplace', MARKETPLACE_MESSAGES),
     'oh-dsh-desktop: marketplace dictionaries',

--- a/plugins/plugin-marketplace/src/client/session-navigation.ts
+++ b/plugins/plugin-marketplace/src/client/session-navigation.ts
@@ -1,0 +1,34 @@
+export interface SessionListSnapshot {
+  current: string | undefined
+  phase: 'pending' | 'ready'
+}
+
+export interface SessionNavigationState {
+  current: string | undefined
+  ready: boolean
+}
+
+export interface SessionNavigationTransition {
+  close: boolean
+  state: SessionNavigationState
+}
+
+/** Track user-visible session activation without treating startup as navigation. */
+export function transitionSessionNavigation(
+  previous: SessionNavigationState,
+  snapshot: SessionListSnapshot,
+): SessionNavigationTransition {
+  if (snapshot.phase !== 'ready') return { close: false, state: previous }
+
+  const current = snapshot.current === '' ? undefined : snapshot.current
+  if (!previous.ready) return { close: false, state: { current, ready: true } }
+
+  return {
+    close: current !== undefined && current !== previous.current,
+    state: { current, ready: true },
+  }
+}
+
+export function initialSessionNavigationState(): SessionNavigationState {
+  return { current: undefined, ready: false }
+}

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -20,6 +20,10 @@ import {
   type MarketplaceRuntime,
 } from '../plugins/plugin-marketplace/src/host/transaction-manager.ts'
 import { startMarketplaceAgentGateway } from '../plugins/plugin-marketplace/src/host/agent-gateway.ts'
+import {
+  initialSessionNavigationState,
+  transitionSessionNavigation,
+} from '../plugins/plugin-marketplace/src/client/session-navigation.ts'
 
 const COMMIT = '0123456789abcdef0123456789abcdef01234567'
 const UPDATED_COMMIT = 'fedcba9876543210fedcba9876543210fedcba98'
@@ -414,7 +418,10 @@ test('marketplace navigation reserves room for Settings in short windows', () =>
   assert.match(css, /\.oh-marketplace-nav \{[\s\S]*gap: 8px;/)
   assert.match(css, /\.oh-marketplace-nav \{[\s\S]*padding: 6px 2px 6px 10px;/)
   assert.match(css, /\.oh-marketplace-nav svg \{[\s\S]*width: 16px;[\s\S]*height: 16px;/)
-  assert.match(client, /export const inject = \['locale'\]/)
+  assert.match(client, /export const inject = \['locale', 'sessions'\]/)
+  assert.match(client, /ctx\.get\('sessions'\) as SessionsService/)
+  assert.match(client, /this\.#sessions\.list\.subscribe\(syncSessionNavigation\)/)
+  assert.match(client, /this\.#unsubscribeSessions\?\.\(\)/)
   assert.match(client, /locale\.register\('oh-dsh\.plugin-marketplace'/)
   assert.match(client, /\['installed', t\('installed'\)\]/)
   assert.match(client, /\['available', t\('not-installed'\)\]/)
@@ -435,6 +442,46 @@ test('marketplace navigation reserves room for Settings in short windows', () =>
   assert.match(client, /document\.addEventListener\('click', this\.#handleDocumentClick, true\)/)
   assert.match(client, /button === settingsButton\(\)/)
   assert.match(client, /if \(disposed \|\| info\.preview !== null\) return/)
+})
+
+test('marketplace session navigation closes only after a ready session baseline', () => {
+  let state = initialSessionNavigationState()
+  let transition = transitionSessionNavigation(state, { current: undefined, phase: 'pending' })
+  assert.equal(transition.close, false)
+  assert.deepEqual(transition.state, { current: undefined, ready: false })
+
+  state = transition.state
+  transition = transitionSessionNavigation(state, { current: 'session-a', phase: 'ready' })
+  assert.equal(transition.close, false)
+  assert.deepEqual(transition.state, { current: 'session-a', ready: true })
+
+  state = transition.state
+  transition = transitionSessionNavigation(state, { current: 'session-b', phase: 'pending' })
+  assert.equal(transition.close, false)
+  assert.deepEqual(transition.state, { current: 'session-a', ready: true })
+
+  state = transition.state
+  transition = transitionSessionNavigation(state, { current: 'session-b', phase: 'ready' })
+  assert.equal(transition.close, true)
+  assert.deepEqual(transition.state, { current: 'session-b', ready: true })
+
+  state = transition.state
+  transition = transitionSessionNavigation(state, { current: 'session-b', phase: 'ready' })
+  assert.equal(transition.close, false)
+  assert.deepEqual(transition.state, { current: 'session-b', ready: true })
+
+  state = transition.state
+  transition = transitionSessionNavigation(state, { current: undefined, phase: 'ready' })
+  assert.equal(transition.close, false)
+  assert.deepEqual(transition.state, { current: undefined, ready: true })
+})
+
+test('marketplace session navigation closes when an empty baseline activates a session', () => {
+  let state = initialSessionNavigationState()
+  state = transitionSessionNavigation(state, { current: undefined, phase: 'ready' }).state
+  const transition = transitionSessionNavigation(state, { current: 'new-session', phase: 'ready' })
+  assert.equal(transition.close, true)
+  assert.deepEqual(transition.state, { current: 'new-session', ready: true })
 })
 
 test('bundle preview remains isolated until apply and supports undo', async () => {


### PR DESCRIPTION
## Summary

- close the Plugins marketplace overlay after a different ready session is activated
- close it when a session is created from an empty ready baseline
- preserve the persisted Plugins state during startup and reconnect transitions
- clean up the sessions subscription when the marketplace is disposed

## Tests

- `pnpm test`
- `pnpm run typecheck`
- `pnpm run build`

Closes #14
