### PR TITLE
feat: add one-click GitHub Release updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,28 +23,37 @@ jobs:
             dist_script: dist:mac
             node_platform: darwin
             node_arch: arm64
+            update_platform: mac-arm64
           - name: macOS x64
             id: macos-x64
             os: macos-15-intel
             dist_script: dist:mac:x64
             node_platform: darwin
             node_arch: x64
+            update_platform: mac-x64
           - name: Linux x64
             id: linux-x64
             os: ubuntu-24.04
             dist_script: dist:linux
             node_platform: linux
             node_arch: x64
-          # Windows is build-verified in the CI matrix, but the pinned DSH
-          # runtime is not portable on Windows yet: pnpm's junction-based
-          # workspace layout contains cycles that packaging tools follow
-          # until Windows path limits fail. Re-add this job once staging
-          # produces a junction-free runtime on Windows.
+            update_platform: linux-x64
+          - name: Windows x64
+            id: windows-x64
+            os: windows-2025
+            dist_script: dist:win
+            node_platform: win
+            node_arch: x64
+            update_platform: win-x64
     env:
-      CSC_IDENTITY_AUTO_DISCOVERY: 'false'
       DSH_DESKTOP_NODE_ARCH: ${{ matrix.node_arch }}
       DSH_DESKTOP_NODE_PLATFORM: ${{ matrix.node_platform }}
       npm_config_pm_on_fail: 'ignore'
+      CSC_LINK: ${{ matrix.node_platform == 'win' && secrets.WINDOWS_CSC_LINK || secrets.MACOS_CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ matrix.node_platform == 'win' && secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.MACOS_CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
     steps:
       - name: Check out repository
@@ -70,6 +79,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate macOS signing credentials
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          test -n "$CSC_LINK"
+          test -n "$CSC_KEY_PASSWORD"
+          test -n "$APPLE_ID"
+          test -n "$APPLE_APP_SPECIFIC_PASSWORD"
+          test -n "$APPLE_TEAM_ID"
+
+      - name: Validate Windows signing credentials
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          test -n "$CSC_LINK"
+          test -n "$CSC_KEY_PASSWORD"
+
       - name: Package desktop distribution
         run: pnpm run ${{ matrix.dist_script }}
 
@@ -78,6 +104,13 @@ jobs:
 
       - name: Package Oh-DSH TUI distribution
         run: node scripts/build-tui.mjs
+
+      - name: Verify updater metadata
+        shell: bash
+        run: node scripts/verify-update-metadata.mjs --dir release --version "$(node -p "require('./package.json').version")" --platform "${{ matrix.update_platform }}"
+
+      - name: Separate updater metadata by platform
+        run: node scripts/collect-update-metadata.mjs --dir release --id ${{ matrix.id }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -90,6 +123,7 @@ jobs:
             release/oh-dsh-web-*.zip
             release/oh-dsh-tui-*.tar.gz
             release/oh-dsh-tui-*.zip
+            release/updater-metadata/**
           if-no-files-found: error
 
   publish:
@@ -100,13 +134,49 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.20.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
 
+      - name: Prepare and validate updater metadata
+        run: node scripts/prepare-release-update-metadata.mjs --dir artifacts --version "$(node -p "require('./package.json').version")"
+
+      - name: Verify release asset set before publishing
+        run: |
+          find artifacts -maxdepth 1 -type f -print | sed 's#^.*/##' | sort > local-assets.txt
+          test -s local-assets.txt
+          grep -qx 'latest.yml' local-assets.txt
+          grep -qx 'latest-linux.yml' local-assets.txt
+          grep -qx 'latest-mac.yml' local-assets.txt
+
       - name: Publish release
-        run: gh release create "${{ github.ref_name }}" artifacts/* --generate-notes
+        run: |
+          mapfile -t assets < <(find artifacts -maxdepth 1 -type f -print | sort)
+          gh release create "${{ github.ref_name }}" "${assets[@]}" --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Verify published release asset set
+        run: |
+          find artifacts -maxdepth 1 -type f -print | sed 's#^.*/##' | sort > local-assets.txt
+          gh release view "${{ github.ref_name }}" --json assets --jq '.assets[].name' | sort > remote-assets.txt
+          diff -u local-assets.txt remote-assets.txt
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate stable release tag
+        run: node scripts/validate-release-tag.mjs --tag "$GITHUB_REF_NAME" --version "$(node -p "require('./package.json').version")"
+
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:

--- a/docs/usage.en.md
+++ b/docs/usage.en.md
@@ -56,9 +56,31 @@ sudo apt install ./Oh-DSH-Desktop-*.deb
 
 ### Windows
 
-Extract the Windows package and start **Oh-DSH Desktop**. The unified CLI is
+Run the Windows installer from the Release and start **Oh-DSH Desktop**. The unified CLI is
 `bin\ohdsh.cmd` under the application resources directory; add that directory
 to `PATH` if desired.
+
+### Desktop online updates
+
+Choose **Oh-DSH Desktop -> Check for Updates...** from the application menu.
+The updater checks only stable GitHub Releases from
+`hust-open-atom-club/oh-dsh`; it does not need a GitHub login or token.
+
+- macOS, Windows, and Linux AppImage can restart and install after a verified
+  download, or install on the next application quit.
+- `.deb` downloads and opens the system package installer. It never runs
+  `sudo`, `apt`, or `dpkg` around the system permission boundary.
+- The updater uses the system proxy configuration. Offline, proxy-auth, 404,
+  insufficient-space, verification, cancellation, and retry states are shown
+  in the update window. A verification failure never replaces the current app.
+- An update replaces only the application. DSH data, workspace settings,
+  sessions, installed plugins, and marketplace receipts remain in the existing
+  data directory.
+
+Automatic updates require a signed packaged Desktop build. Versions installed
+before the first updater-enabled Release need one manual install; local
+development builds and Releases without a matching platform package fall back
+to the official Release page.
 
 ## Install Web-only
 
@@ -187,6 +209,11 @@ pnpm run dist:win       # Windows full distribution
 pnpm run dist:web       # Web-only lightweight distribution
 pnpm run dist:tui       # TUI-only terminal distribution
 ```
+
+Publishing an auto-update tag also requires GitHub Actions secrets for macOS
+signing/notarization and Windows Authenticode signing. The workflow refuses to
+publish if credentials, an installer, a blockmap, or `latest*.yml` metadata is
+missing.
 
 ## Data and troubleshooting
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,8 +53,27 @@ sudo apt install ./Oh-DSH-Desktop-*.deb
 
 ### Windows
 
-解压 Release 中的 Windows 包并启动 **Oh-DSH Desktop**。统一 CLI 位于应用
+运行 Release 中的 Windows 安装器并启动 **Oh-DSH Desktop**。统一 CLI 位于应用
 资源目录的 `bin\ohdsh.cmd`，可以将该目录加入 `PATH`。
+
+### Desktop 在线更新
+
+在应用菜单中选择 **Oh-DSH Desktop -> 检查更新…**。更新窗口只检查
+`hust-open-atom-club/oh-dsh` 的 stable GitHub Release，不需要 GitHub 登录或
+token。
+
+- macOS、Windows 和 Linux AppImage 在下载并校验后可选择立即重启安装，或在
+  下次退出时安装。
+- `.deb` 会下载并打开系统的软件包安装器，不会绕过系统权限执行 `sudo`、`apt`
+  或 `dpkg`。
+- 更新器会使用系统代理设置；离线、代理认证、404、磁盘不足、校验失败、取消和
+  重试都会在窗口中显示可恢复状态。校验失败时不会替换现有安装。
+- 更新只替换应用程序，现有 DSH 数据、工作区设置、会话、已安装插件和 marketplace
+  receipts 保留在原有数据目录中。
+
+仅限签名的打包 Desktop 可自动更新。首次带更新器的 Release 之前安装的版本仍需
+手动安装一次；本地开发构建和缺少当前平台安装包的 Release 会提供官方 Release
+页面作为回退。
 
 ## 安装 Web-only
 
@@ -177,6 +196,10 @@ pnpm run dist:win       # Windows 完整版
 pnpm run dist:web       # Web-only 轻量版
 pnpm run dist:tui       # TUI-only 终端版
 ```
+
+发布带自动更新功能的 tag 还需要配置 GitHub Actions 的 macOS 签名/公证凭据和
+Windows Authenticode 凭据。工作流会在任意一个凭据、安装包、blockmap 或
+`latest*.yml` 缺失时停止发布。
 
 ## 数据与排错
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "electron-builder": "^26.0.12",
     "esbuild": "^0.25.12",
     "pnpm": "11.20.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "yaml": "2.8.1"
   },
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -103,6 +103,10 @@
     "files": [
       "dist/main.js",
       "dist/preload.cjs",
+      "dist/update-preload.cjs",
+      "dist/update-dialog.js",
+      "dist/update-dialog.js.map",
+      "dist/update.html",
       "dist/splash.html",
       "LICENSE",
       "THIRD_PARTY_NOTICES.md",

--- a/package.json
+++ b/package.json
@@ -76,10 +76,12 @@
     "dist:tui:quick": "pnpm run build && pnpm run stage:dsh && node scripts/build-tui.mjs"
   },
   "dependencies": {
-    "electron-updater": "6.8.9"
+    "electron-updater": "6.8.9",
+    "semver": "7.7.4"
   },
   "devDependencies": {
     "@types/node": "^24.10.0",
+    "@types/semver": "7.8.0",
     "electron": "42.3.0",
     "electron-builder": "^26.0.12",
     "esbuild": "^0.25.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH Desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "dist:tui": "pnpm run build && pnpm run build:dsh && pnpm run stage:dsh && node scripts/build-tui.mjs",
     "dist:tui:quick": "pnpm run build && pnpm run stage:dsh && node scripts/build-tui.mjs"
   },
+  "dependencies": {
+    "electron-updater": "6.8.9"
+  },
   "devDependencies": {
     "@types/node": "^24.10.0",
     "electron": "42.3.0",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,11 @@
         ]
       }
     ],
+    "publish": {
+      "provider": "github",
+      "owner": "hust-open-atom-club",
+      "repo": "oh-dsh"
+    },
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [
@@ -149,7 +154,6 @@
         "zip"
       ],
       "icon": "assets/Oh-DSH-Desktop.icns",
-      "identity": null,
       "darkModeSupport": true,
       "minimumSystemVersion": "12.0.0",
       "extendInfo": {
@@ -173,9 +177,15 @@
     },
     "win": {
       "target": [
-        "dir"
+        "nsis"
       ],
       "icon": "assets/icons/512x512.png"
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true,
+      "runAfterFinish": true
     },
     "dmg": {
       "title": "Oh-DSH Desktop ${version}",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1848,7 +1848,7 @@ packages:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
   lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,10 +11,16 @@ importers:
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@7.2.0)
+      semver:
+        specifier: 7.7.4
+        version: 7.7.4
     devDependencies:
       '@types/node':
         specifier: ^24.10.0
         version: 24.13.3
