### PR TITLE
nix: add dev shell and desktop packages

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ release/
 tmp/
 *.log
 .DS_Store
+.direnv/
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,142 @@
+{
+  "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1786704638,
+        "narHash": "sha256-/fVVDevImdj8PFczYgd9WFm0k8nxESbfWVgmy4pFR/k=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "901c200318d2b06ce3c31e667fd63e979a22ec42",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "llm-agents": "llm-agents",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "Oh-DSH: an installable DeepSeek Harness desktop and web distribution";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, llm-agents }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      # The version of deepseek-harness pinned by this repository.
+      dshSourceSpec = builtins.fromJSON (builtins.readFile ./dsh-source.json);
+    in
+    {
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.nodejs_24
+              pkgs.pnpm
+              pkgs.git
+              pkgs.curl
+              pkgs.python3 # node-gyp
+              pkgs.pkg-config
+            ];
+
+            # pnpm install fetches its own electron; no nixpkgs electron here.
+            shellHook = ''
+              export OH_DSH_SOURCE_ROOT="$PWD"
+            '';
+          };
+        });
+
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          mkOhDsh = import ./nix/oh-dsh.nix {
+            inherit pkgs system llm-agents dshSourceSpec;
+          };
+        in
+        rec {
+          # Default dsh source: numtide/llm-agents.nix.
+          oh-dsh-web = mkOhDsh { surface = "web"; dshSource = "llm-agents"; };
+          oh-dsh-desktop = mkOhDsh { surface = "desktop"; dshSource = "llm-agents"; };
+
+          # Variant pinning the DSH runtime to this repo's dsh-source.json.
+          oh-dsh-web-pinned = mkOhDsh { surface = "web"; dshSource = "pinned"; };
+          oh-dsh-desktop-pinned = mkOhDsh { surface = "desktop"; dshSource = "pinned"; };
+
+          # "nixpkgs" variant is available via mkOhDsh but not exposed as a
+          # package until pkgs.deepseek-harness lands (NixOS/nixpkgs#552467).
+
+          default = oh-dsh-web;
+        });
+    };
+}

--- a/nix/collect-deps.py
+++ b/nix/collect-deps.py
@@ -1,0 +1,63 @@
+"""Collect the transitive npm dependency closure of a package from a pnpm
+virtual store, dereferencing symlinks.
+
+Usage: collect-deps.py <pnpmStoreDir> <packageJsonPath> <outDir>
+  pnpmStoreDir    — node_modules/.pnpm
+  packageJsonPath — the plugin's package.json (its `dependencies` are seeds)
+  outDir          — flat output directory, one subdirectory per package
+"""
+
+import json
+import os
+import shutil
+import sys
+
+def find_package(store_dir, name):
+    """Find the newest directory matching name@* in the pnpm store."""
+    prefix = name.replace("/", "+") + "@"
+    candidates = sorted(
+        d for d in os.listdir(store_dir)
+        if d.startswith(prefix) and os.path.isdir(os.path.join(store_dir, d))
+    )
+    if not candidates:
+        return None
+    return os.path.join(store_dir, candidates[-1], "node_modules", name)
+
+def main():
+    store_dir, package_json, out_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    with open(package_json) as f:
+        manifest = json.load(f)
+
+    os.makedirs(out_dir, exist_ok=True)
+    visited = set()
+    queue = list(manifest.get("dependencies", {}).keys())
+
+    while queue:
+        dep = queue.pop()
+        if dep in visited:
+            continue
+        visited.add(dep)
+
+        src = find_package(store_dir, dep)
+        if src is None or not os.path.isdir(src):
+            continue
+
+        dst = os.path.join(out_dir, dep)
+        if os.path.exists(dst):
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst, symlinks=False)
+
+        # Enqueue transitive deps.
+        dep_manifest_path = os.path.join(dst, "package.json")
+        if os.path.exists(dep_manifest_path):
+            with open(dep_manifest_path) as f:
+                dep_manifest = json.load(f)
+            for transitive in dep_manifest.get("dependencies", {}):
+                if transitive not in visited:
+                    queue.append(transitive)
+
+        print(f"collected {dep}")
+
+if __name__ == "__main__":
+    main()

