### PR TITLE
fix: serialize desktop update install lifecycle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import {
 } from './runtime-paths.ts'
 import { resolveProductVersion } from './version.ts'
 import { DesktopUpdateManager, detectPackageType } from './update-manager.ts'
+import { scheduleImmediateUpdateInstall, singleFlight } from './update-lifecycle.ts'
 
 const PRODUCT_NAME = 'Oh-DSH Desktop'
 const LEGACY_DATA_DIRECTORY = 'Oh-DSH-Desktop'
@@ -403,7 +404,7 @@ async function openUpdateWindow(): Promise<void> {
   void manager.check()
 }
 
-async function stopForApplicationQuit(): Promise<void> {
+const stopForApplicationQuit = singleFlight(async (): Promise<void> => {
   await Promise.allSettled([
     runtime?.stop() ?? Promise.resolve(),
     stopPreviewSurface(),
@@ -420,7 +421,7 @@ async function stopForApplicationQuit(): Promise<void> {
   runtimeOrigin = undefined
   marketplaceAgentGateway = undefined
   if (updateWindow !== undefined && !updateWindow.isDestroyed()) updateWindow.close()
-}
+})
 
 function normalizeWorkspacePaths(paths: readonly string[]): string[] {
   const normalized: string[] = []
@@ -795,16 +796,13 @@ function installIpc(): void {
     const installNow = command.type === 'install-now'
       && current.status === 'downloaded'
       && current.platform !== 'deb'
-    const result = await manager.command(command)
     if (installNow) {
-      if (result.status === 'error') {
-        quittingForUpdate = false
-      } else {
+      return await scheduleImmediateUpdateInstall(manager, () => {
         quittingForUpdate = true
-        await stopForApplicationQuit()
-      }
+        app.quit()
+      })
     }
-    return result
+    return await manager.command(command)
   })
   ipcMain.handle('desktop:get-info', event => {
     const preview = previewWindow?.webContents.id === event.sender.id ? previewIdentity ?? null : null

--- a/src/update-lifecycle.ts
+++ b/src/update-lifecycle.ts
@@ -1,0 +1,30 @@
+import type { DesktopUpdateCommand, DesktopUpdateState } from './contracts.ts'
+
+interface UpdateCommandTarget {
+  command(command: DesktopUpdateCommand): Promise<DesktopUpdateState>
+}
+
+/** Route an immediate install through the application's before-quit lifecycle. */
+export async function scheduleImmediateUpdateInstall(
+  manager: UpdateCommandTarget,
+  quit: () => void,
+): Promise<DesktopUpdateState> {
+  const state = await manager.command({ type: 'install-on-quit' })
+  if (state.status === 'scheduled') quit()
+  return state
+}
+
+/** Ensure concurrent callers share one asynchronous cleanup operation. */
+export function singleFlight<T>(operation: () => Promise<T>): () => Promise<T> {
+  let pending: Promise<T> | undefined
+  return () => {
+    if (pending !== undefined) return pending
+    const current = operation()
+    pending = current
+    void current.then(
+      () => { if (pending === current) pending = undefined },
+      () => { if (pending === current) pending = undefined },
+    )
+    return current
+  }
+}

--- a/tests/update-lifecycle.test.ts
+++ b/tests/update-lifecycle.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { DesktopUpdateState } from '../src/contracts.ts'
+import { scheduleImmediateUpdateInstall, singleFlight } from '../src/update-lifecycle.ts'
+
+function scheduledState(): DesktopUpdateState {
+  return {
+    status: 'scheduled',
+    currentVersion: '1.1.0',
+    latestVersion: '1.2.0',
+    releaseName: 'v1.2.0',
+    releaseNotes: 'notes',
+    size: 100,
+    platform: 'mac',
+    releaseUrl: 'https://github.com/hust-open-atom-club/oh-dsh/releases/tag/v1.2.0',
+  }
+}
+
+test('immediate update requests install-on-quit before quitting', async () => {
+  const commands: string[] = []
+  let quitCalls = 0
+  const result = await scheduleImmediateUpdateInstall({
+    command: async command => {
+      commands.push(command.type)
+      return scheduledState()
+    },
+  }, () => { quitCalls += 1 })
+
+  assert.equal(result.status, 'scheduled')
+  assert.deepEqual(commands, ['install-on-quit'])
+  assert.equal(quitCalls, 1)
+})
+
+test('immediate update does not quit when scheduling fails', async () => {
+  let quitCalls = 0
+  const errorState: DesktopUpdateState = {
+    status: 'error',
+    currentVersion: '1.1.0',
+    stage: 'install',
+    code: 'UPDATE_FAILED',
+    message: 'cannot schedule update',
+    releaseUrl: null,
+    retryable: true,
+  }
+  const result = await scheduleImmediateUpdateInstall({
+    command: async () => errorState,
+  }, () => { quitCalls += 1 })
+
+  assert.equal(result.status, 'error')
+  assert.equal(quitCalls, 0)
+})
+
+test('single-flight cleanup shares concurrent calls and resets after completion', async () => {
+  let starts = 0
+  let release!: () => void
+  const gate = new Promise<void>(resolve => { release = resolve })
+  const cleanup = singleFlight(async () => {
+    starts += 1
+    await gate
+    return starts
+  })
+
+  const first = cleanup()
+  const second = cleanup()
+  assert.equal(first, second)
+  assert.equal(starts, 1)
+
+  release()
+  assert.deepEqual(await Promise.all([first, second]), [1, 1])
+  assert.equal(await cleanup(), 2)
+})


### PR DESCRIPTION
## Summary
- route Restart and Install Now through the existing before-quit update lifecycle
- serialize application shutdown cleanup so concurrent quit paths share one teardown
- cover immediate scheduling and single-flight cleanup with regression tests

## Validation
- pnpm run typecheck
- pnpm test (126 passed)
- pnpm run build
- lifecycle harness: active runtime and marketplace cleanup each ran once before updater installation