### PR TITLE
feat: support provider-neutral onboarding and OAuth providers

### DIFF
--- a/dsh-source.json
+++ b/dsh-source.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/deepseek-ai/deepseek-harness.git",
-  "ref": "47f943859bef60e4160492346772ded9b24f765a",
-  "revision": "47f943859bef60e4160492346772ded9b24f765a",
+  "ref": "09dcaf1b8d97ad06b382200ddbf66c86f524b819",
+  "revision": "09dcaf1b8d97ad06b382200ddbf66c86f524b819",
   "version": "0.1.0-rc.5"
 }


### PR DESCRIPTION
## Summary

- adopt provider-neutral model setup and native OAuth flows
- keep API-key setup available through the generic OpenAI-compatible Endpoint
- preserve the DeepSeek API-key path without making it the only onboarding choice

Related issue: #6

## Implementation

- Keep the Oh-DSH Electron shell unchanged and update its pinned DSH runtime reference.
- Move provider setup behind a provider-neutral configuration model: catalog providers inherit their endpoint and model metadata, while custom routes can declare an OpenAI-compatible endpoint, model list, headers, and reasoning capabilities.
- Expose native provider authentication through host-owned `llm.auth` operations (`start`, `status`, `cancel`, and `logout`). OAuth tokens stay in the host credential store; the browser receives only safe login status and device-code or authorization-URL events.
- Build onboarding from the available provider capabilities instead of hard-coding DeepSeek. API-key and OAuth setup use separate paths, and the selected provider is carried through to model selection so a Codex or other OAuth choice does not fall back to DeepSeek.
- Keep the generic OpenAI-compatible Endpoint as the API-key escape hatch for providers that do not have a native OAuth adapter.

## Validation

- `pnpm test`: 91 passed
- `pnpm run build`: passed
- `pnpm run typecheck`: passed