### PR TITLE
feat(nix): package desktop web and tui surfaces

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Oh-DSH: an installable DeepSeek Harness desktop and web distribution";
+  description = "Oh-DSH: installable Desktop, Web, and TUI distributions";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -46,18 +46,24 @@
           };
         in
         rec {
-          # Default dsh source: numtide/llm-agents.nix.
+          # Full distribution: Desktop, Web, and TUI through one launcher.
+          oh-dsh = mkOhDsh { surface = "full"; dshSource = "llm-agents"; };
+          oh-dsh-desktop = oh-dsh;
+
+          # Layered distributions without Electron.
           oh-dsh-web = mkOhDsh { surface = "web"; dshSource = "llm-agents"; };
-          oh-dsh-desktop = mkOhDsh { surface = "desktop"; dshSource = "llm-agents"; };
+          oh-dsh-tui = mkOhDsh { surface = "tui"; dshSource = "llm-agents"; };
 
-          # Variant pinning the DSH runtime to this repo's dsh-source.json.
+          # Variants pinning the DSH runtime to this repo's dsh-source.json.
+          oh-dsh-pinned = mkOhDsh { surface = "full"; dshSource = "pinned"; };
+          oh-dsh-desktop-pinned = oh-dsh-pinned;
           oh-dsh-web-pinned = mkOhDsh { surface = "web"; dshSource = "pinned"; };
-          oh-dsh-desktop-pinned = mkOhDsh { surface = "desktop"; dshSource = "pinned"; };
+          oh-dsh-tui-pinned = mkOhDsh { surface = "tui"; dshSource = "pinned"; };
 
-          # "nixpkgs" variant is available via mkOhDsh but not exposed as a
-          # package until pkgs.deepseek-harness lands (NixOS/nixpkgs#552467).
+          # "nixpkgs" variants remain available through mkOhDsh once
+          # pkgs.deepseek-harness lands (NixOS/nixpkgs#552467).
 
-          default = oh-dsh-web;
+          default = oh-dsh;
         });
     };
 }

--- a/nix/collect-deps.py
+++ b/nix/collect-deps.py
@@ -1,10 +1,9 @@
-"""Collect the transitive npm dependency closure of a package from a pnpm
-virtual store, dereferencing symlinks.
+"""Collect a package's transitive npm dependency closure from a pnpm store.
+
+Each copied package receives a node_modules symlink to the flat closure root,
+so nested ESM imports resolve exactly as they do in the pnpm workspace.
 
 Usage: collect-deps.py <pnpmStoreDir> <packageJsonPath> <outDir>