--- a/nix/dsh-runtime-pinned.nix
+++ b/nix/dsh-runtime-pinned.nix
@@ -1,0 +1,51 @@
+# Build the pinned deepseek-harness runtime from source, matching the
+# revision recorded in this repository's dsh-source.json.
+
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, nodejs_22
+, dshSourceSpec
+}:
+
+buildNpmPackage rec {
+  pname = "dsh-runtime-pinned";
+  version = dshSourceSpec.version;
+
+  src = fetchFromGitHub {
+    owner = "deepseek-ai";
+    repo = "deepseek-harness";
+    rev = dshSourceSpec.revision;
+    hash = lib.fakeHash; # filled in below after first build
+  };
+
+  nodejs = nodejs_22;
+
+  npmDepsHash = lib.fakeHash; # filled in below after first build
+
+  # The deepseek-harness release tarball ships compiled lib/ output; building
+  # from git requires the full monorepo build. Keep this as a source build
+  # so the pinned variant tracks the exact revision in dsh-source.json.
+  buildPhase = ''
+    runHook preBuild
+    npm run build --if-present
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/dsh
+    cp -r lib config package.json node_modules $out/lib/dsh/ 2>/dev/null || true
+    # Fallback: if no lib/ was produced, copy the whole tree.
+    if [ ! -d $out/lib/dsh/lib ]; then
+      cp -r . $out/lib/dsh/
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Pinned DeepSeek Harness runtime (${dshSourceSpec.version})";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -1,0 +1,226 @@
+# Oh-DSH package builder.
+#
+# dshSource selects where the pinned DeepSeek Harness runtime comes from:
+#   "llm-agents"  (default) — numtide/llm-agents.nix, pre-built npm package
+#   "pinned"                — this repo's dsh-source.json revision, built from source
+#   "nixpkgs"               — pkgs.deepseek-harness (kept as a placeholder; the
+#                             nixpkgs PR is not yet merged, so this throws)
+
+{ pkgs, system, llm-agents, dshSourceSpec }:
+
+{ surface # "web" | "desktop"
+, dshSource ? "llm-agents"
+}:
+
+let
+  lib = pkgs.lib;
+
+  isDesktop = surface == "desktop";
+
+  # ---------------------------------------------------------------------------
+  # DSH runtime selection
+  # ---------------------------------------------------------------------------
+
+  dshRuntime =
+    if dshSource == "llm-agents" then
+      llm-agents.packages.${system}.dsh
+    else if dshSource == "pinned" then
+      pkgs.callPackage ./dsh-runtime-pinned.nix { inherit dshSourceSpec; }
+    else if dshSource == "nixpkgs" then
+      # Reserved: the nixpkgs deepseek-harness PR has not landed yet.
+      pkgs.deepseek-harness or (throw ''
+        dshSource = "nixpkgs" requires pkgs.deepseek-harness, which is not yet
+        in nixpkgs (see NixOS/nixpkgs#552467). Use "llm-agents" (default) or
+        "pinned" for now.
+      '')
+    else
+      throw "unknown dshSource: ${dshSource}";
+
+  # ---------------------------------------------------------------------------
+  # Oh-DSH front-end bundle (built once per surface; desktop adds electron)
+  # ---------------------------------------------------------------------------
+
+  ohDshBundle = pkgs.stdenv.mkDerivation rec {
+    pname = "oh-dsh-${surface}-bundle";
+    version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
+
+    # Main source tree without build artifacts.
+    src = lib.cleanSourceWith {
+      src = ../.;
+      filter = path: type:
+        let base = baseNameOf path;
+        in !(lib.hasSuffix ".nix" base)
+        && base != "flake.lock"
+        && base != "release"
+        && base != ".stage"
+        && base != ".cache"
+        && base != "node_modules"
+        && base != "dist";
+    };
+
+    # The better-sidebar submodule, fetched separately since nix git src
+    # doesn't materialise submodule contents.
+    betterSidebarSrc = pkgs.fetchFromGitHub {
+      owner = "omdsh-dev";
+      repo = "DSH-better-sidebar";
+      rev = "2e9db44a71bb75c9fa1185330541dce2582deee3";
+      hash = "sha256-VQ8lyHNtcTHrOum21Z4dZyZgrxexmUY7yEN8kjao838=";
+    };
+
+    # Materialise the submodule into the source tree before building.
+    postUnpack = ''
+      rm -rf source/upstream/DSH-better-sidebar
+      cp -r ${betterSidebarSrc} source/upstream/DSH-better-sidebar
+      chmod -R u+w source/upstream/DSH-better-sidebar
+    '';
+
+    pnpmDeps = pkgs.fetchPnpmDeps {
+      inherit pname version src;
+      fetcherVersion = 4;
+      hash = "sha256-zn78SIfOgJvnRqpjRWU79d53Zba9HdnQpdZFF6WKZB4=";
+    };
+
+    nativeBuildInputs = [
+      pkgs.nodejs_24
+      pkgs.pnpm
+      pkgs.pnpmConfigHook
+    ];
+
+    # The upstream build scripts (esbuild) are what produce dist/.
+    buildPhase = ''
+      runHook preBuild
+
+      # The full release pipeline (build:dsh + stage:dsh) is skipped on purpose:
+      # the DSH runtime is provided by ${dshSource} instead of the staged copy.
+      node scripts/build.mjs
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib/oh-dsh
+      cp -r dist $out/lib/oh-dsh/
+      cp -r bin $out/lib/oh-dsh/
+      cp package.json $out/lib/oh-dsh/
+
+      # Carry the per-plugin manifests so the final package can register each
+      # plugin into dsh-runtime/node_modules (mirroring stage-dsh.mjs).
+      mkdir -p $out/lib/oh-dsh/manifests
+      cp package.json $out/lib/oh-dsh/manifests/desktop.json
+      for p in plugins/*/package.json; do
+        name=$(basename $(dirname "$p"))
+        cp "$p" "$out/lib/oh-dsh/manifests/$name.json"
+      done
+      cp web/package.json $out/lib/oh-dsh/manifests/web.json
+
+      # Extract plugin runtime dependencies that the DSH runtime may not
+      # ship. better-sidebar-runtime declares externals that the DSH runtime
+      # partially provides; collect the full transitive closure here and let
+      # the outer derivation keep only what is missing.
+      mkdir -p $out/lib/oh-dsh/extra-deps
+      ${pkgs.python3}/bin/python3 ${./collect-deps.py} \
+        node_modules/.pnpm \
+        plugins/better-sidebar-runtime/package.json \
+        $out/lib/oh-dsh/extra-deps
+
+      runHook postInstall
+    '';
+
+    # We do not need electron in the web bundle.
+    env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  };
+
+in
+pkgs.stdenv.mkDerivation {
+  pname = "oh-dsh-${surface}${lib.optionalString (dshSource != "llm-agents") "-${dshSource}"}";
+  version = ohDshBundle.version;
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/oh-dsh $out/bin
+
+    # Oh-DSH built assets
+    cp -r ${ohDshBundle}/lib/oh-dsh/dist $out/lib/oh-dsh/dist
+    cp ${ohDshBundle}/lib/oh-dsh/package.json $out/lib/oh-dsh/package.json
+
+    # DSH runtime
+    mkdir -p $out/dsh-runtime
+    cp -r ${dshRuntime}/lib/dsh/* $out/dsh-runtime/
+    chmod -R u+w $out/dsh-runtime
+    chmod +x $out/dsh-runtime/lib/bin.js || true
+
+    # Node runtime: reuse the same nodejs that built the bundle. The DSH
+    # runtime's HMR service requires --expose-internals (upstream releases
+    # ship the flag baked into their launcher; we wrap node itself).
+    mkdir -p $out/node-runtime/bin
+    makeWrapper ${pkgs.nodejs_24}/bin/node $out/node-runtime/bin/node \
+      --add-flags "--expose-internals"
+
+    # Register Oh-DSH packages into dsh-runtime/node_modules so the DSH
+    # profile loader can resolve them (mirrors installDesktopPackages in
+    # scripts/stage-dsh.mjs).
+    ${pkgs.python3}/bin/python3 ${./register-plugins.py} \
+      ${ohDshBundle}/lib/oh-dsh \
+      $out/lib/oh-dsh/dist \
+      $out/dsh-runtime
+
+    # Copy plugin runtime dependencies that the DSH runtime does not ship
+    # (e.g. schemastery for better-sidebar-runtime).
+    if [ -d "${ohDshBundle}/lib/oh-dsh/extra-deps" ]; then
+      for dep in ${ohDshBundle}/lib/oh-dsh/extra-deps/*/; do
+        name=$(basename "$dep")
+        if [ ! -d "$out/dsh-runtime/node_modules/$name" ]; then
+          cp -r "$dep" "$out/dsh-runtime/node_modules/$name"
+          chmod -R u+w "$out/dsh-runtime/node_modules/$name"
+        fi
+      done
+    fi
+
+    # HMR is a development-time feature that requires --expose-internals;
+    # the packaged runtime keeps it enabled (matching upstream releases).
+
+    # ohdsh launcher
+    makeWrapper ${pkgs.nodejs_24}/bin/node $out/bin/ohdsh \
+      --add-flags "$out/lib/oh-dsh/dist/ohdsh.js" \
+      --set DSH_OH_WEB_ROOT "$out" \
+      ${lib.optionalString isDesktop ''
+        --set OH_DSH_DESKTOP_APP "$out/bin/oh-dsh-desktop" \
+      ''}
+
+    ${lib.optionalString isDesktop ''
+      # Electron wrapper. OH_DSH_RESOURCES_ROOT is required because loading
+      # dist/main.js directly keeps app.isPackaged false under Nix.
+      makeWrapper ${pkgs.electron_42}/bin/electron $out/bin/oh-dsh-desktop \
+        --add-flags "$out/lib/oh-dsh/dist/main.js" \
+        --set OH_DSH_RESOURCES_ROOT "$out" \
+        --set DSH_OH_WEB_ROOT "$out"
+
+      # Desktop entry
+      mkdir -p $out/share/applications
+      cat > $out/share/applications/oh-dsh-desktop.desktop <<EOF
+      [Desktop Entry]
+      Name=Oh-DSH Desktop
+      Exec=$out/bin/oh-dsh-desktop
+      Type=Application
+      Categories=Development;
+      EOF
+    ''}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Oh-DSH ${if isDesktop then "Desktop" else "Web"}: DeepSeek Harness ${surface} distribution";
+    homepage = "https://github.com/hust-open-atom-club/oh-dsh";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    mainProgram = if isDesktop then "oh-dsh-desktop" else "ohdsh";
+  };
+}

--- a/nix/register-plugins.py
+++ b/nix/register-plugins.py
@@ -1,0 +1,103 @@
+"""Register Oh-DSH plugin packages into dsh-runtime/node_modules.
+
+Mirrors installDesktopPackages() from scripts/stage-dsh.mjs: each plugin
+manifest is copied into node_modules/<name>/package.json with build/scripts/
+devDependencies stripped, and the compiled dist files are placed beside it.
+Runtime dependencies are resolved via a symlink to dsh-runtime/node_modules.
+
+Usage: register-plugins.py <bundleRoot> <distRoot> <dshRuntimeRoot>
+  bundleRoot     — oh-dsh bundle output (contains manifests/)
+  distRoot       — final package dist root ($out/lib/oh-dsh/dist)
+  dshRuntimeRoot — $out/dsh-runtime
+"""
+
+import json
+import os
+import shutil
+import sys
+
+def main():
+    bundle_root, dist_root, dsh_runtime = sys.argv[1], sys.argv[2], sys.argv[3]
+    manifests_dir = os.path.join(bundle_root, "manifests")
+    node_modules = os.path.join(dsh_runtime, "node_modules")
+
+    # manifest file key -> subdirectory under distRoot that holds the
+    # compiled output. None means the root package (dist/ itself).
+    plugin_dirs = {
+        "desktop": None,
+        "web": "web",
+        "skins": os.path.join("plugins", "skins"),
+        "sidebar": os.path.join("plugins", "sidebar"),
+        "panel-controls": os.path.join("plugins", "panel-controls"),
+        "pinned-summary": os.path.join("plugins", "pinned-summary"),
+        "plugin-marketplace": os.path.join("plugins", "plugin-marketplace"),
+        "better-sidebar-runtime": os.path.join("plugins", "better-sidebar-runtime"),
+    }
+
+    for manifest_file in sorted(os.listdir(manifests_dir)):
+        plugin_key = manifest_file.removesuffix(".json")
+        with open(os.path.join(manifests_dir, manifest_file)) as f:
+            manifest = json.load(f)
+
+        for key in ("build", "devDependencies", "scripts"):
+            manifest.pop(key, None)
+
+        name = manifest.get("name")
+        if not name:
+            print(f"skipping {manifest_file}: no name", file=sys.stderr)
+            continue
+
+        package_dir = os.path.join(node_modules, *name.split("/"))
+        os.makedirs(package_dir, exist_ok=True)
+
+        with open(os.path.join(package_dir, "package.json"), "w") as f:
+            json.dump(manifest, f, indent=2)
+            f.write("\n")
+
+        # Symlink the plugin's dependency resolution to the shared
+        # dsh-runtime node_modules (satisfies require() for runtime deps).
+        deps_link = os.path.join(package_dir, "node_modules")
+        if not os.path.exists(deps_link):
+            os.symlink(node_modules, deps_link)
+
+        # Copy the compiled dist files.
+        dist_subdir = plugin_dirs.get(plugin_key)
+        if dist_subdir is None:
+            # Root package (@oh-dsh/desktop): dist/plugin.js, dist/client.js,
+            # cordis.patch.yml live directly under distRoot.
+            dst_dir = os.path.join(package_dir, "dist")
+            os.makedirs(dst_dir, exist_ok=True)
+            for fname in ("plugin.js", "client.js", "client.js.map", "cordis.patch.yml"):
+                src = os.path.join(dist_root, fname)
+                if os.path.exists(src):
+                    shutil.copy2(src, os.path.join(dst_dir, fname))
+        else:
+            src_base = os.path.join(dist_root, dist_subdir)
+            if not os.path.isdir(src_base):
+                print(f"warning: no dist dir for {name}: {src_base}", file=sys.stderr)
+                continue
+            dst_dir = os.path.join(package_dir, "dist")
+            os.makedirs(dst_dir, exist_ok=True)
+            for fname in os.listdir(src_base):
+                shutil.copy2(os.path.join(src_base, fname), os.path.join(dst_dir, fname))
+
+        print(f"registered {name}")
+
+    # Merge registered oh-dsh package names into the dsh runtime's
+    # package.json dependencies so healProfilesModuleFallback links them
+    # into the profile's module fallback (mirrors stage-dsh.mjs:616-621).
+    cli_manifest_path = os.path.join(dsh_runtime, "package.json")
+    with open(cli_manifest_path) as f:
+        cli_manifest = json.load(f)
+    deps = cli_manifest.setdefault("dependencies", {})
+    for manifest_file in sorted(os.listdir(manifests_dir)):
+        with open(os.path.join(manifests_dir, manifest_file)) as f:
+            m = json.load(f)
+        if m.get("name") and m.get("version"):
+            deps[m["name"]] = m["version"]
+    with open(cli_manifest_path, "w") as f:
+        json.dump(cli_manifest, f, indent=2)
+        f.write("\n")
+
+if __name__ == "__main__":
+    main()

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,12 @@ import type { DesktopCommand, DesktopInfo, DesktopRuntimeSnapshot } from './cont
 import { allowsRuntimeClipboardWrite, originOf } from './permissions.ts'
 import { BUNDLED_DESKTOP_PLUGINS, DESKTOP_PROFILE, ensureDesktopProfile } from './profile.ts'
 import { DshRuntimeSupervisor, runDshCommand, type DshRuntimeOptions, type RuntimeExit } from './runtime.ts'
-import { bundledRuntimePaths, runtimeSearchPath, type BundledRuntimePaths } from './runtime-paths.ts'
+import {
+  bundledRuntimePaths,
+  resolveRuntimeResourcesRoot,
+  runtimeSearchPath,
+  type BundledRuntimePaths,
+} from './runtime-paths.ts'
 import { resolveProductVersion } from './version.ts'
 
 const PRODUCT_NAME = 'Oh-DSH Desktop'
@@ -68,7 +73,11 @@ function appendLog(stream: 'desktop' | 'stderr' | 'stdout', line: string): void 
 }
 
 function resourcesRoot(): string {
-  return app.isPackaged ? process.resourcesPath : join(currentDir, '..', '.stage')
+  return resolveRuntimeResourcesRoot(
+    process.resourcesPath,
+    join(currentDir, '..', '.stage'),
+    app.isPackaged,
+  )
 }
 
 function runtimePaths(): BundledRuntimePaths {

--- a/src/runtime-paths.ts
+++ b/src/runtime-paths.ts
@@ -14,6 +14,18 @@ function pathApi(platform: NodeJS.Platform): typeof posix | typeof win32 {
   return platform === 'win32' ? win32 : posix
 }
 
+/** Resolve an explicit distribution root before Electron's packaged/dev defaults. */
+export function resolveRuntimeResourcesRoot(
+  packagedRoot: string,
+  developmentRoot: string,
+  isPackaged: boolean,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicit = environment.OH_DSH_RESOURCES_ROOT ?? environment.DSH_OH_WEB_ROOT
+  if (explicit !== undefined && explicit !== '') return explicit
+  return isPackaged ? packagedRoot : developmentRoot
+}
+
 /** Resolve the bundled DSH and Node entry points for one target platform. */
 export function bundledRuntimePaths(
   resourcesRoot: string,

--- a/tests/runtime-paths.test.ts
+++ b/tests/runtime-paths.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { bundledRuntimePaths, runtimeSearchPath } from '../src/runtime-paths.ts'
+import {
+  bundledRuntimePaths,
+  resolveRuntimeResourcesRoot,
+  runtimeSearchPath,
+} from '../src/runtime-paths.ts'
 
 test('bundled runtime paths use POSIX layouts on macOS and Linux', () => {
   const mac = bundledRuntimePaths('/Applications/Oh.app/Contents/Resources', 'darwin')
@@ -42,4 +46,36 @@ test('bundled runtime paths use Windows executables and PATH separators', () => 
     'C:\\Program Files\\Oh-DSH\\resources\\dsh-runtime\\node_modules\\.bin',
     'C:\\Windows\\System32;D:\\Git\\cmd',
   ].join(';'))
+})
+
+test('runtime resources root honors explicit distribution overrides', () => {
+  assert.equal(
+    resolveRuntimeResourcesRoot(
+      '/electron/resources',
+      '/source/.stage',
+      false,
+      { OH_DSH_RESOURCES_ROOT: '/nix/store/oh-dsh' },
+    ),
+    '/nix/store/oh-dsh',
+  )
+  assert.equal(
+    resolveRuntimeResourcesRoot(
+      '/electron/resources',
+      '/source/.stage',
+      false,
+      { DSH_OH_WEB_ROOT: '/portable/oh-dsh' },
+    ),
+    '/portable/oh-dsh',
+  )
+})
+
+test('runtime resources root falls back to Electron package mode', () => {
+  assert.equal(
+    resolveRuntimeResourcesRoot('/electron/resources', '/source/.stage', true, {}),
+    '/electron/resources',
+  )
+  assert.equal(
+    resolveRuntimeResourcesRoot('/electron/resources', '/source/.stage', false, {}),
+    '/source/.stage',
+  )
 })


### PR DESCRIPTION
Add reproducible web and desktop packages with selectable DeepSeek Harness sources. Default to llm-agents.nix, retain pinned-source and future nixpkgs variants, register bundled plugins, and make the Electron launcher resolve its Nix runtime root.

我添加了nix支持，目前的初步实现是提供devshell和两个package: oh-dsh-desktop和oh-dsh-web（这个是本体，直接运行会给出desktop web tui3个选项）

下一步计划是实现homeModule或者nixosModule, 实现可复现的声明式配置

实现中dsh提供可选多种方式：nixpkgs或者强行numtide/llm-agents.nix中获取
由于nixpkgs的dsh还在open pr，目前无法直接使用nixpkgs里的
还未实现直接用固定的dsh-source，因为固定的dsh不能确认对其打nix包的方式，其官方没有提供nix支持。（如果我强行参考nixpkgs的方式实现，那么之后dsh更新不保证nix可用，因为他在早期快速更新，需要长期维护，还不如使用现有的nixpkgs或者llm-agents.nix版本，其中，nixpkgs版本是源码构建的，llm-agents.nix是npm registry里下的成品，根据经验，这种带很多依赖的ts项目一般用nix从头构建是很牢的，默认参考llm-agents的做法直接下）