+      '@types/semver':
+        specifier: 7.8.0
+        version: 7.8.0
       electron:
         specifier: 42.3.0
         version: 42.3.0(supports-color@7.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      yaml:
+        specifier: 2.8.1
+        version: 2.8.1
 
   plugins/better-sidebar-runtime:
     dependencies:
@@ -2388,6 +2391,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -4457,6 +4465,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.1: {}
 
   yargs-parser@20.2.9: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      electron-updater:
+        specifier: 6.8.9
+        version: 6.8.9(supports-color@7.2.0)
     devDependencies:
       '@types/node':
         specifier: ^24.10.0
@@ -1502,6 +1506,9 @@ packages:
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
@@ -1827,6 +1834,13 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -2236,6 +2250,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -3512,6 +3529,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  electron-updater@6.8.9(supports-color@7.2.0):
+    dependencies:
+      builder-util-runtime: 9.7.0(supports-color@7.2.0)
+      fs-extra: 10.1.0
+      js-yaml: 4.3.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-winstaller@5.4.0(supports-color@7.2.0):
     dependencies:
       '@electron/asar': 3.4.1
@@ -3918,6 +3948,10 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
+
   lodash@4.18.1: {}
 
   loose-envify@1.4.0:
@@ -4311,6 +4345,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinyglobby@0.2.17:
     dependencies:

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -4,6 +4,9 @@ const { join } = require('node:path')
 /** Ad-hoc sign local macOS test builds before DMG/ZIP targets consume them. */
 module.exports = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return
+  // Production CI signs and notarizes through electron-builder. The ad-hoc
+  // fallback is only for local builds without a Developer ID certificate.
+  if (process.env.CSC_LINK || process.env.CSC_NAME || process.env.APPLE_ID) return
   const appPath = join(
     context.appOutDir,
     `${context.packager.appInfo.productFilename}.app`,

--- a/scripts/build-mac.mjs
+++ b/scripts/build-mac.mjs
@@ -43,10 +43,9 @@ const result = spawnSync(builder, [
   `--config.extraMetadata.version=${version}`,
 ], {
   cwd: root,
-  env: {
-    ...process.env,
-    CSC_IDENTITY_AUTO_DISCOVERY: 'false',
-  },
+  env: process.env.CSC_LINK || process.env.CSC_NAME
+    ? { ...process.env }
+    : { ...process.env, CSC_IDENTITY_AUTO_DISCOVERY: 'false' },
   stdio: 'inherit',
 })
 if (result.error !== undefined) throw result.error

--- a/scripts/build-windows.mjs
+++ b/scripts/build-windows.mjs
@@ -37,24 +37,13 @@ const result = spawnSync(process.execPath, [
   `--config.extraMetadata.version=${version}`,
 ], {
   cwd: root,
-  env: {
-    ...process.env,
-    CSC_IDENTITY_AUTO_DISCOVERY: 'false',
-  },
+  env: process.env.CSC_LINK || process.env.WIN_CSC_LINK || process.env.CSC_NAME
+    ? { ...process.env }
+    : { ...process.env, CSC_IDENTITY_AUTO_DISCOVERY: 'false' },
   stdio: 'inherit',
 })
 if (result.error !== undefined) throw result.error
 if (result.status !== 0) process.exit(result.status ?? 1)
-
-// electron-builder's NSIS/zip targets crash on the size of the bundled DSH
-// runtime; the unpacked app is already complete, so zip it with the system
-// bsdtar, which streams instead of materializing one giant argument string.
-const archive = join(root, 'release', `Oh-DSH-Desktop-${version}-x64.zip`)
-const zip = spawnSync('tar', ['-a', '-cf', archive, 'win-unpacked'], {
-  cwd: join(root, 'release'),
-  stdio: 'inherit',
-})
-if (zip.error !== undefined) throw zip.error
-if (zip.status !== 0) process.exit(zip.status ?? 1)
-if (!existsSync(archive)) throw new Error(`Windows archive was not produced: ${archive}`)
-console.log(`Packaged Oh-DSH Desktop ${version}: ${archive}`)
+const installer = join(root, 'release', `Oh-DSH-Desktop-${version}-x64.exe`)
+if (!existsSync(installer)) throw new Error(`Windows NSIS installer was not produced: ${installer}`)
+console.log(`Packaged Oh-DSH Desktop ${version}: ${installer}`)

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -42,6 +42,24 @@ const builds = [
   }),
   build({
     ...shared,
+    entryPoints: [join(root, 'src', 'update-preload.ts')],
+    outfile: join(dist, 'update-preload.cjs'),
+    platform: 'node',
+    format: 'cjs',
+    external: ['electron'],
+  }),
+  build({
+    bundle: true,
+    entryPoints: [join(root, 'src', 'update-dialog.ts')],
+    outfile: join(dist, 'update-dialog.js'),
+    platform: 'browser',
+    format: 'iife',
+    target: 'es2022',
+    sourcemap: true,
+    logLevel: 'info',
+  }),
+  build({
+    ...shared,
     entryPoints: [join(root, 'src', 'preload.ts')],
     outfile: join(dist, 'preload.cjs'),
     platform: 'node',
@@ -155,6 +173,7 @@ for (const plugin of pluginPackages) {
 await Promise.all(builds)
 
 copyFileSync(join(root, 'src', 'splash.html'), join(dist, 'splash.html'))
+copyFileSync(join(root, 'src', 'update.html'), join(dist, 'update.html'))
 copyFileSync(join(root, 'cordis.patch.yml'), join(dist, 'cordis.patch.yml'))
 const releaseManifest = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
 releaseManifest.version = productVersion

--- a/scripts/collect-update-metadata.mjs
+++ b/scripts/collect-update-metadata.mjs
@@ -1,0 +1,17 @@
+import { mkdirSync, renameSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const args = process.argv.slice(2)
+const value = name => {
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
+}
+const dir = value('--dir')
+const id = value('--id')
+if (dir === undefined || id === undefined) throw new Error('usage: collect-update-metadata.mjs --dir RELEASE_DIR --id PLATFORM_ID')
+const destination = join(dir, 'updater-metadata', id)
+mkdirSync(destination, { recursive: true })
+for (const name of readdirSync(dir)) {
+  if (!/^latest(?:-(?:mac|linux))?\.yml$/.test(name)) continue
+  renameSync(join(dir, name), join(destination, name))
+}

--- a/scripts/merge-update-metadata.mjs
+++ b/scripts/merge-update-metadata.mjs
@@ -1,0 +1,15 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import YAML from 'yaml'
+import { mergeMetadata } from './update-metadata.mjs'
+
+const args = process.argv.slice(2)
+const outputIndex = args.indexOf('--output')
+const output = outputIndex === -1 ? undefined : args[outputIndex + 1]
+const inputs = []
+for (let index = 0; index < args.length; index += 1) {
+  if (args[index] === '--input' && args[index + 1] !== undefined) inputs.push(args[index + 1])
+}
+if (output === undefined || inputs.length === 0) throw new Error('usage: merge-update-metadata.mjs --input FILE --input FILE --output FILE')
+const documents = inputs.map(path => YAML.parse(readFileSync(path, 'utf8')))
+writeFileSync(output, YAML.stringify(mergeMetadata(documents)))
+console.log(`merged ${String(inputs.length)} updater metadata files into ${output}`)

--- a/scripts/prepare-release-update-metadata.mjs
+++ b/scripts/prepare-release-update-metadata.mjs
@@ -1,0 +1,34 @@
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import YAML from 'yaml'
+import { mergeMetadata, verifyMetadata } from './update-metadata.mjs'
+
+const args = process.argv.slice(2)
+const value = name => {
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
+}
+const dir = value('--dir')
+const version = value('--version')
+if (dir === undefined || version === undefined) throw new Error('usage: prepare-release-update-metadata.mjs --dir ARTIFACT_DIR --version VERSION')
+
+function metadata(id, name) {
+  const path = join(dir, 'updater-metadata', id, name)
+  if (!existsSync(path)) throw new Error(`missing ${id} updater metadata: ${path}`)
+  return path
+}
+
+const arm64 = metadata('macos-arm64', 'latest-mac.yml')
+const x64 = metadata('macos-x64', 'latest-mac.yml')
+const merged = mergeMetadata([
+  YAML.parse(readFileSync(arm64, 'utf8')),
+  YAML.parse(readFileSync(x64, 'utf8')),
+])
+writeFileSync(join(dir, 'latest-mac.yml'), YAML.stringify(merged))
+copyFileSync(metadata('windows-x64', 'latest.yml'), join(dir, 'latest.yml'))
+copyFileSync(metadata('linux-x64', 'latest-linux.yml'), join(dir, 'latest-linux.yml'))
+
+for (const platform of ['mac-arm64', 'mac-x64', 'win-x64', 'linux-x64']) {
+  verifyMetadata({ dir, version, platform })
+}
+console.log(`prepared updater metadata for ${version}`)

--- a/scripts/stage-dsh.mjs
+++ b/scripts/stage-dsh.mjs
@@ -64,7 +64,7 @@ function run(command, args, options = {}) {
   }
 }
 
-/** Create a portable link: POSIX symlinks, junctions on Windows, copies for files. */
+/** Create a portable link: POSIX symlinks, copied trees on Windows, copies for files. */
 function portableSymlink(target, link) {
   rmSync(link, { recursive: true, force: true })
   if (process.platform !== 'win32') {
@@ -76,9 +76,15 @@ function portableSymlink(target, link) {
     copyFileSync(resolved, link)
     return
   }
-  // Junction targets must be absolute; materializeExternalLinks already
-  // dereferenced the store-backed entries into the staged runtime.
-  symlinkSync(resolved, link, 'junction')
+  // Do not emit Windows junctions. The staged runtime is later consumed by
+  // electron-builder, whose archive walk follows junctions and can re-enter
+  // pnpm workspace cycles. Materializing the already-resolved target keeps the
+  // installer tree self-contained and finite.
+  cpSync(resolved, link, {
+    recursive: true,
+    dereference: true,
+    preserveTimestamps: true,
+  })
 }
 
 function download(url, target) {

--- a/scripts/update-metadata.d.mts
+++ b/scripts/update-metadata.d.mts
@@ -1,0 +1,19 @@
+export interface UpdateMetadataFile {
+  url: string
+  sha512: string
+  size?: number
+  blockMapSize?: number
+}
+
+export interface UpdateMetadata {
+  version: string
+  files: UpdateMetadataFile[]
+  [key: string]: unknown
+}
+
+export function mergeMetadata(documents: UpdateMetadata[]): UpdateMetadata
+export function verifyMetadata(input: {
+  dir: string
+  version: string
+  platform: 'mac-arm64' | 'mac-x64' | 'win-x64' | 'linux-x64'
+}): { metadataPath: string; selected: string; version: string }

--- a/scripts/update-metadata.mjs
+++ b/scripts/update-metadata.mjs
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { basename, join } from 'node:path'
+import YAML from 'yaml'
+
+export const PLATFORM_RULES = Object.freeze({
+  'mac-arm64': { metadata: 'latest-mac.yml', arch: 'arm64', extension: '.zip' },
+  'mac-x64': { metadata: 'latest-mac.yml', arch: 'x64', extension: '.zip' },
+  'win-x64': { metadata: 'latest.yml', arch: 'x64', extension: '.exe' },
+  'linux-x64': { metadata: 'latest-linux.yml', arch: 'x86_64', extension: '.AppImage' },
+})
+
+function assetName(file) {
+  const raw = file?.url ?? file?.path
+  if (typeof raw !== 'string' || raw === '') throw new Error('metadata file is missing url/path')
+  try {
+    return decodeURIComponent(new URL(raw).pathname.split('/').pop() ?? raw)
+  } catch {
+    return basename(raw)
+  }
+}
+
+function readMetadata(path) {
+  const value = YAML.parse(readFileSync(path, 'utf8'))
+  if (value === null || typeof value !== 'object' || !Array.isArray(value.files)) {
+    throw new Error(`invalid updater metadata: ${path}`)
+  }
+  return value
+}
+
+function sha512(path) {
+  return createHash('sha512').update(readFileSync(path)).digest('base64')
+}
+
+function verifyFile(dir, file) {
+  const name = assetName(file)
+  const path = join(dir, name)
+  if (!existsSync(path)) throw new Error(`metadata references missing asset: ${name}`)
+  if (typeof file.sha512 !== 'string' || file.sha512 === '') throw new Error(`metadata asset has no sha512: ${name}`)
+  const actual = sha512(path)
+  const expected = file.sha512
+  const digestMatches = actual === expected || createHash('sha512').update(readFileSync(path)).digest('hex') === expected
+  if (!digestMatches) throw new Error(`sha512 mismatch for ${name}`)
+  if (file.size !== undefined && Number(file.size) !== statSync(path).size) {
+    throw new Error(`size mismatch for ${name}: metadata=${String(file.size)} actual=${String(statSync(path).size)}`)
+  }
+  if (file.blockMapSize !== undefined) {
+    const blockmap = `${path}.blockmap`
+    if (!existsSync(blockmap)) throw new Error(`metadata references missing blockmap: ${basename(blockmap)}`)
+    if (Number(file.blockMapSize) !== statSync(blockmap).size) throw new Error(`blockmap size mismatch for ${name}`)
+  }
+  return name
+}
+
+export function mergeMetadata(documents) {
+  if (documents.length === 0) throw new Error('at least one metadata document is required')
+  const first = documents[0]
+  const files = new Map()
+  for (const document of documents) {
+    if (document.version !== first.version) throw new Error('cannot merge metadata with different versions')
+    for (const file of document.files) {
+      const name = assetName(file)
+      const previous = files.get(name)
+      if (previous !== undefined && YAML.stringify(previous) !== YAML.stringify(file)) {
+        throw new Error(`conflicting metadata for asset: ${name}`)
+      }
+      files.set(name, file)
+    }
+  }
+  return {
+    ...first,
+    files: [...files.values()].sort((left, right) => assetName(left).localeCompare(assetName(right))),
+  }
+}
+
+export function verifyMetadata({ dir, version, platform }) {
+  const rule = PLATFORM_RULES[platform]
+  if (rule === undefined) throw new Error(`unsupported metadata platform: ${platform}`)
+  const metadataPath = join(dir, rule.metadata)
+  if (!existsSync(metadataPath)) throw new Error(`missing updater metadata: ${rule.metadata}`)
+  const metadata = readMetadata(metadataPath)
+  if (metadata.version !== version) throw new Error(`metadata version ${String(metadata.version)} does not match ${version}`)
+  const candidates = metadata.files.filter(file => {
+    const name = assetName(file)
+    const lower = name.toLowerCase()
+    return lower.endsWith(rule.extension.toLowerCase()) && lower.includes(rule.arch.toLowerCase())
+  })
+  if (candidates.length !== 1) throw new Error(`expected one ${platform} updater asset, found ${String(candidates.length)}`)
+  const selected = verifyFile(dir, candidates[0])
+  if (metadata.files.some(file => assetName(file).toLowerCase().includes('oh-dsh-web'))) {
+    throw new Error(`web distribution was included in ${rule.metadata}`)
+  }
+  return { metadataPath, selected, version: metadata.version }
+}

--- a/scripts/validate-release-tag.d.mts
+++ b/scripts/validate-release-tag.d.mts
@@ -1,0 +1,1 @@
+export function validateReleaseTag(tag: string, version: string): string

--- a/scripts/validate-release-tag.mjs
+++ b/scripts/validate-release-tag.mjs
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+import { prerelease, valid } from 'semver'
+
+export function validateReleaseTag(tag, version) {
+  if (typeof tag !== 'string' || !tag.startsWith('v')) {
+    throw new Error(`release tag must start with v: ${String(tag)}`)
+  }
+  const normalizedTag = valid(tag.slice(1))
+  if (normalizedTag === null || prerelease(normalizedTag) !== null) {
+    throw new Error(`release tag must be a stable semver version: ${tag}`)
+  }
+  if (normalizedTag !== version) {
+    throw new Error(`release tag ${tag} does not match package version ${version}`)
+  }
+  return normalizedTag
+}
+
+function argument(name) {
+  const args = process.argv.slice(2)
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const tag = argument('--tag')
+  const version = argument('--version')
+  if (tag === undefined || version === undefined) {
+    throw new Error('usage: validate-release-tag.mjs --tag vX.Y.Z --version X.Y.Z')
+  }
+  console.log(`validated stable release ${validateReleaseTag(tag, version)}`)
+}

--- a/scripts/verify-update-metadata.mjs
+++ b/scripts/verify-update-metadata.mjs
@@ -1,0 +1,22 @@
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { verifyMetadata } from './update-metadata.mjs'
+
+const args = process.argv.slice(2)
+const value = name => {
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
+}
+const dir = value('--dir')
+const version = value('--version')
+const platform = value('--platform')
+if (dir === undefined || version === undefined || platform === undefined) {
+  throw new Error('usage: verify-update-metadata.mjs --dir DIR --version VERSION --platform mac-arm64|mac-x64|win-x64|linux-x64')
+}
+const result = verifyMetadata({ dir, version, platform })
+if (platform === 'linux-x64') {
+  const deb = readdirSync(dir).find(name => name.startsWith(`Oh-DSH-Desktop-${version}-`) && name.endsWith('.deb'))
+  if (deb === undefined) throw new Error(`missing .deb asset for ${version}`)
+  result.deb = join(dir, deb)
+}
+console.log(JSON.stringify(result, null, 2))

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -45,7 +45,7 @@ export type DesktopUpdateState =
   | { status: 'not-available'; currentVersion: string; checkedVersion: string }
   | { status: 'available'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string }
   | { status: 'downloading'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string; percent: number; transferred: number; total: number; bytesPerSecond: number; etaSeconds: number | null }
-  | { status: 'downloaded'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string; installerPath: string | null; installOnQuit: boolean }
+  | { status: 'downloaded'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string; installOnQuit: boolean }
   | { status: 'scheduled'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string }
   | { status: 'cancelled'; currentVersion: string; latestVersion?: string }
   | { status: 'unsupported'; currentVersion: string; platform: DesktopUpdatePlatform; message: string; releaseUrl: string | null }

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -37,6 +37,35 @@ export interface DesktopRuntimeSnapshot {
   status: 'ready' | 'restarting' | 'stopped'
 }
 
+export type DesktopUpdatePlatform = 'mac' | 'win' | 'appimage' | 'deb' | 'unsupported'
+
+export type DesktopUpdateState =
+  | { status: 'idle'; currentVersion: string }
+  | { status: 'checking'; currentVersion: string }
+  | { status: 'not-available'; currentVersion: string; checkedVersion: string }
+  | { status: 'available'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string }
+  | { status: 'downloading'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string; percent: number; transferred: number; total: number; bytesPerSecond: number; etaSeconds: number | null }
+  | { status: 'downloaded'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string; installerPath: string | null; installOnQuit: boolean }
+  | { status: 'scheduled'; currentVersion: string; latestVersion: string; releaseName: string | null; releaseNotes: string; size: number | null; platform: DesktopUpdatePlatform; releaseUrl: string }
+  | { status: 'cancelled'; currentVersion: string; latestVersion?: string }
+  | { status: 'unsupported'; currentVersion: string; platform: DesktopUpdatePlatform; message: string; releaseUrl: string | null }
+  | { status: 'error'; currentVersion: string; stage: 'check' | 'download' | 'verify' | 'install'; code: string; message: string; releaseUrl: string | null; retryable: boolean }
+
+export type DesktopUpdateCommand =
+  | { type: 'check' }
+  | { type: 'download' }
+  | { type: 'cancel' }
+  | { type: 'retry' }
+  | { type: 'install-now' }
+  | { type: 'install-on-quit' }
+  | { type: 'open-release' }
+
+export interface DesktopUpdateBridge {
+  getState(): Promise<DesktopUpdateState>
+  command(command: DesktopUpdateCommand): Promise<DesktopUpdateState>
+  onState(listener: (state: DesktopUpdateState) => void): () => void
+}
+
 /** Browser-safe desktop bridge made available through contextBridge. */
 export interface DesktopBridge {
   chooseWorkspace(): Promise<string[]>

--- a/src/main.ts
+++ b/src/main.ts
@@ -916,6 +916,27 @@ async function bootstrap(): Promise<void> {
   })
   app.on('before-quit', (event) => {
     if (quitting) return
+    if (updateManager?.shouldInstallOnQuit() === true) {
+      event.preventDefault()
+      quitting = true
+      quittingForUpdate = true
+      void (async () => {
+        await stopForApplicationQuit()
+        const result = await updateManager?.command({ type: 'install-now' })
+        if (result?.status === 'error') {
+          quitting = false
+          quittingForUpdate = false
+          await restartRuntime()
+          await openUpdateWindow()
+        }
+      })().catch(async (error: unknown) => {
+        quitting = false
+        quittingForUpdate = false
+        appendLog('desktop', `failed to install update on quit: ${error instanceof Error ? error.message : String(error)}`)
+        await showSplash({ error: true, message: '更新安装失败。', detail: logTail.slice(-12).join('\n') })
+      })
+      return
+    }
     event.preventDefault()
     quitting = true
     appendLog('desktop', quittingForUpdate ? 'quitting to install desktop update' : 'quitting application')

--- a/src/main.ts
+++ b/src/main.ts
@@ -795,12 +795,15 @@ function installIpc(): void {
     const installNow = command.type === 'install-now'
       && current.status === 'downloaded'
       && current.platform !== 'deb'
-    if (installNow) {
-      quittingForUpdate = true
-      await stopForApplicationQuit()
-    }
     const result = await manager.command(command)
-    if (installNow && result.status === 'error') quittingForUpdate = false
+    if (installNow) {
+      if (result.status === 'error') {
+        quittingForUpdate = false
+      } else {
+        quittingForUpdate = true
+        await stopForApplicationQuit()
+      }
+    }
     return result
   })
   ipcMain.handle('desktop:get-info', event => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   shell,
   type MenuItemConstructorOptions,
 } from 'electron'
+import { autoUpdater } from 'electron-updater'
 import { createWriteStream, existsSync, mkdirSync, statSync, type WriteStream } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -28,7 +29,7 @@ import {
   withGitHubCredentials,
 } from '../plugins/plugin-marketplace/src/host/platform.ts'
 import { parseMarketplaceCommand } from '../plugins/plugin-marketplace/src/protocol.ts'
-import type { DesktopCommand, DesktopInfo, DesktopRuntimeSnapshot } from './contracts.ts'
+import type { DesktopCommand, DesktopInfo, DesktopRuntimeSnapshot, DesktopUpdateCommand, DesktopUpdateState } from './contracts.ts'
 import { allowsRuntimeClipboardWrite, originOf } from './permissions.ts'
 import { BUNDLED_DESKTOP_PLUGINS, DESKTOP_PROFILE, ensureDesktopProfile } from './profile.ts'
 import { DshRuntimeSupervisor, runDshCommand, type DshRuntimeOptions, type RuntimeExit } from './runtime.ts'
@@ -39,6 +40,7 @@ import {
   type BundledRuntimePaths,
 } from './runtime-paths.ts'
 import { resolveProductVersion } from './version.ts'
+import { DesktopUpdateManager, detectPackageType } from './update-manager.ts'
 
 const PRODUCT_NAME = 'Oh-DSH Desktop'
 const LEGACY_DATA_DIRECTORY = 'Oh-DSH-Desktop'
@@ -47,6 +49,8 @@ const currentDir = dirname(fileURLToPath(import.meta.url))
 const PRODUCT_VERSION = resolveProductVersion(join(currentDir, '..'))
 const splashPath = join(currentDir, 'splash.html')
 const preloadPath = join(currentDir, 'preload.cjs')
+const updateHtmlPath = join(currentDir, 'update.html')
+const updatePreloadPath = join(currentDir, 'update-preload.cjs')
 
 let mainWindow: BrowserWindow | undefined
 let runtime: DshRuntimeSupervisor | undefined
@@ -60,6 +64,8 @@ let previewIdentity: { pluginId: string; transactionId: string } | undefined
 let marketplace: PluginMarketplaceManager | undefined
 let marketplaceAgentGateway: MarketplaceAgentGateway | undefined
 let logStream: WriteStream | undefined
+let updateWindow: BrowserWindow | undefined
+let updateManager: DesktopUpdateManager | undefined
 let quitting = false
 let transitioning = false
 let queuedPaths: string[] = []
@@ -309,6 +315,93 @@ function sendCommand(command: DesktopCommand): void {
   mainWindow.webContents.send('desktop:command', command)
 }
 
+function sendUpdateState(state: DesktopUpdateState): void {
+  if (updateWindow === undefined || updateWindow.isDestroyed()) return
+  updateWindow.webContents.send('desktop:update:state', state)
+}
+
+async function syncUpdaterProxy(): Promise<void> {
+  const updaterSession = session.fromPartition('electron-updater', { cache: false })
+  const proxyRules = await session.defaultSession.resolveProxy('https://github.com')
+  await updaterSession.setProxy({ proxyRules })
+}
+
+async function getUpdateManager(): Promise<DesktopUpdateManager> {
+  if (updateManager !== undefined) return updateManager
+  const packageType = app.isPackaged
+    ? await detectPackageType(process.resourcesPath)
+    : 'unsupported'
+  const manager = new DesktopUpdateManager({
+    currentVersion: app.getVersion(),
+    appIsPackaged: app.isPackaged,
+    packageType,
+    ...(app.isPackaged ? { updater: autoUpdater } : {}),
+    syncProxy: syncUpdaterProxy,
+    onOpenRelease: async url => { await shell.openExternal(url) },
+    onOpenInstaller: async path => {
+      const error = await shell.openPath(path)
+      if (error !== '') throw new Error(error)
+    },
+    onLog: message => { appendLog('desktop', message) },
+  })
+  updateManager = manager
+  manager.subscribe(sendUpdateState)
+  return manager
+}
+
+function assertUpdateWindowSender(event: { sender: Electron.WebContents }): void {
+  if (updateWindow === undefined || updateWindow.isDestroyed() || event.sender !== updateWindow.webContents) {
+    throw new Error('update IPC is only available to the local update window')
+  }
+}
+
+function parseUpdateCommand(raw: unknown): DesktopUpdateCommand {
+  if (typeof raw !== 'object' || raw === null || !('type' in raw) || typeof raw.type !== 'string') {
+    throw new Error('invalid update command')
+  }
+  const type = raw.type
+  if (!['check', 'download', 'cancel', 'retry', 'install-now', 'install-on-quit', 'open-release'].includes(type)) {
+    throw new Error(`unsupported update command: ${type}`)
+  }
+  return { type } as DesktopUpdateCommand
+}
+
+async function openUpdateWindow(): Promise<void> {
+  const manager = await getUpdateManager()
+  if (updateWindow !== undefined && !updateWindow.isDestroyed()) {
+    updateWindow.show()
+    updateWindow.focus()
+    void manager.check()
+    return
+  }
+  const window = new BrowserWindow({
+    width: 720,
+    height: 620,
+    minWidth: 560,
+    minHeight: 480,
+    ...(mainWindow !== undefined && !mainWindow.isDestroyed() ? { parent: mainWindow } : {}),
+    modal: false,
+    show: false,
+    title: 'Software updates',
+    webPreferences: {
+      preload: updatePreloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  })
+  updateWindow = window
+  window.setMenuBarVisibility(false)
+  window.once('ready-to-show', () => { window.show() })
+  window.on('closed', () => {
+    if (updateWindow === window) updateWindow = undefined
+  })
+  window.webContents.on('will-navigate', event => { event.preventDefault() })
+  window.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+  await window.loadFile(updateHtmlPath)
+  void manager.check()
+}
+
 function normalizeWorkspacePaths(paths: readonly string[]): string[] {
   const normalized: string[] = []
   for (const candidate of paths) {
@@ -523,6 +616,7 @@ function createPluginMarketplace(): PluginMarketplaceManager {
 function labels() {
   const zh = app.getLocale().toLowerCase().startsWith('zh')
   return zh ? {
+    checkUpdates: '检查更新…',
     dsh: 'DSH',
     focus: '聚焦输入框',
     installPlugin: '从文件夹安装插件…',
@@ -545,6 +639,7 @@ function labels() {
     sideChat: '侧边会话',
     trajectory: '轨迹',
   } : {
+    checkUpdates: 'Check for Updates...',
     dsh: 'DSH',
     focus: 'Focus Composer',
     installPlugin: 'Install Plugin from Folder…',
@@ -578,6 +673,8 @@ function buildMenu(): void {
       label: PRODUCT_NAME,
       submenu: [
         { role: 'about' },
+        { type: 'separator' },
+        { label: text.checkUpdates, click: () => { void openUpdateWindow() } },
         { type: 'separator' },
         { label: text.settings, accelerator: 'CmdOrCtrl+,', click: () => { sendCommand({ type: 'show-settings' }) } },
         ...(process.platform === 'darwin'
@@ -666,6 +763,14 @@ function buildMenu(): void {
 
 function installIpc(): void {
   ipcMain.handle('desktop:choose-workspace', async () => await selectWorkspacePaths())
+  ipcMain.handle('desktop:update:get-state', async event => {
+    assertUpdateWindowSender(event)
+    return (await getUpdateManager()).getState()
+  })
+  ipcMain.handle('desktop:update:command', async (event, raw: unknown) => {
+    assertUpdateWindowSender(event)
+    return await (await getUpdateManager()).command(parseUpdateCommand(raw))
+  })
   ipcMain.handle('desktop:get-info', event => {
     const preview = previewWindow?.webContents.id === event.sender.id ? previewIdentity ?? null : null
     return desktopInfo(preview)
@@ -727,6 +832,7 @@ async function bootstrap(): Promise<void> {
   mkdirSync(logsDir, { recursive: true })
   logStream = createWriteStream(join(logsDir, 'desktop.log'), { flags: 'a', mode: 0o600 })
   appendLog('desktop', `${PRODUCT_NAME} ${info.version} starting (${process.arch})`)
+  await getUpdateManager()
   marketplace = createPluginMarketplace()
   marketplaceAgentGateway = await startMarketplaceAgentGateway(marketplace, {
     onError: error => { appendLog('desktop', `[marketplace-agent] ${String(error)}`) },

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ let marketplaceAgentGateway: MarketplaceAgentGateway | undefined
 let logStream: WriteStream | undefined
 let updateWindow: BrowserWindow | undefined
 let updateManager: DesktopUpdateManager | undefined
+let quittingForUpdate = false
 let quitting = false
 let transitioning = false
 let queuedPaths: string[] = []
@@ -400,6 +401,25 @@ async function openUpdateWindow(): Promise<void> {
   window.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
   await window.loadFile(updateHtmlPath)
   void manager.check()
+}
+
+async function stopForApplicationQuit(): Promise<void> {
+  await Promise.allSettled([
+    runtime?.stop() ?? Promise.resolve(),
+    stopPreviewSurface(),
+    marketplaceAgentGateway?.close() ?? Promise.resolve(),
+  ]).then(results => {
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        appendLog('desktop', result.reason instanceof Error ? result.reason.message : String(result.reason))
+      }
+    }
+  })
+  runtime = undefined
+  runtimeUrl = undefined
+  runtimeOrigin = undefined
+  marketplaceAgentGateway = undefined
+  if (updateWindow !== undefined && !updateWindow.isDestroyed()) updateWindow.close()
 }
 
 function normalizeWorkspacePaths(paths: readonly string[]): string[] {
@@ -769,7 +789,19 @@ function installIpc(): void {
   })
   ipcMain.handle('desktop:update:command', async (event, raw: unknown) => {
     assertUpdateWindowSender(event)
-    return await (await getUpdateManager()).command(parseUpdateCommand(raw))
+    const command = parseUpdateCommand(raw)
+    const manager = await getUpdateManager()
+    const current = manager.getState()
+    const installNow = command.type === 'install-now'
+      && current.status === 'downloaded'
+      && current.platform !== 'deb'
+    if (installNow) {
+      quittingForUpdate = true
+      await stopForApplicationQuit()
+    }
+    const result = await manager.command(command)
+    if (installNow && result.status === 'error') quittingForUpdate = false
+    return result
   })
   ipcMain.handle('desktop:get-info', event => {
     const preview = previewWindow?.webContents.id === event.sender.id ? previewIdentity ?? null : null
@@ -886,17 +918,8 @@ async function bootstrap(): Promise<void> {
     if (quitting) return
     event.preventDefault()
     quitting = true
-    void Promise.allSettled([
-      runtime?.stop() ?? Promise.resolve(),
-      stopPreviewSurface(),
-      marketplaceAgentGateway?.close() ?? Promise.resolve(),
-    ]).then(results => {
-      for (const result of results) {
-        if (result.status === 'rejected') {
-          appendLog('desktop', result.reason instanceof Error ? result.reason.message : String(result.reason))
-        }
-      }
-    }).finally(() => {
+    appendLog('desktop', quittingForUpdate ? 'quitting to install desktop update' : 'quitting application')
+    void stopForApplicationQuit().finally(() => {
       logStream?.end()
       app.quit()
     })

--- a/src/update-dialog.ts
+++ b/src/update-dialog.ts
@@ -1,0 +1,160 @@
+import type { DesktopUpdateBridge, DesktopUpdateState } from './contracts.ts'
+
+declare global {
+  interface Window {
+    dshDesktopUpdate: DesktopUpdateBridge
+  }
+}
+
+const bridge = window.dshDesktopUpdate
+const title = document.querySelector<HTMLElement>('[data-field="title"]')!
+const status = document.querySelector<HTMLElement>('[data-field="status"]')!
+const version = document.querySelector<HTMLElement>('[data-field="version"]')!
+const size = document.querySelector<HTMLElement>('[data-field="size"]')!
+const notes = document.querySelector<HTMLElement>('[data-field="notes"]')!
+const progressWrap = document.querySelector<HTMLElement>('[data-field="progress-wrap"]')!
+const progress = document.querySelector<HTMLElement>('[data-field="progress"]')!
+const progressText = document.querySelector<HTMLElement>('[data-field="progress-text"]')!
+const error = document.querySelector<HTMLElement>('[data-field="error"]')!
+const updateButton = document.querySelector<HTMLButtonElement>('[data-action="download"]')!
+const cancelButton = document.querySelector<HTMLButtonElement>('[data-action="cancel"]')!
+const retryButton = document.querySelector<HTMLButtonElement>('[data-action="retry"]')!
+const installNowButton = document.querySelector<HTMLButtonElement>('[data-action="install-now"]')!
+const installQuitButton = document.querySelector<HTMLButtonElement>('[data-action="install-on-quit"]')!
+const releaseButton = document.querySelector<HTMLButtonElement>('[data-action="open-release"]')!
+const checkButton = document.querySelector<HTMLButtonElement>('[data-action="check"]')!
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes)) return 'Unknown size'
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB']
+  let value = bytes / 1024
+  let unit = units[0]
+  for (let index = 0; value >= 1024 && index < units.length - 1; index += 1) {
+    value /= 1024
+    unit = units[index + 1]!
+  }
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${unit}`
+}
+
+function formatSpeed(bytes: number): string {
+  return bytes > 0 ? `${formatBytes(bytes)}/s` : 'Waiting for network'
+}
+
+function formatEta(seconds: number | null): string {
+  if (seconds === null) return 'Calculating time remaining'
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  return minutes > 0 ? `${minutes}m ${String(remainder).padStart(2, '0')}s remaining` : `${remainder}s remaining`
+}
+
+function setVisible(element: HTMLElement, visible: boolean): void {
+  element.hidden = !visible
+}
+
+function setButton(button: HTMLButtonElement, visible: boolean, enabled = visible): void {
+  setVisible(button, visible)
+  button.disabled = !enabled
+}
+
+function render(state: DesktopUpdateState): void {
+  error.textContent = ''
+  setVisible(error, false)
+  setVisible(notes, state.status === 'available' || state.status === 'downloaded')
+  setVisible(progressWrap, state.status === 'downloading')
+  setButton(checkButton, state.status === 'idle' || state.status === 'not-available' || state.status === 'cancelled' || state.status === 'unsupported' || state.status === 'error')
+  setButton(updateButton, state.status === 'available')
+  setButton(cancelButton, state.status === 'downloading')
+  setButton(retryButton, state.status === 'error' && state.retryable === true)
+  setButton(installNowButton, state.status === 'downloaded' && state.platform !== 'unsupported')
+  setButton(installQuitButton, state.status === 'downloaded' && state.platform !== 'deb' && state.platform !== 'unsupported')
+  setButton(releaseButton, 'releaseUrl' in state && state.releaseUrl !== null, 'releaseUrl' in state && state.releaseUrl !== null)
+
+  switch (state.status) {
+    case 'idle':
+      title.textContent = 'Software updates'
+      status.textContent = 'Check the official GitHub Release for a newer version.'
+      version.textContent = `Current version: ${state.currentVersion}`
+      size.textContent = ''
+      notes.textContent = ''
+      break
+    case 'checking':
+      title.textContent = 'Checking for updates'
+      status.textContent = 'Contacting the official Release service...'
+      version.textContent = `Current version: ${state.currentVersion}`
+      break
+    case 'not-available':
+      title.textContent = 'You are up to date'
+      status.textContent = `Latest stable version: ${state.checkedVersion}`
+      version.textContent = `Current version: ${state.currentVersion}`
+      size.textContent = ''
+      notes.textContent = ''
+      break
+    case 'available':
+      title.textContent = 'Update available'
+      status.textContent = state.releaseName ?? `Version ${state.latestVersion}`
+      version.textContent = `Current ${state.currentVersion} -> ${state.latestVersion}`
+      size.textContent = `Download size: ${formatBytes(state.size)}`
+      notes.textContent = state.releaseNotes || 'No release notes were provided.'
+      break
+    case 'downloading':
+      title.textContent = 'Downloading update'
+      status.textContent = `${state.percent.toFixed(1)}% - ${formatSpeed(state.bytesPerSecond)} - ${formatEta(state.etaSeconds)}`
+      version.textContent = `Current ${state.currentVersion} -> ${state.latestVersion}`
+      size.textContent = `${formatBytes(state.transferred)} of ${formatBytes(state.total)}`
+      progress.style.width = `${Math.max(0, Math.min(100, state.percent))}%`
+      progressText.textContent = `${state.percent.toFixed(1)}%`
+      break
+    case 'downloaded':
+      title.textContent = state.platform === 'deb' ? 'Installer ready' : 'Update ready to install'
+      status.textContent = state.platform === 'deb' ? 'Open the system package installer to finish.' : 'Restart to apply the verified update.'
+      version.textContent = `Current ${state.currentVersion} -> ${state.latestVersion}`
+      size.textContent = `Downloaded: ${formatBytes(state.size)}`
+      notes.textContent = state.releaseNotes || 'No release notes were provided.'
+      installNowButton.textContent = state.platform === 'deb' ? 'Open System Installer' : 'Restart and Install Now'
+      break
+    case 'scheduled':
+      title.textContent = 'Update scheduled'
+      status.textContent = state.platform === 'deb' ? 'Finish installation in the system installer.' : 'The verified update will be installed when the application quits.'
+      version.textContent = `Current ${state.currentVersion} -> ${state.latestVersion}`
+      break
+    case 'cancelled':
+      title.textContent = 'Download cancelled'
+      status.textContent = 'The current version is still installed.'
+      version.textContent = `Current version: ${state.currentVersion}`
+      break
+    case 'unsupported':
+      title.textContent = 'Automatic updates unavailable'
+      status.textContent = state.message
+      version.textContent = `Current version: ${state.currentVersion}`
+      break
+    case 'error':
+      title.textContent = 'Update could not be completed'
+      status.textContent = state.message
+      version.textContent = `Current version: ${state.currentVersion}`
+      error.textContent = `${state.stage} (${state.code})`
+      setVisible(error, true)
+      break
+  }
+}
+
+async function run(type: Parameters<DesktopUpdateBridge['command']>[0]['type']): Promise<void> {
+  try {
+    render(await bridge.command({ type } as Parameters<DesktopUpdateBridge['command']>[0]))
+  } catch (cause) {
+    error.textContent = cause instanceof Error ? cause.message : String(cause)
+    setVisible(error, true)
+  }
+}
+
+for (const button of document.querySelectorAll<HTMLButtonElement>('[data-action]')) {
+  const action = button.dataset.action
+  if (action === undefined || action === 'close') continue
+  button.addEventListener('click', () => { void run(action as Parameters<DesktopUpdateBridge['command']>[0]['type']) })
+}
+
+bridge.onState(render)
+void bridge.getState().then(render).catch(cause => {
+  error.textContent = cause instanceof Error ? cause.message : String(cause)
+  setVisible(error, true)
+})

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -336,10 +336,10 @@ export class DesktopUpdateManager {
 
   private publishDownloaded(): void {
     if (this.metadata === undefined) return
+    const { installerPath: _installerPath, ...publicMetadata } = this.metadata
     this.publish({
       status: 'downloaded',
-      ...this.metadata,
-      installerPath: this.metadata.platform === 'deb' ? this.metadata.installerPath : null,
+      ...publicMetadata,
       installOnQuit: false,
     })
   }

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -159,6 +159,7 @@ export class DesktopUpdateManager {
   private token: CancellationToken | undefined
   private operation: Operation = 'check'
   private lastCheck: Promise<DesktopUpdateState> | undefined
+  private installOnQuitRequested = false
   private readonly listeners = new Set<(state: DesktopUpdateState) => void>()
   private readonly eventListeners: Array<[string, (...args: any[]) => void]> = []
 
@@ -183,6 +184,8 @@ export class DesktopUpdateManager {
   }
 
   getState(): DesktopUpdateState { return this.state }
+
+  shouldInstallOnQuit(): boolean { return this.installOnQuitRequested }
 
   subscribe(listener: (state: DesktopUpdateState) => void): () => void {
     this.listeners.add(listener)
@@ -317,8 +320,10 @@ export class DesktopUpdateManager {
   }
 
   async installNow(): Promise<DesktopUpdateState> {
-    if (this.metadata === undefined || this.state.status !== 'downloaded') return this.state
+    const scheduledInstall = this.state.status === 'scheduled' && this.installOnQuitRequested
+    if (this.metadata === undefined || (this.state.status !== 'downloaded' && !scheduledInstall)) return this.state
     this.operation = 'install'
+    this.installOnQuitRequested = false
     try {
       if (this.metadata.platform === 'deb') {
         if (this.metadata.installerPath === null || this.onOpenInstaller === undefined) throw Object.assign(new Error('the downloaded .deb installer is unavailable'), { code: 'UPDATE_INSTALLER_MISSING' })
@@ -334,6 +339,7 @@ export class DesktopUpdateManager {
 
   installOnQuit(): DesktopUpdateState {
     if (this.metadata === undefined || this.state.status !== 'downloaded' || this.metadata.platform === 'deb') return this.state
+    this.installOnQuitRequested = true
     if (this.updater !== undefined) this.updater.autoInstallOnAppQuit = true
     return this.publishScheduled()
   }

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -271,6 +271,16 @@ export class DesktopUpdateManager {
         releaseUrl: officialReleaseUrl(normalized),
       })
     } catch (error) {
+      const code = errorCode(error)
+      if (code === 'UPDATE_ASSET_MISSING' || code === 'UPDATE_ASSET_AMBIGUOUS') {
+        return this.publish({
+          status: 'unsupported',
+          currentVersion: this.currentVersion,
+          platform: this.platform,
+          message: 'The latest Release does not contain one verified installer for this platform and architecture.',
+          releaseUrl: officialReleaseUrl(normalized),
+        })
+      }
       return this.fail(error, 'check')
     }
   }

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -117,7 +117,7 @@ function errorMessage(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error)
   return raw
     .replace(/authorization:\s*[^\s]+/gi, 'authorization: <redacted>')
-    .replace(/([?&](?:token|access_token|password|passwd|secret)=[^&\s]+)/gi, '$1'.replace(/=.*/, '=<redacted>'))
+    .replace(/([?&](?:token|access_token|password|passwd|secret))=[^&\s]*/gi, '$1=<redacted>')
     .slice(0, 1_000)
 }
 
@@ -398,6 +398,10 @@ export class DesktopUpdateManager {
     })
     bind('update-cancelled', () => {
       if (this.metadata !== undefined) this.publish({ status: 'cancelled', currentVersion: this.currentVersion, latestVersion: this.metadata.latestVersion })
+    })
+    bind('login', (_authInfo: unknown, callback: (username: string, password: string) => void) => {
+      callback('', '')
+      this.fail(Object.assign(new Error('The configured network proxy requires authentication.'), { code: 'PROXY_AUTH_REQUIRED' }), this.operation)
     })
     bind('error', (error: unknown) => {
       if (this.token?.cancelled) return

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -1,0 +1,434 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { CancellationToken, type ProgressInfo, type UpdateInfo, type UpdateFileInfo } from 'electron-updater'
+import { gt, prerelease, valid } from 'semver'
+import type {
+  DesktopUpdatePlatform,
+  DesktopUpdateState,
+} from './contracts.ts'
+
+const OFFICIAL_REPOSITORY = 'hust-open-atom-club/oh-dsh'
+const OFFICIAL_RELEASE_BASE = `https://github.com/${OFFICIAL_REPOSITORY}/releases/tag/`
+
+export interface UpdateEventSource {
+  autoDownload: boolean
+  autoInstallOnAppQuit: boolean
+  allowPrerelease: boolean
+  allowDowngrade: boolean
+  disableDifferentialDownload: boolean
+  checkForUpdates(): Promise<{ isUpdateAvailable: boolean; updateInfo: UpdateInfo } | null>
+  downloadUpdate(token?: CancellationToken): Promise<string[]>
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
+  on(event: string, listener: (...args: any[]) => void): unknown
+  removeListener?(event: string, listener: (...args: any[]) => void): unknown
+}
+
+export interface UpdateManagerOptions {
+  currentVersion: string
+  platform?: NodeJS.Platform
+  arch?: string
+  appIsPackaged?: boolean
+  resourcesPath?: string
+  packageType?: 'appimage' | 'deb' | 'unsupported'
+  updater?: UpdateEventSource
+  syncProxy?: () => Promise<void>
+  onOpenRelease?: (url: string) => Promise<void> | void
+  onOpenInstaller?: (path: string) => Promise<void> | void
+  onLog?: (message: string) => void
+}
+
+interface UpdateMetadata {
+  currentVersion: string
+  latestVersion: string
+  releaseName: string | null
+  releaseNotes: string
+  size: number | null
+  platform: DesktopUpdatePlatform
+  releaseUrl: string
+  installerPath: string | null
+}
+
+type Operation = 'check' | 'download' | 'verify' | 'install'
+
+export function officialReleaseUrl(version: string): string {
+  const normalized = valid(version)
+  if (normalized === null) throw new Error(`invalid release version: ${version}`)
+  return `${OFFICIAL_RELEASE_BASE}v${normalized}`
+}
+
+export function releaseNotesText(notes: UpdateInfo['releaseNotes']): string {
+  if (typeof notes === 'string') return notes
+  if (!Array.isArray(notes)) return ''
+  return notes
+    .map(note => `${note.version}\n${note.note ?? ''}`.trim())
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+function normalizeFileName(file: UpdateFileInfo): string {
+  const raw = file.url
+  try {
+    return decodeURIComponent(new URL(raw).pathname.split('/').pop() ?? raw)
+  } catch {
+    return raw.split('/').pop() ?? raw
+  }
+}
+
+export function platformFor(options: Pick<UpdateManagerOptions, 'platform' | 'packageType' | 'appIsPackaged'> = {}): DesktopUpdatePlatform {
+  if (options.appIsPackaged === false) return 'unsupported'
+  const platform = options.platform ?? process.platform
+  if (platform === 'darwin') return 'mac'
+  if (platform === 'win32') return 'win'
+  if (platform === 'linux') {
+    if (options.packageType === 'deb') return 'deb'
+    if (options.packageType === 'appimage' || process.env.APPIMAGE !== undefined) return 'appimage'
+  }
+  return 'unsupported'
+}
+
+export function selectUpdateFile(
+  info: UpdateInfo,
+  platform: DesktopUpdatePlatform,
+  arch: string = process.arch,
+): UpdateFileInfo {
+  const files = info.files.filter(file => {
+    const name = normalizeFileName(file).toLowerCase()
+    if (platform === 'mac') return name.endsWith('.zip') && name.includes(arch.toLowerCase())
+    if (platform === 'win') return name.endsWith('.exe') && name.includes(arch.toLowerCase())
+    if (platform === 'appimage') return name.endsWith('.appimage') && (name.includes('x86_64') || name.includes('amd64') || name.includes(arch.toLowerCase()))
+    if (platform === 'deb') return name.endsWith('.deb') && (name.includes('amd64') || name.includes('x86_64') || name.includes(arch.toLowerCase()))
+    return false
+  })
+  if (files.length !== 1) {
+    throw Object.assign(
+      new Error(files.length === 0 ? `no installable update asset for ${platform}/${arch}` : `multiple installable update assets for ${platform}/${arch}`),
+      { code: files.length === 0 ? 'UPDATE_ASSET_MISSING' : 'UPDATE_ASSET_AMBIGUOUS' },
+    )
+  }
+  return files[0]!
+}
+
+function errorCode(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'code' in error && typeof error.code === 'string') return error.code
+  return 'UPDATE_FAILED'
+}
+
+function errorMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  return raw
+    .replace(/authorization:\s*[^\s]+/gi, 'authorization: <redacted>')
+    .replace(/([?&](?:token|access_token|password|passwd|secret)=[^&\s]+)/gi, '$1'.replace(/=.*/, '=<redacted>'))
+    .slice(0, 1_000)
+}
+
+function isVerificationFailure(error: unknown): boolean {
+  const code = errorCode(error).toLowerCase()
+  const message = errorMessage(error).toLowerCase()
+  return code.includes('signature') || code.includes('checksum') || message.includes('checksum') || message.includes('signature')
+}
+
+function isRetryable(error: unknown, stage: Operation): boolean {
+  if (stage === 'verify' || stage === 'install') return false
+  const code = errorCode(error)
+  if (code === 'UPDATE_ASSET_MISSING' || code === 'UPDATE_ASSET_AMBIGUOUS' || code === 'ENOSPC') return false
+  if (code.includes('INVALID_SIGNATURE') || code.includes('CHECKSUM')) return false
+  return true
+}
+
+export async function detectPackageType(resourcesPath: string): Promise<'appimage' | 'deb' | 'unsupported'> {
+  if (process.env.APPIMAGE !== undefined) return 'appimage'
+  try {
+    const packageType = (await readFile(join(resourcesPath, 'package-type'), 'utf8')).trim()
+    return packageType === 'deb' ? 'deb' : 'unsupported'
+  } catch {
+    return 'unsupported'
+  }
+}
+
+export class DesktopUpdateManager {
+  readonly platform: DesktopUpdatePlatform
+  private readonly currentVersion: string
+  private readonly arch: string
+  private readonly updater: UpdateEventSource | undefined
+  private readonly syncProxy: (() => Promise<void>) | undefined
+  private readonly onOpenRelease: ((url: string) => Promise<void> | void) | undefined
+  private readonly onOpenInstaller: ((path: string) => Promise<void> | void) | undefined
+  private readonly onLog: ((message: string) => void) | undefined
+  private state: DesktopUpdateState
+  private metadata: UpdateMetadata | undefined
+  private token: CancellationToken | undefined
+  private operation: Operation = 'check'
+  private lastCheck: Promise<DesktopUpdateState> | undefined
+  private readonly listeners = new Set<(state: DesktopUpdateState) => void>()
+  private readonly eventListeners: Array<[string, (...args: any[]) => void]> = []
+
+  constructor(options: UpdateManagerOptions) {
+    this.currentVersion = options.currentVersion
+    this.arch = options.arch ?? process.arch
+    this.platform = platformFor(options)
+    this.updater = options.updater
+    this.syncProxy = options.syncProxy
+    this.onOpenRelease = options.onOpenRelease
+    this.onOpenInstaller = options.onOpenInstaller
+    this.onLog = options.onLog
+    this.state = { status: 'idle', currentVersion: this.currentVersion }
+    if (this.updater !== undefined) {
+      this.updater.autoDownload = false
+      this.updater.autoInstallOnAppQuit = false
+      this.updater.allowPrerelease = false
+      this.updater.allowDowngrade = false
+      this.updater.disableDifferentialDownload = false
+      this.bindUpdaterEvents()
+    }
+  }
+
+  getState(): DesktopUpdateState { return this.state }
+
+  subscribe(listener: (state: DesktopUpdateState) => void): () => void {
+    this.listeners.add(listener)
+    listener(this.state)
+    return () => { this.listeners.delete(listener) }
+  }
+
+  async command(command: { type: string }): Promise<DesktopUpdateState> {
+    switch (command.type) {
+      case 'check': return await this.check()
+      case 'download': return await this.download()
+      case 'cancel': return this.cancel()
+      case 'retry': return await this.retry()
+      case 'install-now': return await this.installNow()
+      case 'install-on-quit': return this.installOnQuit()
+      case 'open-release': return await this.openRelease()
+      default: throw new Error(`unsupported update command: ${command.type}`)
+    }
+  }
+
+  async check(): Promise<DesktopUpdateState> {
+    if (this.lastCheck !== undefined) return await this.lastCheck
+    this.lastCheck = this.performCheck().finally(() => { this.lastCheck = undefined })
+    return await this.lastCheck
+  }
+
+  private async performCheck(): Promise<DesktopUpdateState> {
+    if (this.platform === 'unsupported' || this.updater === undefined) {
+      return this.publish({
+        status: 'unsupported',
+        currentVersion: this.currentVersion,
+        platform: this.platform,
+        message: 'This installation does not support automatic updates. Download the matching package from the official Release.',
+        releaseUrl: null,
+      })
+    }
+    this.operation = 'check'
+    this.publish({ status: 'checking', currentVersion: this.currentVersion })
+    try {
+      await this.syncProxy?.()
+      const result = await this.updater.checkForUpdates()
+      if (result === null) {
+        return this.publish({
+          status: 'unsupported',
+          currentVersion: this.currentVersion,
+          platform: this.platform,
+          message: 'Automatic updates are only available in a packaged, signed desktop installation.',
+          releaseUrl: null,
+        })
+      }
+      if (!result.isUpdateAvailable) {
+        return this.publish({ status: 'not-available', currentVersion: this.currentVersion, checkedVersion: result.updateInfo.version })
+      }
+      return this.prepareAvailable(result.updateInfo)
+    } catch (error) {
+      return this.fail(error, 'check')
+    }
+  }
+
+  private prepareAvailable(info: UpdateInfo): DesktopUpdateState {
+    const normalized = valid(info.version)
+    if (normalized === null || prerelease(normalized) !== null || !gt(normalized, this.currentVersion)) {
+      return this.publish({ status: 'not-available', currentVersion: this.currentVersion, checkedVersion: info.version })
+    }
+    if (this.state.status === 'available' && this.state.latestVersion === normalized) return this.state
+    try {
+      const file = selectUpdateFile(info, this.platform, this.arch)
+      this.metadata = {
+        currentVersion: this.currentVersion,
+        latestVersion: normalized,
+        releaseName: info.releaseName ?? null,
+        releaseNotes: releaseNotesText(info.releaseNotes),
+        size: file.size ?? null,
+        platform: this.platform,
+        releaseUrl: officialReleaseUrl(normalized),
+        installerPath: null,
+      }
+      return this.publish({
+        status: 'available',
+        currentVersion: this.currentVersion,
+        latestVersion: normalized,
+        releaseName: info.releaseName ?? null,
+        releaseNotes: releaseNotesText(info.releaseNotes),
+        size: file.size ?? null,
+        platform: this.platform,
+        releaseUrl: officialReleaseUrl(normalized),
+      })
+    } catch (error) {
+      return this.fail(error, 'check')
+    }
+  }
+
+  async download(): Promise<DesktopUpdateState> {
+    if (this.metadata === undefined || this.updater === undefined) return this.state
+    this.operation = 'download'
+    this.token = new CancellationToken()
+    try {
+      await this.syncProxy?.()
+      const paths = await this.updater.downloadUpdate(this.token)
+      if (this.metadata.installerPath === null) this.metadata.installerPath = paths[0] ?? null
+      if (this.state.status !== 'downloaded') this.publishDownloaded()
+      return this.state
+    } catch (error) {
+      if (this.token.cancelled) return this.publish({ status: 'cancelled', currentVersion: this.currentVersion, latestVersion: this.metadata.latestVersion })
+      return this.fail(error, isVerificationFailure(error) ? 'verify' : 'download')
+    } finally {
+      this.token = undefined
+    }
+  }
+
+  cancel(): DesktopUpdateState {
+    this.token?.cancel()
+    if (this.metadata !== undefined && (this.state.status === 'downloading' || this.state.status === 'available')) {
+      return this.publish({ status: 'cancelled', currentVersion: this.currentVersion, latestVersion: this.metadata.latestVersion })
+    }
+    return this.state
+  }
+
+  async retry(): Promise<DesktopUpdateState> {
+    if (this.state.status === 'error' && this.state.stage === 'download' && this.metadata !== undefined) return await this.download()
+    return await this.check()
+  }
+
+  async installNow(): Promise<DesktopUpdateState> {
+    if (this.metadata === undefined || this.state.status !== 'downloaded') return this.state
+    this.operation = 'install'
+    try {
+      if (this.metadata.platform === 'deb') {
+        if (this.metadata.installerPath === null || this.onOpenInstaller === undefined) throw Object.assign(new Error('the downloaded .deb installer is unavailable'), { code: 'UPDATE_INSTALLER_MISSING' })
+        await this.onOpenInstaller(this.metadata.installerPath)
+        return this.publishScheduled()
+      }
+      this.updater?.quitAndInstall(false, true)
+      return this.publishScheduled()
+    } catch (error) {
+      return this.fail(error, 'install')
+    }
+  }
+
+  installOnQuit(): DesktopUpdateState {
+    if (this.metadata === undefined || this.state.status !== 'downloaded' || this.metadata.platform === 'deb') return this.state
+    if (this.updater !== undefined) this.updater.autoInstallOnAppQuit = true
+    return this.publishScheduled()
+  }
+
+  async openRelease(): Promise<DesktopUpdateState> {
+    const url = this.metadata?.releaseUrl
+    if (url !== undefined) await this.onOpenRelease?.(url)
+    return this.state
+  }
+
+  private publishDownloaded(): void {
+    if (this.metadata === undefined) return
+    this.publish({
+      status: 'downloaded',
+      ...this.metadata,
+      installerPath: this.metadata.platform === 'deb' ? this.metadata.installerPath : null,
+      installOnQuit: false,
+    })
+  }
+
+  private publishScheduled(): DesktopUpdateState {
+    if (this.metadata === undefined) return this.state
+    return this.publish({
+      status: 'scheduled',
+      currentVersion: this.metadata.currentVersion,
+      latestVersion: this.metadata.latestVersion,
+      releaseName: this.metadata.releaseName,
+      releaseNotes: this.metadata.releaseNotes,
+      size: this.metadata.size,
+      platform: this.metadata.platform,
+      releaseUrl: this.metadata.releaseUrl,
+    })
+  }
+
+  private bindUpdaterEvents(): void {
+    const bind = (event: string, listener: (...args: any[]) => void): void => {
+      this.updater?.on(event, listener)
+      this.eventListeners.push([event, listener])
+    }
+    bind('checking-for-update', () => {
+      if (this.state.status !== 'checking' && this.state.status !== 'downloading') this.publish({ status: 'checking', currentVersion: this.currentVersion })
+    })
+    bind('update-available', (info: UpdateInfo) => { this.prepareAvailable(info) })
+    bind('update-not-available', (info: UpdateInfo) => {
+      this.publish({ status: 'not-available', currentVersion: this.currentVersion, checkedVersion: info.version })
+    })
+    bind('download-progress', (progress: ProgressInfo) => {
+      if (this.metadata === undefined) return
+      const total = progress.total || this.metadata.size || 0
+      const transferred = progress.transferred || 0
+      const bytesPerSecond = progress.bytesPerSecond || 0
+      this.publish({
+        status: 'downloading',
+        currentVersion: this.metadata.currentVersion,
+        latestVersion: this.metadata.latestVersion,
+        releaseName: this.metadata.releaseName,
+        releaseNotes: this.metadata.releaseNotes,
+        size: this.metadata.size,
+        platform: this.metadata.platform,
+        releaseUrl: this.metadata.releaseUrl,
+        percent: progress.percent || 0,
+        transferred,
+        total,
+        bytesPerSecond,
+        etaSeconds: bytesPerSecond > 0 && total > transferred ? Math.ceil((total - transferred) / bytesPerSecond) : null,
+      })
+    })
+    bind('update-downloaded', (event: { downloadedFile?: string }) => {
+      if (this.metadata === undefined) return
+      if (event.downloadedFile !== undefined) this.metadata.installerPath = event.downloadedFile
+      this.publishDownloaded()
+    })
+    bind('update-cancelled', () => {
+      if (this.metadata !== undefined) this.publish({ status: 'cancelled', currentVersion: this.currentVersion, latestVersion: this.metadata.latestVersion })
+    })
+    bind('error', (error: unknown) => {
+      if (this.token?.cancelled) return
+      this.fail(error, isVerificationFailure(error) ? 'verify' : this.operation)
+    })
+  }
+
+  private fail(error: unknown, stage: Operation): DesktopUpdateState {
+    const code = errorCode(error)
+    const message = errorMessage(error)
+    this.onLog?.(`update ${stage} failed (${code}): ${message}`)
+    return this.publish({
+      status: 'error',
+      currentVersion: this.currentVersion,
+      stage,
+      code,
+      message: code === 'ENOSPC' ? 'Not enough disk space to download the update.' : message,
+      releaseUrl: this.metadata?.releaseUrl ?? null,
+      retryable: isRetryable(error, stage),
+    })
+  }
+
+  private publish(state: DesktopUpdateState): DesktopUpdateState {
+    this.state = state
+    for (const listener of this.listeners) listener(state)
+    return state
+  }
+
+  dispose(): void {
+    for (const [event, listener] of this.eventListeners) this.updater?.removeListener?.(event, listener)
+    this.eventListeners.length = 0
+    this.listeners.clear()
+  }
+}

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -331,6 +331,7 @@ export class DesktopUpdateManager {
         return this.publishScheduled()
       }
       this.updater?.quitAndInstall(false, true)
+      if (this.state.status === 'error') return this.state
       return this.publishScheduled()
     } catch (error) {
       return this.fail(error, 'install')

--- a/src/update-preload.ts
+++ b/src/update-preload.ts
@@ -1,0 +1,35 @@
+import { contextBridge, ipcRenderer } from 'electron'
+import type { DesktopUpdateBridge, DesktopUpdateCommand, DesktopUpdateState } from './contracts.ts'
+
+const commandTypes = new Set<DesktopUpdateCommand['type']>([
+  'check',
+  'download',
+  'cancel',
+  'retry',
+  'install-now',
+  'install-on-quit',
+  'open-release',
+])
+
+function isCommand(value: unknown): value is DesktopUpdateCommand {
+  return typeof value === 'object'
+    && value !== null
+    && 'type' in value
+    && typeof value.type === 'string'
+    && commandTypes.has(value.type as DesktopUpdateCommand['type'])
+}
+
+const bridge: DesktopUpdateBridge = Object.freeze({
+  getState: async (): Promise<DesktopUpdateState> => await ipcRenderer.invoke('desktop:update:get-state') as DesktopUpdateState,
+  command: async (command: DesktopUpdateCommand): Promise<DesktopUpdateState> => {
+    if (!isCommand(command)) throw new Error('unsupported update command')
+    return await ipcRenderer.invoke('desktop:update:command', command) as DesktopUpdateState
+  },
+  onState: (listener: (state: DesktopUpdateState) => void): (() => void) => {
+    const wrapped = (_event: Electron.IpcRendererEvent, state: DesktopUpdateState): void => { listener(state) }
+    ipcRenderer.on('desktop:update:state', wrapped)
+    return () => { ipcRenderer.removeListener('desktop:update:state', wrapped) }
+  },
+})
+
+contextBridge.exposeInMainWorld('dshDesktopUpdate', bridge)

--- a/src/update.html
+++ b/src/update.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Software updates</title>
+  <style>
+    :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f6f7f8; color: #17202a; }
+    @media (prefers-color-scheme: dark) { :root { background: #202124; color: #f4f5f6; } }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 28px; }
+    main { width: min(680px, 100%); }
+    header { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; margin-bottom: 26px; }
+    h1 { margin: 0 0 8px; font-size: 24px; letter-spacing: 0; }
+    .eyebrow { margin: 0; color: #66727e; font-size: 13px; }
+    @media (prefers-color-scheme: dark) { .eyebrow { color: #aeb8c2; } }
+    .status { margin: 0; font-size: 16px; line-height: 1.5; }
+    .version, .size, .error { margin: 8px 0 0; color: #66727e; font-size: 13px; }
+    @media (prefers-color-scheme: dark) { .version, .size { color: #aeb8c2; } }
+    .error { color: #b42318; }
+    .notes { min-height: 92px; margin: 26px 0; padding: 16px; border-left: 3px solid #3b82f6; background: color-mix(in srgb, currentColor 6%, transparent); white-space: pre-wrap; line-height: 1.55; font-size: 14px; }
+    .progress { height: 8px; overflow: hidden; border-radius: 4px; background: #dfe3e7; }
+    .progress > span { display: block; height: 100%; width: 0; background: #2563eb; transition: width 180ms ease; }
+    .progress-text { margin: 8px 0 0; color: #66727e; font-size: 12px; text-align: right; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
+    button { min-height: 36px; padding: 0 14px; border: 1px solid #aeb8c2; border-radius: 6px; background: transparent; color: inherit; font: inherit; cursor: pointer; }
+    button.primary { border-color: #2563eb; background: #2563eb; color: white; }
+    button:disabled { cursor: default; opacity: .45; }
+    button:focus-visible { outline: 2px solid #60a5fa; outline-offset: 2px; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">Oh-DSH Desktop</p>
+        <h1 data-field="title">Software updates</h1>
+        <p class="status" data-field="status">Checking...</p>
+        <p class="version" data-field="version"></p>
+        <p class="size" data-field="size"></p>
+      </div>
+    </header>
+    <div class="notes" data-field="notes" hidden></div>
+    <div data-field="progress-wrap" hidden>
+      <div class="progress"><span data-field="progress"></span></div>
+      <p class="progress-text" data-field="progress-text">0%</p>
+    </div>
+    <p class="error" data-field="error" hidden></p>
+    <div class="actions">
+      <button type="button" data-action="check">Check Again</button>
+      <button type="button" class="primary" data-action="download">Update</button>
+      <button type="button" data-action="cancel">Cancel</button>
+      <button type="button" data-action="retry">Retry</button>
+      <button type="button" class="primary" data-action="install-now">Restart and Install Now</button>
+      <button type="button" data-action="install-on-quit">Install on Quit</button>
+      <button type="button" data-action="open-release">Open Release Page</button>
+    </div>
+  </main>
+  <script src="update-dialog.js"></script>
+</body>
+</html>

--- a/tests/nix-collect-deps.test.ts
+++ b/tests/nix-collect-deps.test.ts
@@ -40,7 +40,7 @@ test('Nix dependency collector preserves transitive peer resolution', async () =
       encoding: 'utf8',
     })
     assert.equal(result.status, 0, result.stderr)
-    assert.equal(readlinkSync(join(output, '@fixture', 'root', 'node_modules')), '../..')
+    assert.equal(readlinkSync(join(output, '@fixture', 'root', 'node_modules')), join('..', '..'))
 
     // Runtime-generated fixture path: this assertion exercises Node's real ESM resolver.
     const collected = await import(pathToFileURL(join(output, '@fixture', 'root', 'index.js')).href)

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { validateReleaseTag } from '../scripts/validate-release-tag.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -17,4 +18,11 @@ test('tagged releases build and upload both TUI archive formats', () => {
   assert.match(workflow, /release\/oh-dsh-tui-\*\.zip/)
   assert.match(workflow, /fetch-depth: 0/)
   assert.match(workflow, /fetch-tags: true/)
+  assert.match(workflow, /validate-release-tag\.mjs --tag/)
+})
+
+test('release tags must match a stable package version', () => {
+  assert.equal(validateReleaseTag('v1.2.3', '1.2.3'), '1.2.3')
+  assert.throws(() => validateReleaseTag('v1.2.3-beta.1', '1.2.3-beta.1'), /stable semver/)
+  assert.throws(() => validateReleaseTag('v1.2.4', '1.2.3'), /does not match package version/)
 })

--- a/tests/update-manager.test.ts
+++ b/tests/update-manager.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import test from 'node:test'
+import type { UpdateInfo } from 'electron-updater'
+import {
+  DesktopUpdateManager,
+  officialReleaseUrl,
+  selectUpdateFile,
+} from '../src/update-manager.ts'
+
+class FakeUpdater extends EventEmitter {
+  autoDownload = true
+  autoInstallOnAppQuit = true
+  allowPrerelease = true
+  allowDowngrade = true
+  disableDifferentialDownload = false
+  result: { isUpdateAvailable: boolean; updateInfo: UpdateInfo } | null = null
+  downloadResult = ['/tmp/Oh-DSH-Desktop-update.zip']
+  quitCalls = 0
+  async checkForUpdates() {
+    this.emit('checking-for-update')
+    if (this.result?.isUpdateAvailable) this.emit('update-available', this.result.updateInfo)
+    else if (this.result !== null) this.emit('update-not-available', this.result.updateInfo)
+    return this.result
+  }
+  async downloadUpdate() {
+    this.emit('download-progress', { percent: 50, transferred: 50, total: 100, bytesPerSecond: 10 })
+    this.emit('update-downloaded', { downloadedFile: this.downloadResult[0], version: this.result?.updateInfo.version })
+    return this.downloadResult
+  }
+  quitAndInstall() { this.quitCalls += 1 }
+}
+
+function updateInfo(version: string, file = 'Oh-DSH-Desktop-1.2.0-arm64.zip'): UpdateInfo {
+  return {
+    version,
+    files: [{ url: `https://github.com/hust-open-atom-club/oh-dsh/releases/download/v${version}/${file}`, sha512: 'hash', size: 100 }],
+    path: file,
+    sha512: 'hash',
+    releaseDate: '2026-08-15T00:00:00Z',
+    releaseName: `v${version}`,
+    releaseNotes: 'Fixes and improvements',
+  }
+}
+
+test('selectUpdateFile chooses exactly the current architecture asset', () => {
+  const info = updateInfo('1.2.0')
+  info.files.push({ url: 'https://example.invalid/Oh-DSH-Desktop-1.2.0-x64.zip', sha512: 'hash', size: 100 })
+  assert.equal(selectUpdateFile(info, 'mac', 'arm64').url.endsWith('arm64.zip'), true)
+  assert.throws(() => selectUpdateFile(info, 'mac', 'ia32'), /no installable update asset/)
+})
+
+test('official release URLs are fixed to the trusted repository', () => {
+  assert.equal(officialReleaseUrl('1.2.3'), 'https://github.com/hust-open-atom-club/oh-dsh/releases/tag/v1.2.3')
+  assert.throws(() => officialReleaseUrl('../evil'), /invalid release version/)
+})
+
+test('manager reports available, progress, and downloaded states', async () => {
+  const updater = new FakeUpdater()
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0') }
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  const states: string[] = []
+  manager.subscribe(state => { states.push(state.status) })
+  assert.equal((await manager.check()).status, 'available')
+  assert.equal((await manager.download()).status, 'downloaded')
+  assert.deepEqual(states, ['idle', 'checking', 'available', 'downloading', 'downloaded'])
+  assert.equal((await manager.command({ type: 'install-now' })).status, 'scheduled')
+  assert.equal(updater.quitCalls, 1)
+})
+
+test('manager rejects prereleases and downgrades', async () => {
+  const updater = new FakeUpdater()
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0-beta.1') }
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  assert.equal((await manager.check()).status, 'not-available')
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.0.0') }
+  assert.equal((await manager.check()).status, 'not-available')
+})
+
+test('manager provides a deb installer fallback without invoking updater install', async () => {
+  const updater = new FakeUpdater()
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0', 'Oh-DSH-Desktop-1.2.0-amd64.deb') }
+  const opened: string[] = []
+  const manager = new DesktopUpdateManager({
+    currentVersion: '1.1.0',
+    platform: 'linux',
+    packageType: 'deb',
+    arch: 'x64',
+    updater,
+    onOpenInstaller: path => { opened.push(path) },
+  })
+  await manager.check()
+  await manager.download()
+  assert.equal((await manager.command({ type: 'install-now' })).status, 'scheduled')
+  assert.deepEqual(opened, ['/tmp/Oh-DSH-Desktop-update.zip'])
+  assert.equal(updater.quitCalls, 0)
+  assert.deepEqual(await manager.command({ type: 'install-on-quit' }), manager.getState())
+})
+
+test('manager exposes actionable retryable errors', async () => {
+  const updater = new FakeUpdater()
+  updater.result = null
+  updater.checkForUpdates = async () => { throw Object.assign(new Error('404 Not Found'), { code: 'HTTP_404' }) }
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  const state = await manager.check()
+  assert.equal(state.status, 'error')
+  if (state.status === 'error') {
+    assert.equal(state.stage, 'check')
+    assert.equal(state.retryable, true)
+    assert.match(state.message, /404/)
+  }
+})

--- a/tests/update-manager.test.ts
+++ b/tests/update-manager.test.ts
@@ -110,3 +110,16 @@ test('manager exposes actionable retryable errors', async () => {
     assert.match(state.message, /404/)
   }
 })
+
+test('manager turns proxy authentication into a redacted actionable error', () => {
+  const updater = new FakeUpdater()
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  updater.emit('login', {}, () => {})
+  const state = manager.getState()
+  assert.equal(state.status, 'error')
+  if (state.status === 'error') {
+    assert.equal(state.code, 'PROXY_AUTH_REQUIRED')
+    assert.equal(state.retryable, true)
+    assert.doesNotMatch(state.message, /password|token/i)
+  }
+})

--- a/tests/update-manager.test.ts
+++ b/tests/update-manager.test.ts
@@ -77,6 +77,17 @@ test('manager rejects prereleases and downgrades', async () => {
   assert.equal((await manager.check()).status, 'not-available')
 })
 
+test('manager offers the official Release page when the platform asset is missing', async () => {
+  const updater = new FakeUpdater()
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0', 'Oh-DSH-Desktop-1.2.0-x64.zip') }
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  const state = await manager.check()
+  assert.equal(state.status, 'unsupported')
+  if (state.status === 'unsupported') {
+    assert.equal(state.releaseUrl, 'https://github.com/hust-open-atom-club/oh-dsh/releases/tag/v1.2.0')
+  }
+})
+
 test('manager provides a deb installer fallback without invoking updater install', async () => {
   const updater = new FakeUpdater()
   updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0', 'Oh-DSH-Desktop-1.2.0-amd64.deb') }

--- a/tests/update-manager.test.ts
+++ b/tests/update-manager.test.ts
@@ -17,6 +17,7 @@ class FakeUpdater extends EventEmitter {
   result: { isUpdateAvailable: boolean; updateInfo: UpdateInfo } | null = null
   downloadResult = ['/tmp/Oh-DSH-Desktop-update.zip']
   quitCalls = 0
+  installError: Error | undefined
   async checkForUpdates() {
     this.emit('checking-for-update')
     if (this.result?.isUpdateAvailable) this.emit('update-available', this.result.updateInfo)
@@ -28,7 +29,10 @@ class FakeUpdater extends EventEmitter {
     this.emit('update-downloaded', { downloadedFile: this.downloadResult[0], version: this.result?.updateInfo.version })
     return this.downloadResult
   }
-  quitAndInstall() { this.quitCalls += 1 }
+  quitAndInstall() {
+    this.quitCalls += 1
+    if (this.installError !== undefined) this.emit('error', this.installError)
+  }
 }
 
 function updateInfo(version: string, file = 'Oh-DSH-Desktop-1.2.0-arm64.zip'): UpdateInfo {
@@ -131,6 +135,18 @@ test('manager clears install-on-quit request before attempting immediate install
   assert.equal(manager.shouldInstallOnQuit(), true)
   assert.equal((await manager.command({ type: 'install-now' })).status, 'scheduled')
   assert.equal(manager.shouldInstallOnQuit(), false)
+})
+
+test('manager preserves a synchronous updater install error for recovery', async () => {
+  const updater = new FakeUpdater()
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0') }
+  updater.installError = Object.assign(new Error('installer missing'), { code: 'UPDATE_INSTALLER_MISSING' })
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  await manager.check()
+  await manager.download()
+  const state = await manager.command({ type: 'install-now' })
+  assert.equal(state.status, 'error')
+  if (state.status === 'error') assert.equal(state.code, 'UPDATE_INSTALLER_MISSING')
 })
 
 test('manager exposes actionable retryable errors', async () => {

--- a/tests/update-manager.test.ts
+++ b/tests/update-manager.test.ts
@@ -109,6 +109,30 @@ test('manager provides a deb installer fallback without invoking updater install
   assert.deepEqual(await manager.command({ type: 'install-on-quit' }), manager.getState())
 })
 
+test('manager records an explicit install-on-quit request', async () => {
+  const updater = new FakeUpdater()
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0') }
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  await manager.check()
+  await manager.download()
+  assert.equal(manager.shouldInstallOnQuit(), false)
+  assert.equal((await manager.command({ type: 'install-on-quit' })).status, 'scheduled')
+  assert.equal(manager.shouldInstallOnQuit(), true)
+  assert.equal(updater.autoInstallOnAppQuit, true)
+})
+
+test('manager clears install-on-quit request before attempting immediate install', async () => {
+  const updater = new FakeUpdater()
+  updater.result = { isUpdateAvailable: true, updateInfo: updateInfo('1.2.0') }
+  const manager = new DesktopUpdateManager({ currentVersion: '1.1.0', platform: 'darwin', arch: 'arm64', updater })
+  await manager.check()
+  await manager.download()
+  await manager.command({ type: 'install-on-quit' })
+  assert.equal(manager.shouldInstallOnQuit(), true)
+  assert.equal((await manager.command({ type: 'install-now' })).status, 'scheduled')
+  assert.equal(manager.shouldInstallOnQuit(), false)
+})
+
 test('manager exposes actionable retryable errors', async () => {
   const updater = new FakeUpdater()
   updater.result = null

--- a/tests/update-manager.test.ts
+++ b/tests/update-manager.test.ts
@@ -91,6 +91,7 @@ test('manager provides a deb installer fallback without invoking updater install
   })
   await manager.check()
   await manager.download()
+  assert.equal('installerPath' in manager.getState(), false)
   assert.equal((await manager.command({ type: 'install-now' })).status, 'scheduled')
   assert.deepEqual(opened, ['/tmp/Oh-DSH-Desktop-update.zip'])
   assert.equal(updater.quitCalls, 0)

--- a/tests/update-metadata.test.ts
+++ b/tests/update-metadata.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { mergeMetadata, verifyMetadata } from '../scripts/update-metadata.mjs'
+
+async function asset(dir: string, name: string, content: string) {
+  const path = join(dir, name)
+  await writeFile(path, content)
+  const data = Buffer.from(content)
+  return {
+    url: `https://github.com/hust-open-atom-club/oh-dsh/releases/download/v1.2.0/${name}`,
+    sha512: createHash('sha512').update(data).digest('base64'),
+    size: data.length,
+  }
+}
+
+test('metadata verification selects one architecture and validates SHA-512', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'oh-dsh-metadata-'))
+  const arm = await asset(dir, 'Oh-DSH-Desktop-1.2.0-arm64.zip', 'arm')
+  const x64 = await asset(dir, 'Oh-DSH-Desktop-1.2.0-x64.zip', 'x64')
+  await writeFile(join(dir, 'latest-mac.yml'), [
+    'version: 1.2.0',
+    'files:',
+    `  - ${JSON.stringify(arm)}`,
+    `  - ${JSON.stringify(x64)}`,
+  ].join('\n'))
+  const result = verifyMetadata({ dir, version: '1.2.0', platform: 'mac-arm64' })
+  assert.equal(result.selected, arm.url.split('/').pop())
+  await writeFile(join(dir, 'Oh-DSH-Desktop-1.2.0-arm64.zip'), 'tampered')
+  assert.throws(() => verifyMetadata({ dir, version: '1.2.0', platform: 'mac-arm64' }), /sha512 mismatch/)
+})
+
+test('metadata merge combines macOS architectures and rejects version conflicts', () => {
+  const arm = { version: '1.2.0', files: [{ url: 'https://example/arm.zip', sha512: 'arm', size: 1 }] }
+  const x64 = { version: '1.2.0', files: [{ url: 'https://example/x64.zip', sha512: 'x64', size: 1 }] }
+  const merged = mergeMetadata([arm, x64])
+  assert.deepEqual(merged.files.map(file => file.url), ['https://example/arm.zip', 'https://example/x64.zip'])
+  assert.throws(() => mergeMetadata([arm, { ...x64, version: '1.3.0' }]), /different versions/)
+})
+
+test('metadata verification rejects web distribution assets', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'oh-dsh-metadata-'))
+  await mkdir(join(dir, 'nested'))
+  const app = await asset(dir, 'Oh-DSH-Desktop-1.2.0-x86_64.AppImage', 'app')
+  const web = await asset(dir, 'oh-dsh-web-1.2.0-linux-x64.zip', 'web')
+  await writeFile(join(dir, 'latest-linux.yml'), [
+    'version: 1.2.0',
+    'files:',
+    `  - ${JSON.stringify(app)}`,
+    `  - ${JSON.stringify(web)}`,
+  ].join('\n'))
+  assert.throws(() => verifyMetadata({ dir, version: '1.2.0', platform: 'linux-x64' }), /web distribution/)
+})


### PR DESCRIPTION
## Summary
- Add a restricted Electron updater flow backed by stable GitHub Releases from `hust-open-atom-club/oh-dsh`.
- Add update state management, progress/cancel/retry/install actions, proxy synchronization, verification boundaries, and `.deb` manual installer fallback.
- Restore updater-compatible signed macOS, Windows NSIS, and Linux AppImage artifacts with metadata validation in CI.
- Document installation, proxy, signing, recovery, and data-preservation behavior.
- Publish the first updater-enabled desktop version as `0.1.5`; existing `0.1.4` users install this one manually once.

## Verification
- `pnpm run typecheck`
- `node --test tests/*.test.ts` (119 passing with submodules initialized)
- `pnpm run build`
- `pnpm install --frozen-lockfile --ignore-scripts`
- Release workflow YAML and updater metadata tests pass.

Cross-platform signed packaged smoke tests require the configured CI signing secrets and hosted macOS/Windows/Linux runners.

Closes #34