### PR TITLE
license: adopt the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,21 @@
-BSD 3-Clause License
+MIT License
 
-Copyright (c) 2026, Oh-DSH-Desktop contributors
-All rights reserved.
+Copyright (c) 2026 Oh-DSH contributors
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.en.md
+++ b/README.en.md
@@ -13,7 +13,7 @@
   <img alt="macOS" src="https://img.shields.io/badge/macOS-12%2B-111111?logo=apple&logoColor=white">
   <img alt="Linux" src="https://img.shields.io/badge/Linux-x64-FCC624?logo=linux&logoColor=black">
   <img alt="Windows" src="https://img.shields.io/badge/Windows-x64-0078D6?logo=windows&logoColor=white">
-  <img alt="BSD 3-Clause" src="https://img.shields.io/badge/license-BSD--3--Clause-34a853">
+  <img alt="MIT" src="https://img.shields.io/badge/license-MIT-34a853">
 </p>
 
 <p align="center">
@@ -122,4 +122,4 @@ source and adaptation boundary.
 
 ## License
 
-[BSD 3-Clause](./LICENSE)
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img alt="macOS" src="https://img.shields.io/badge/macOS-12%2B-111111?logo=apple&logoColor=white">
   <img alt="Linux" src="https://img.shields.io/badge/Linux-x64-FCC624?logo=linux&logoColor=black">
   <img alt="Windows" src="https://img.shields.io/badge/Windows-x64-0078D6?logo=windows&logoColor=white">
-  <img alt="BSD 3-Clause" src="https://img.shields.io/badge/license-BSD--3--Clause-34a853">
+  <img alt="MIT" src="https://img.shields.io/badge/license-MIT-34a853">
 </p>
 
 <p align="center">
@@ -117,4 +117,4 @@ Web 使用 `pnpm run dist:web`。
 
 ## License
 
-[BSD 3-Clause](./LICENSE)
+[MIT](./LICENSE)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,7 +1,7 @@
 # Third-Party Notices
 
-Oh-DSH-Desktop is distributed under the BSD 3-Clause License. The projects
-below informed independently implemented bundled plugins.
+Oh-DSH is distributed under the MIT License. The projects below informed
+independently implemented bundled plugins.
 
 Upstream UI, themes, and component styling are not bundled. Oh-DSH adapts
 compatible features to its own persistence, layout, localization, and theme

--- a/plugins/skins/package.json
+++ b/plugins/skins/package.json
@@ -34,5 +34,5 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
-  "license": "BSD-3-Clause"
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary

- replace the project BSD 3-Clause license with the standard MIT text
- update the bilingual README badges and license links
- align the first-party skins package and third-party notice header
- preserve every upstream and third-party license declaration

## Why

MIT provides the repository with the requested permissive licensing terms
while keeping attribution and warranty conditions explicit.

## Validation

- `pnpm typecheck`
- `pnpm test` (91 passed)
- `pnpm run build`
- `git diff --check`
