### PR TITLE
fix(marketplace): survive Windows read-only preview cleanup

### DIFF
--- a/plugins/plugin-marketplace/src/host/transaction-manager.ts
+++ b/plugins/plugin-marketplace/src/host/transaction-manager.ts
@@ -1,7 +1,9 @@
 import { createHash, randomUUID } from 'node:crypto'
 import {
+  chmodSync,
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -76,6 +78,7 @@ export interface MarketplaceRuntime {
 export interface PluginMarketplaceOptions {
   appDataPath: string
   dshHome: string
+  onWarn?: (message: string) => void
   platform: MarketplacePlatform
   profile: string
   runtime: MarketplaceRuntime
@@ -460,9 +463,62 @@ function ensureWithin(parent: string, candidate: string): void {
   }
 }
 
-function removeWithin(parent: string, candidate: string): void {
+function defaultWarn(message: string): void {
+  console.warn(`plugin-marketplace: ${message}`)
+}
+
+/**
+ * Windows maps the read-only attribute to the owner write bit. Git packs and
+ * some cloned files are created read-only, so `rmSync` fails with EPERM before
+ * it can recurse into the tree. Clear that attribute before the retry while
+ * never following symlinks out of the disposable tree.
+ */
+function clearReadOnlyAttributes(
+  path: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== 'win32') return
+  try {
+    const stats = lstatSync(path)
+    if (stats.isDirectory()) {
+      chmodSync(path, stats.mode | 0o200)
+      for (const entry of readdirSync(path)) {
+        clearReadOnlyAttributes(join(path, entry), platform)
+      }
+    } else if (stats.isFile()) {
+      chmodSync(path, stats.mode | 0o200)
+    }
+  } catch {
+    // Best-effort attribute pass; the removal retry below reports the real failure.
+  }
+}
+
+function removeTree(
+  path: string,
+  onWarn: (message: string) => void = defaultWarn,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  try {
+    rmSync(path, { force: true, recursive: true })
+    return
+  } catch {
+    if (platform === 'win32') clearReadOnlyAttributes(path, platform)
+  }
+  try {
+    rmSync(path, { force: true, recursive: true })
+  } catch (error) {
+    onWarn(`failed to clean plugin marketplace tree at ${path}: ${message(error)}`)
+  }
+}
+
+export function removeWithin(
+  parent: string,
+  candidate: string,
+  onWarn: (message: string) => void = defaultWarn,
+  platform: NodeJS.Platform = process.platform,
+): void {
   ensureWithin(parent, candidate)
-  rmSync(candidate, { force: true, recursive: true })
+  removeTree(candidate, onWarn, platform)
 }
 
 function copyDirectory(source: string, target: string): void {
@@ -532,15 +588,17 @@ export class PluginMarketplaceManager {
   #lastAction: string | null = null
   #plan: MarketplacePlan | null = null
   #rollback: RollbackState | null
+  readonly #warn: (message: string) => void
 
   constructor(options: PluginMarketplaceOptions) {
     this.#options = options
+    this.#warn = options.onWarn ?? defaultWarn
     this.#profileDir = join(options.dshHome, 'profiles', options.profile)
     this.#root = join(options.appDataPath, 'plugin-marketplace')
     this.#previewsRoot = join(this.#root, 'previews')
     this.#rollbacksRoot = join(this.#root, 'rollbacks')
     this.#rollbackStatePath = join(this.#rollbacksRoot, 'current.json')
-    rmSync(this.#previewsRoot, { force: true, recursive: true })
+    removeTree(this.#previewsRoot, this.#warn)
     mkdirSync(this.#previewsRoot, { recursive: true, mode: 0o700 })
     mkdirSync(this.#rollbacksRoot, { recursive: true, mode: 0o700 })
     this.#rollback = this.readRollback()
@@ -868,7 +926,7 @@ export class PluginMarketplaceManager {
           if (existsSync(sources)) {
             for (const entry of readdirSync(sources)) {
               if (entry.startsWith(`${plan.pluginId}-`)) {
-                removeWithin(sources, join(sources, entry))
+                removeWithin(sources, join(sources, entry), this.#warn)
               }
             }
           }
@@ -980,7 +1038,7 @@ export class PluginMarketplaceManager {
     } catch (error) {
       this.#active = null
       await this.#options.runtime.stopPreview().catch(() => {})
-      removeWithin(this.#previewsRoot, root)
+      removeWithin(this.#previewsRoot, root, this.#warn)
       throw error
     }
   }
@@ -1000,7 +1058,7 @@ export class PluginMarketplaceManager {
     const sources = join(candidateProfile, MANAGED_DIRECTORY, 'sources')
     if (!existsSync(sources)) return
     for (const entry of readdirSync(sources)) {
-      if (entry.startsWith(`${installed.pluginId}-`)) removeWithin(sources, join(sources, entry))
+      if (entry.startsWith(`${installed.pluginId}-`)) removeWithin(sources, join(sources, entry), this.#warn)
     }
   }
 
@@ -1011,7 +1069,7 @@ export class PluginMarketplaceManager {
       return
     }
     await this.#options.runtime.stopPreview()
-    removeWithin(this.#previewsRoot, active.root)
+    removeWithin(this.#previewsRoot, active.root, this.#warn)
     this.#active = null
     this.#plan = null
     this.#lastAction = `Discarded the ${active.preview.pluginId} preview without changing the desktop profile.`
@@ -1054,7 +1112,7 @@ export class PluginMarketplaceManager {
       transactionId: active.preview.transactionId,
     }
     writeJsonAtomic(this.#rollbackStatePath, this.#rollback)
-    removeWithin(this.#previewsRoot, active.root)
+    removeWithin(this.#previewsRoot, active.root, this.#warn)
     this.#active = null
     this.#plan = null
     this.#lastAction = `Applied ${active.preview.pluginId}; the previous profile remains available for Undo.`
@@ -1083,9 +1141,9 @@ export class PluginMarketplaceManager {
       await this.#options.runtime.startLive().catch(() => {})
       throw new Error(`failed to restore the previous plugin profile: ${message(error)}`)
     }
-    removeWithin(this.#rollbacksRoot, replacedProfile)
+    removeWithin(this.#rollbacksRoot, replacedProfile, this.#warn)
     rmSync(this.#rollbackStatePath, { force: true })
-    removeWithin(this.#rollbacksRoot, rollbackRoot)
+    removeWithin(this.#rollbacksRoot, rollbackRoot, this.#warn)
     this.#rollback = null
     this.#lastAction = `Restored the profile from before ${rollback.pluginId} was applied.`
     this.remapCatalogInstalled()

--- a/src/main.ts
+++ b/src/main.ts
@@ -502,6 +502,7 @@ function createPluginMarketplace(): PluginMarketplaceManager {
   return new PluginMarketplaceManager({
     appDataPath: info.appDataPath,
     dshHome: info.dshHome,
+    onWarn: line => { appendLog('desktop', `[marketplace] ${line}`) },
     platform: new ProductionMarketplacePlatform({
       cliEntry: paths.cliEntry,
       cwd: workingDirectory,

--- a/tests/nix-collect-deps.test.ts
+++ b/tests/nix-collect-deps.test.ts
@@ -40,7 +40,7 @@ test('Nix dependency collector preserves transitive peer resolution', async () =
       encoding: 'utf8',
     })
     assert.equal(result.status, 0, result.stderr)
-    assert.equal(readlinkSync(join(output, '@fixture', 'root', 'node_modules')), '../..')
+    assert.equal(readlinkSync(join(output, '@fixture', 'root', 'node_modules')), join('..', '..'))
 
     // Runtime-generated fixture path: this assertion exercises Node's real ESM resolver.
     const collected = await import(pathToFileURL(join(output, '@fixture', 'root', 'index.js')).href)

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { test } from 'node:test'
@@ -19,6 +19,7 @@ import {
 } from '../plugins/plugin-marketplace/src/host/platform.ts'
 import {
   PluginMarketplaceManager,
+  removeWithin,
   type MarketplacePreviewRuntimeInput,
   type MarketplaceRuntime,
 } from '../plugins/plugin-marketplace/src/host/transaction-manager.ts'
@@ -216,6 +217,60 @@ function fixture(): {
     runtime,
   }
 }
+
+test('preview tree cleanup clears Windows read-only attributes before retrying', () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-cleanup-'))
+  const previews = join(root, 'plugin-marketplace', 'previews')
+  const pack = join(previews, 'stale', '.git', 'objects', 'pack')
+  try {
+    mkdirSync(pack, { recursive: true })
+    writeFileSync(join(pack, 'pack-demo.pack'), 'pack', { mode: 0o444 })
+    writeFileSync(join(pack, 'pack-demo.idx'), 'idx', { mode: 0o444 })
+    chmodSync(previews, 0o555)
+    chmodSync(pack, 0o555)
+    const warnings: string[] = []
+    removeWithin(root, previews, message => { warnings.push(message) }, 'win32')
+    assert.deepEqual(warnings, [])
+    assert.equal(existsSync(previews), false)
+  } finally {
+    if (existsSync(previews)) chmodSync(previews, 0o755)
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('marketplace startup survives a previews tree that cannot be removed', () => {
+  const appDataPath = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-startup-'))
+  const dshHome = join(appDataPath, 'dsh')
+  const profileDir = join(dshHome, 'profiles', 'desktop')
+  const previews = join(appDataPath, 'plugin-marketplace', 'previews')
+  try {
+    mkdirSync(profileDir, { recursive: true })
+    writeFileSync(join(profileDir, 'package.json'), JSON.stringify({
+      name: 'desktop',
+      private: true,
+      dependencies: {},
+      dsh: { profile: { bundles: ['@oh-dsh/desktop'] } },
+    }, undefined, 2) + '\n')
+    mkdirSync(join(previews, 'stale'), { recursive: true })
+    writeFileSync(join(previews, 'stale', 'pack-demo.pack'), 'pack')
+    chmodSync(previews, 0o555)
+    const warnings: string[] = []
+    const manager = new PluginMarketplaceManager({
+      appDataPath,
+      dshHome,
+      onWarn: message => { warnings.push(message) },
+      platform: new FakePlatform(),
+      profile: 'desktop',
+      runtime: new FakeRuntime(),
+    })
+    assert.match(warnings.join('\n'), /failed to clean plugin marketplace tree/)
+    assert.equal(existsSync(previews), true)
+    assert.deepEqual(manager.getSnapshot().installed, [])
+  } finally {
+    if (existsSync(previews)) chmodSync(previews, 0o755)
+    rmSync(appDataPath, { recursive: true, force: true })
+  }
+})
 
 test('catalog parser keeps safe entries and labels unsupported managers', () => {
   const catalog = parseMarketplaceCatalog(catalogDocument())

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -238,7 +238,49 @@ test('preview tree cleanup clears Windows read-only attributes before retrying',
   }
 })
 
-test('marketplace startup survives a previews tree that cannot be removed', () => {
+test('marketplace startup clears read-only Git pack files on Windows', {
+  skip: process.platform !== 'win32' ? 'requires Windows read-only attribute semantics' : false,
+}, () => {
+  const appDataPath = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-windows-'))
+  const dshHome = join(appDataPath, 'dsh')
+  const profileDir = join(dshHome, 'profiles', 'desktop')
+  const previews = join(appDataPath, 'plugin-marketplace', 'previews')
+  const pack = join(previews, 'stale', '.git', 'objects', 'pack')
+  try {
+    mkdirSync(profileDir, { recursive: true })
+    writeFileSync(join(profileDir, 'package.json'), JSON.stringify({
+      name: 'desktop',
+      private: true,
+      dependencies: {},
+      dsh: { profile: { bundles: ['@oh-dsh/desktop'] } },
+    }, undefined, 2) + '\n')
+    mkdirSync(pack, { recursive: true })
+    writeFileSync(join(pack, 'pack-demo.pack'), 'pack')
+    writeFileSync(join(pack, 'pack-demo.idx'), 'idx')
+    chmodSync(join(pack, 'pack-demo.pack'), 0o444)
+    chmodSync(join(pack, 'pack-demo.idx'), 0o444)
+    const warnings: string[] = []
+    const manager = new PluginMarketplaceManager({
+      appDataPath,
+      dshHome,
+      onWarn: message => { warnings.push(message) },
+      platform: new FakePlatform(),
+      profile: 'desktop',
+      runtime: new FakeRuntime(),
+    })
+    assert.deepEqual(warnings, [])
+    assert.equal(existsSync(join(previews, 'stale')), false)
+    assert.deepEqual(manager.getSnapshot().installed, [])
+  } finally {
+    rmSync(appDataPath, { recursive: true, force: true })
+  }
+})
+
+test('marketplace startup survives a previews tree that cannot be removed', {
+  skip: process.platform === 'win32'
+    ? 'Windows directory read-only attributes do not block recursive removal'
+    : false,
+}, () => {
   const appDataPath = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-startup-'))
   const dshHome = join(appDataPath, 'dsh')
   const profileDir = join(dshHome, 'profiles', 'desktop')


### PR DESCRIPTION
Fixes #45

## Problem

`PluginMarketplaceManager` recursively deletes `plugin-marketplace/previews` on every startup. On Windows, Git clones leave read-only files under `.git/objects/pack` (mode 0444), and `fs.rmSync` throws `EPERM` instead of clearing the ReadOnly attribute first. Because this happens during bootstrap, the whole app fails to start.

## Changes

- Add a Windows-specific recursive ReadOnly-attribute clearing pass for disposable marketplace trees.
- Retry `rmSync` after clearing those attributes; if cleanup still fails, degrade to an `onWarn` log instead of throwing.
- Route every preview/rollback cleanup point through the same tolerant path, so discard/apply/undo and failed-preview cleanup no longer mask transactions on Windows.
- Pass `onWarn` from the Electron main process into the desktop log.
- Add Windows regression tests for read-only Git pack cleanup.
- Make the Nix collector symlink assertion use the platform-native `..` path so the existing Windows CI matrix passes.

## Verification

- Full CI on the fork: 5/5 jobs passed (Windows x64, Linux x64, macOS x64, macOS arm64, runtime smoke).
- Windows x64 job: `pnpm run typecheck`, `pnpm test`, and `pnpm run build` all passed.
- Windows-specific tests:
  - `preview tree cleanup clears Windows read-only attributes before retrying`
  - `marketplace startup clears read-only Git pack files on Windows`