-  pnpmStoreDir    — node_modules/.pnpm
-  packageJsonPath — the plugin's package.json (its `dependencies` are seeds)
-  outDir          — flat output directory, one subdirectory per package
 """
 
 import json
@@ -31,7 +30,11 @@ def main():
 
     os.makedirs(out_dir, exist_ok=True)
     visited = set()
-    queue = list(manifest.get("dependencies", {}).keys())
+    queue = list({
+        *manifest.get("dependencies", {}),
+        *manifest.get("optionalDependencies", {}),
+        *manifest.get("peerDependencies", {}),
+    })
 
     while queue:
         dep = queue.pop()
@@ -48,14 +51,28 @@ def main():
             shutil.rmtree(dst)
         shutil.copytree(src, dst, symlinks=False)
 
-        # Enqueue transitive deps.
+        # Recreate dependency lookup against the flat collected closure.
+        # Relative links keep the bundle relocatable into the final runtime.
+        package_node_modules = os.path.join(dst, "node_modules")
+        if os.path.lexists(package_node_modules):
+            if os.path.isdir(package_node_modules) and not os.path.islink(package_node_modules):
+                shutil.rmtree(package_node_modules)
+            else:
+                os.unlink(package_node_modules)
+        os.symlink(os.path.relpath(out_dir, dst), package_node_modules)
+
+        # Enqueue every dependency class that can participate in runtime ESM
+        # resolution. Missing optional peers are intentionally ignored above.
         dep_manifest_path = os.path.join(dst, "package.json")
         if os.path.exists(dep_manifest_path):
             with open(dep_manifest_path) as f:
                 dep_manifest = json.load(f)
-            for transitive in dep_manifest.get("dependencies", {}):
-                if transitive not in visited:
-                    queue.append(transitive)
+            transitives = {
+                *dep_manifest.get("dependencies", {}),
+                *dep_manifest.get("optionalDependencies", {}),
+                *dep_manifest.get("peerDependencies", {}),
+            }
+            queue.extend(transitives - visited)
 
         print(f"collected {dep}")
 

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -8,14 +8,16 @@
 
 { pkgs, system, llm-agents, dshSourceSpec }:
 
-{ surface # "web" | "desktop"
+{ surface # "full" | "web" | "tui"
 , dshSource ? "llm-agents"
 }:
 
 let
   lib = pkgs.lib;
 
-  isDesktop = surface == "desktop";
+  isFull = surface == "full";
+  includesWeb = surface != "tui";
+  includesTui = surface != "web";
 
   # ---------------------------------------------------------------------------
   # DSH runtime selection
@@ -37,47 +39,53 @@ let
       throw "unknown dshSource: ${dshSource}";
 
   # ---------------------------------------------------------------------------
-  # Oh-DSH front-end bundle (built once per surface; desktop adds electron)
-  # ---------------------------------------------------------------------------
+  # Oh-DSH front-end bundle. The same build produces all surface adapters;
+  # the outer derivation controls which launchers and renderers are exposed.
+  cleanSource = lib.cleanSourceWith {
+    src = ../.;
+    filter = path: type:
+      let base = baseNameOf path;
+      in !(lib.hasSuffix ".nix" base)
+      && base != "flake.lock"
+      && base != "release"
+      && base != ".stage"
+      && base != ".cache"
+      && base != "node_modules"
+      && base != "dist";
+  };
+
+  betterSidebarSrc = pkgs.fetchFromGitHub {
+    owner = "omdsh-dev";
+    repo = "DSH-better-sidebar";
+    rev = "2e9db44a71bb75c9fa1185330541dce2582deee3";
+    hash = "sha256-VQ8lyHNtcTHrOum21Z4dZyZgrxexmUY7yEN8kjao838=";
+  };
+  tuiSrc = pkgs.fetchFromGitHub {
+    owner = "ccch1mneyyy";
+    repo = "dsh-TUI";
+    rev = "6a8956678fc3746ed14b62bfee066ee8fc68f3cb";
+    hash = "sha256-dxR0MdhKY+HHbLOZscCpNaww1Clfxc781HxmBg8kpcg=";
+  };
+
+  # fetchPnpmDeps and the real build MUST see the same workspace graph.
+  source = pkgs.runCommand "oh-dsh-source" { } ''
+    cp -r ${cleanSource} $out
+    chmod -R u+w $out
+    rm -rf $out/upstream/DSH-better-sidebar $out/upstream/dsh-TUI
+    cp -r ${betterSidebarSrc} $out/upstream/DSH-better-sidebar
+    cp -r ${tuiSrc} $out/upstream/dsh-TUI
+  '';
 
   ohDshBundle = pkgs.stdenv.mkDerivation rec {
     pname = "oh-dsh-${surface}-bundle";
     version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
 
-    # Main source tree without build artifacts.
-    src = lib.cleanSourceWith {
-      src = ../.;
-      filter = path: type:
-        let base = baseNameOf path;
-        in !(lib.hasSuffix ".nix" base)
-        && base != "flake.lock"
-        && base != "release"
-        && base != ".stage"
-        && base != ".cache"
-        && base != "node_modules"
-        && base != "dist";
-    };
-
-    # The better-sidebar submodule, fetched separately since nix git src
-    # doesn't materialise submodule contents.
-    betterSidebarSrc = pkgs.fetchFromGitHub {
-      owner = "omdsh-dev";
-      repo = "DSH-better-sidebar";
-      rev = "2e9db44a71bb75c9fa1185330541dce2582deee3";
-      hash = "sha256-VQ8lyHNtcTHrOum21Z4dZyZgrxexmUY7yEN8kjao838=";
-    };
-
-    # Materialise the submodule into the source tree before building.
-    postUnpack = ''
-      rm -rf source/upstream/DSH-better-sidebar
-      cp -r ${betterSidebarSrc} source/upstream/DSH-better-sidebar
-      chmod -R u+w source/upstream/DSH-better-sidebar
-    '';
+    src = source;
 
     pnpmDeps = pkgs.fetchPnpmDeps {
       inherit pname version src;
       fetcherVersion = 4;
-      hash = "sha256-zn78SIfOgJvnRqpjRWU79d53Zba9HdnQpdZFF6WKZB4=";
+      hash = "sha256-jCX9aTQwF+3AqEHuZOq3nmrQO+2S0wsno2E+bvzTmfo=";
     };
 
     nativeBuildInputs = [
@@ -105,8 +113,8 @@ let
       cp -r bin $out/lib/oh-dsh/
       cp package.json $out/lib/oh-dsh/
 
-      # Carry the per-plugin manifests so the final package can register each
-      # plugin into dsh-runtime/node_modules (mirroring stage-dsh.mjs).
+      # Carry package manifests so the final package can register the selected
+      # surfaces into dsh-runtime/node_modules (mirrors stage-dsh.mjs).
       mkdir -p $out/lib/oh-dsh/manifests
       cp package.json $out/lib/oh-dsh/manifests/desktop.json
       for p in plugins/*/package.json; do
@@ -114,27 +122,36 @@ let
         cp "$p" "$out/lib/oh-dsh/manifests/$name.json"
       done
       cp web/package.json $out/lib/oh-dsh/manifests/web.json
+      cp upstream/dsh-TUI/package.json $out/lib/oh-dsh/manifests/tui-renderer.json
 
-      # Extract plugin runtime dependencies that the DSH runtime may not
-      # ship. better-sidebar-runtime declares externals that the DSH runtime
-      # partially provides; collect the full transitive closure here and let
-      # the outer derivation keep only what is missing.
+      # Copy the pinned renderer and apply the guarded Oh-DSH adaptation.
+      mkdir -p $out/lib/oh-dsh/tui-renderer
+      cp -r upstream/dsh-TUI/lib upstream/dsh-TUI/skills \
+        upstream/dsh-TUI/cordis.patch.yml upstream/dsh-TUI/cordis.yml \
+        upstream/dsh-TUI/LICENSE $out/lib/oh-dsh/tui-renderer/
+      node -e "import('./scripts/tui-upstream-adapter.mjs').then(({ adaptTuiRendererPackage }) => adaptTuiRendererPackage('$out/lib/oh-dsh/tui-renderer'))"
+
+      # Collect runtime dependency closures that the DSH runtime may not ship.
       mkdir -p $out/lib/oh-dsh/extra-deps
       ${pkgs.python3}/bin/python3 ${./collect-deps.py} \
         node_modules/.pnpm \
         plugins/better-sidebar-runtime/package.json \
         $out/lib/oh-dsh/extra-deps
+      ${pkgs.python3}/bin/python3 ${./collect-deps.py} \
+        node_modules/.pnpm \
+        upstream/dsh-TUI/package.json \
+        $out/lib/oh-dsh/extra-deps
 
       runHook postInstall
     '';
 
-    # We do not need electron in the web bundle.
+    # Electron is supplied by nixpkgs only in the full outer package.
     env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
   };
 
 in
 pkgs.stdenv.mkDerivation {
-  pname = "oh-dsh-${surface}${lib.optionalString (dshSource != "llm-agents") "-${dshSource}"}";
+  pname = "oh-dsh-${if isFull then "desktop" else surface}${lib.optionalString (dshSource != "llm-agents") "-${dshSource}"}";
   version = ohDshBundle.version;
 
   dontUnpack = true;
@@ -169,7 +186,8 @@ pkgs.stdenv.mkDerivation {
     ${pkgs.python3}/bin/python3 ${./register-plugins.py} \
       ${ohDshBundle}/lib/oh-dsh \
       $out/lib/oh-dsh/dist \
-      $out/dsh-runtime
+      $out/dsh-runtime \
+      ${surface}
 
     # Copy plugin runtime dependencies that the DSH runtime does not ship
     # (e.g. schemastery for better-sidebar-runtime).
@@ -190,11 +208,13 @@ pkgs.stdenv.mkDerivation {
     makeWrapper ${pkgs.nodejs_24}/bin/node $out/bin/ohdsh \
       --add-flags "$out/lib/oh-dsh/dist/ohdsh.js" \
       --set DSH_OH_WEB_ROOT "$out" \
-      ${lib.optionalString isDesktop ''
+      --set DSH_OH_TUI_ROOT "$out" \
+      --set OH_DSH_SURFACES "${if isFull then "desktop,web,tui" else surface}" \
+      ${lib.optionalString isFull ''
         --set OH_DSH_DESKTOP_APP "$out/bin/oh-dsh-desktop" \
       ''}
 
-    ${lib.optionalString isDesktop ''
+    ${lib.optionalString isFull ''
       # Electron wrapper. OH_DSH_RESOURCES_ROOT is required because loading
       # dist/main.js directly keeps app.isPackaged false under Nix.
       makeWrapper ${pkgs.electron_42}/bin/electron $out/bin/oh-dsh-desktop \
@@ -202,7 +222,6 @@ pkgs.stdenv.mkDerivation {
         --set OH_DSH_RESOURCES_ROOT "$out" \
         --set DSH_OH_WEB_ROOT "$out"
 
-      # Desktop entry
       mkdir -p $out/share/applications
       cat > $out/share/applications/oh-dsh-desktop.desktop <<EOF
       [Desktop Entry]
@@ -217,10 +236,10 @@ pkgs.stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Oh-DSH ${if isDesktop then "Desktop" else "Web"}: DeepSeek Harness ${surface} distribution";
+    description = "Oh-DSH ${if isFull then "full Desktop/Web/TUI" else if includesWeb then "Web" else "TUI"} distribution";
     homepage = "https://github.com/hust-open-atom-club/oh-dsh";
-    license = licenses.bsd3;
+    license = licenses.mit;
     platforms = platforms.linux;
-    mainProgram = if isDesktop then "oh-dsh-desktop" else "ohdsh";
+    mainProgram = "ohdsh";
   };
 }

--- a/nix/register-plugins.py
+++ b/nix/register-plugins.py
@@ -1,14 +1,14 @@
 """Register Oh-DSH plugin packages into dsh-runtime/node_modules.
 
