### PR TITLE
docs: reserve banner for social preview

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,8 +1,4 @@
 <p align="center">
-  <img src="./assets/oh-dsh-desktop-hero.png" alt="Oh-DSH Desktop Preview" width="100%">
-</p>
-
-<p align="center">
   <a href="./README.md">简体中文</a> ·
   <strong>English</strong>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 <p align="center">
-  <img src="./assets/oh-dsh-desktop-hero.png" alt="Oh-DSH Desktop Preview" width="100%">
-</p>
-
-<p align="center">
   <strong>简体中文</strong> ·
   <a href="./README.en.md">English</a>
 </p>


### PR DESCRIPTION
## Summary

- remove the banner from the Chinese and English README introductions
- keep the supplied image in `assets` as the repository preview source
- avoid coupling GitHub presentation metadata to rendered documentation

## Verification

- `git diff --check`
- confirmed both README files start with the language selector