-Mirrors installDesktopPackages() from scripts/stage-dsh.mjs: each plugin
-manifest is copied into node_modules/<name>/package.json with build/scripts/
-devDependencies stripped, and the compiled dist files are placed beside it.
-Runtime dependencies are resolved via a symlink to dsh-runtime/node_modules.
+Mirrors installDesktopPackages() from scripts/stage-dsh.mjs: selected plugin
+manifests are copied into node_modules/<name>/package.json with build/scripts/
+devDependencies stripped, and compiled files are placed beside them.
 
-Usage: register-plugins.py <bundleRoot> <distRoot> <dshRuntimeRoot>
-  bundleRoot     — oh-dsh bundle output (contains manifests/)
+Usage: register-plugins.py <bundleRoot> <distRoot> <dshRuntimeRoot> <surface>
+  bundleRoot     — oh-dsh bundle output (contains manifests/ and tui-renderer/)
   distRoot       — final package dist root ($out/lib/oh-dsh/dist)
   dshRuntimeRoot — $out/dsh-runtime
+  surface        — full, web, or tui
 """
 
 import json
@@ -17,15 +17,16 @@ import shutil
 import sys
 
 def main():
-    bundle_root, dist_root, dsh_runtime = sys.argv[1], sys.argv[2], sys.argv[3]
+    bundle_root, dist_root, dsh_runtime, surface = sys.argv[1:5]
     manifests_dir = os.path.join(bundle_root, "manifests")
     node_modules = os.path.join(dsh_runtime, "node_modules")
 
-    # manifest file key -> subdirectory under distRoot that holds the
-    # compiled output. None means the root package (dist/ itself).
+    # manifest key -> compiled output under distRoot. The desktop root is the
+    # only package whose files live directly under distRoot.
     plugin_dirs = {
-        "desktop": None,
+        "desktop": "",
         "web": "web",
+        "tui": os.path.join("plugins", "tui"),
         "skins": os.path.join("plugins", "skins"),
         "sidebar": os.path.join("plugins", "sidebar"),
         "panel-controls": os.path.join("plugins", "panel-controls"),
@@ -33,9 +34,19 @@ def main():
         "plugin-marketplace": os.path.join("plugins", "plugin-marketplace"),
         "better-sidebar-runtime": os.path.join("plugins", "better-sidebar-runtime"),
     }
+    selected = {
+        "full": set(plugin_dirs) | {"tui-renderer"},
+        "web": {"web", "skins", "sidebar", "panel-controls", "pinned-summary", "better-sidebar-runtime"},
+        "tui": {"tui", "tui-renderer", "skins"},
+    }.get(surface)
+    if selected is None:
+        raise ValueError(f"unknown Oh-DSH surface: {surface}")
+    installed_versions = {}
 
     for manifest_file in sorted(os.listdir(manifests_dir)):
         plugin_key = manifest_file.removesuffix(".json")
+        if plugin_key not in selected:
+            continue
         with open(os.path.join(manifests_dir, manifest_file)) as f:
             manifest = json.load(f)
 
@@ -43,10 +54,6 @@ def main():
             manifest.pop(key, None)
 
         name = manifest.get("name")
-        if not name:
-            print(f"skipping {manifest_file}: no name", file=sys.stderr)
-            continue
-
         package_dir = os.path.join(node_modules, *name.split("/"))
         os.makedirs(package_dir, exist_ok=True)
 
@@ -54,33 +61,52 @@ def main():
             json.dump(manifest, f, indent=2)
             f.write("\n")
 
-        # Symlink the plugin's dependency resolution to the shared
-        # dsh-runtime node_modules (satisfies require() for runtime deps).
         deps_link = os.path.join(package_dir, "node_modules")
-        if not os.path.exists(deps_link):
+        if plugin_key == "tui-renderer":
+            # The renderer requires React 19 while the Web runtime carries
+            # React 18. Keep its direct dependency graph package-local.
+            os.makedirs(deps_link, exist_ok=True)
+            dependency_names = set(manifest.get("dependencies", {}))
+            dependency_names.update(manifest.get("peerDependencies", {}))
+            extra_deps = os.path.join(bundle_root, "extra-deps")
+            for dependency in sorted(dependency_names):
+                extra = os.path.join(extra_deps, *dependency.split("/"))
+                shared = os.path.join(node_modules, *dependency.split("/"))
+                target = extra if os.path.isdir(extra) else shared
+                if not os.path.isdir(target):
+                    raise FileNotFoundError(f"missing TUI runtime dependency: {dependency}")
+                link = os.path.join(deps_link, *dependency.split("/"))
+                os.makedirs(os.path.dirname(link), exist_ok=True)
+                os.symlink(target, link)
+        else:
+            # Other bundled plugins use the DSH runtime's dependency graph.
             os.symlink(node_modules, deps_link)
 
-        # Copy the compiled dist files.
-        dist_subdir = plugin_dirs.get(plugin_key)
-        if dist_subdir is None:
-            # Root package (@oh-dsh/desktop): dist/plugin.js, dist/client.js,
-            # cordis.patch.yml live directly under distRoot.
+        # Copy the compiled package files.
+        if plugin_key == "tui-renderer":
+            src_base = os.path.join(bundle_root, "tui-renderer")
+            for fname in os.listdir(src_base):
+                src = os.path.join(src_base, fname)
+                dst = os.path.join(package_dir, fname)
+                if os.path.isdir(src):
+                    shutil.copytree(src, dst)
+                else:
+                    shutil.copy2(src, dst)
+        else:
+            dist_subdir = plugin_dirs[plugin_key]
+            src_base = os.path.join(dist_root, dist_subdir)
             dst_dir = os.path.join(package_dir, "dist")
             os.makedirs(dst_dir, exist_ok=True)
-            for fname in ("plugin.js", "client.js", "client.js.map", "cordis.patch.yml"):
-                src = os.path.join(dist_root, fname)
+            if plugin_key == "desktop":
+                filenames = ("plugin.js", "client.js", "client.js.map", "cordis.patch.yml")
+            else:
+                filenames = os.listdir(src_base)
+            for fname in filenames:
+                src = os.path.join(src_base, fname)
                 if os.path.exists(src):
                     shutil.copy2(src, os.path.join(dst_dir, fname))
-        else:
-            src_base = os.path.join(dist_root, dist_subdir)
-            if not os.path.isdir(src_base):
-                print(f"warning: no dist dir for {name}: {src_base}", file=sys.stderr)
-                continue
-            dst_dir = os.path.join(package_dir, "dist")
-            os.makedirs(dst_dir, exist_ok=True)
-            for fname in os.listdir(src_base):
-                shutil.copy2(os.path.join(src_base, fname), os.path.join(dst_dir, fname))
 
+        installed_versions[name] = manifest["version"]
         print(f"registered {name}")
 
     # Merge registered oh-dsh package names into the dsh runtime's
@@ -90,11 +116,7 @@ def main():
     with open(cli_manifest_path) as f:
         cli_manifest = json.load(f)
     deps = cli_manifest.setdefault("dependencies", {})
-    for manifest_file in sorted(os.listdir(manifests_dir)):
-        with open(os.path.join(manifests_dir, manifest_file)) as f:
-            m = json.load(f)
-        if m.get("name") and m.get("version"):
-            deps[m["name"]] = m["version"]
+    deps.update(installed_versions)
     with open(cli_manifest_path, "w") as f:
         json.dump(cli_manifest, f, indent=2)
         f.write("\n")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,18 +8,36 @@ import { UsageError } from './errors.ts'
 import { main as runTui } from './tui.ts'
 import { main as runWeb } from './web.ts'
 
-export const CLI_HELP = `Oh-DSH launcher
+const SURFACE_NAMES = ['desktop', 'web', 'tui'] as const
+type SurfaceName = typeof SURFACE_NAMES[number]
+
+export function availableSurfaces(env: NodeJS.ProcessEnv = process.env): readonly SurfaceName[] {
+  const configured = env.OH_DSH_SURFACES
+  if (configured === undefined || configured === '') return SURFACE_NAMES
+  const requested = new Set(configured.split(',').map(value => value.trim()))
+  return SURFACE_NAMES.filter(surface => requested.has(surface))
+}
+
+export function cliHelp(env: NodeJS.ProcessEnv = process.env): string {
+  const surfaces = availableSurfaces(env)
+  const descriptions: Record<SurfaceName, string> = {
+    desktop: 'Start Oh-DSH Desktop',
+    web: 'Start Oh-DSH Web',
+    tui: 'Start Oh-DSH TUI',
+  }
+  return `Oh-DSH launcher
 
 Usage:
   ohdsh <surface> [options]
 
 Surfaces:
-  desktop   Start Oh-DSH Desktop
-  web       Start Oh-DSH Web
-  tui       Start Oh-DSH TUI
+${surfaces.map(surface => `  ${surface.padEnd(9)} ${descriptions[surface]}`).join('\n')}
 
 Run "ohdsh <surface> --help" for surface options.
 `
+}
+
+export const CLI_HELP = cliHelp()
 
 export interface DesktopLaunchSpec {
   args: string[]
@@ -139,14 +157,20 @@ export async function main(
   tuiRunner: TuiRunner = runTui,
 ): Promise<number> {
   const [surface, ...args] = argv
+  const help = cliHelp(env)
   if (surface === undefined || surface === '--help' || surface === '-h') {
-    stdout.write(CLI_HELP)
+    stdout.write(help)
     return 0
+  }
+  if (SURFACE_NAMES.includes(surface as SurfaceName)
+    && !availableSurfaces(env).includes(surface as SurfaceName)) {
+    stderr.write(`Surface '${surface}' is not included in this Oh-DSH distribution.\n\n${help}`)
+    return 2
   }
   if (surface === 'desktop') return await desktopRunner(args, env)
   if (surface === 'web') return await webRunner(args, env, stdout)
   if (surface === 'tui') return await tuiRunner(args, env, stdout, stderr)
-  stderr.write(`Unknown surface: ${surface}\n\n${CLI_HELP}`)
+  stderr.write(`Unknown surface: ${surface}\n\n${help}`)
   return 2
 }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -68,6 +68,28 @@ test('ohdsh dispatches desktop, web, and TUI through one surface command', async
   ])
 })
 
+test('layered distributions list and reject unavailable surfaces', async () => {
+  const stdout = output()
+  const stderr = output()
+  assert.equal(await main(
+    ['--help'],
+    { OH_DSH_SURFACES: 'web' },
+    stdout.stream,
+    stderr.stream,
+  ), 0)
+  assert.match(stdout.text(), /web\s+Start Oh-DSH Web/)
+  assert.doesNotMatch(stdout.text(), /Start Oh-DSH Desktop/)
+  assert.doesNotMatch(stdout.text(), /Start Oh-DSH TUI/)
+
+  assert.equal(await main(
+    ['desktop'],
+    { OH_DSH_SURFACES: 'web' },
+    stdout.stream,
+    stderr.stream,
+  ), 2)
+  assert.match(stderr.text(), /Surface 'desktop' is not included/)
+})
+
 test('desktop launch keeps source and installed macOS paths distinct', () => {
   assert.deepEqual(desktopLaunchSpec([], {
     OH_DSH_DESKTOP_APP: '/Applications/Oh-DSH Desktop.app',

--- a/tests/nix-collect-deps.test.ts
+++ b/tests/nix-collect-deps.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readlinkSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { test } from 'node:test'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function writePackage(store: string, name: string, version: string, manifest: object, source: string) {
+  const packageDir = join(store, `${name.replace('/', '+')}@${version}`, 'node_modules', ...name.split('/'))
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(packageDir, 'package.json'), JSON.stringify({
+    name,
+    version,
+    type: 'module',
+    main: './index.js',
+    ...manifest,
+  }))
+  writeFileSync(join(packageDir, 'index.js'), source)
+}
+
+test('Nix dependency collector preserves transitive peer resolution', async () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'oh-dsh-nix-deps-'))
+  const store = join(fixture, '.pnpm')
+  const output = join(fixture, 'closure')
+  const manifest = join(fixture, 'package.json')
+
+  try {
+    writePackage(store, '@fixture/root', '1.0.0', {
+      peerDependencies: { '@fixture/peer': '1.0.0' },
+    }, "export { value } from '@fixture/peer'\n")
+    writePackage(store, '@fixture/peer', '1.0.0', {}, "export const value = 'resolved'\n")
+    writeFileSync(manifest, JSON.stringify({
+      dependencies: { '@fixture/root': '1.0.0' },
+    }))
+
+    const result = spawnSync('python3', [join(root, 'nix', 'collect-deps.py'), store, manifest, output], {
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(readlinkSync(join(output, '@fixture', 'root', 'node_modules')), '../..')
+
+    // Runtime-generated fixture path: this assertion exercises Node's real ESM resolver.
+    const collected = await import(pathToFileURL(join(output, '@fixture', 'root', 'index.js')).href)
+    assert.equal(collected.value, 'resolved')
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- expose full, Web-only, and TUI-only Nix packages through one surface-aware launcher
- package the pinned TUI renderer with an isolated React 19 dependency closure
- reject unavailable surfaces explicitly and preserve transitive peer dependency resolution

## Verification
- `nix build .#oh-dsh`
- `nix build .#oh-dsh-web`
- `nix build .#oh-dsh-tui`
- `nix flake check --no-build`
- Web-only package returned HTTP 200
- TUI-only and full packages entered the interactive Oh-DSH TUI
- `pnpm typecheck`
- `pnpm test` (107 passed, 1 macOS-only test skipped)