### PR TITLE
runtime: resolve shared home edge cases

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { posix, win32 } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { OH_DSH_HOME_ENV } from './data-root.ts'
+import { OH_DSH_HOME_ENV, resolveOhDshHome } from './data-root.ts'
 import { UsageError } from './errors.ts'
 import { main as runTui } from './tui.ts'
 import { main as runWeb } from './web.ts'
@@ -83,7 +83,7 @@ function macOpenEnvironment(env: NodeJS.ProcessEnv): string[] {
   const ohDshHome = env[OH_DSH_HOME_ENV]
   return ohDshHome === undefined || ohDshHome === ''
     ? []
-    : ['--env', `${OH_DSH_HOME_ENV}=${ohDshHome}`]
+    : ['--env', `${OH_DSH_HOME_ENV}=${resolveOhDshHome(env)}`]
 }
 
 /** Resolve one desktop launch without starting a process. */

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -145,41 +145,47 @@ function copyEntry(
   source: string,
   destination: string,
   roots?: CopyRoots,
-): void {
+): boolean {
   const sourceStat = stat(source)
-  if (sourceStat === undefined) return
+  if (sourceStat === undefined) return true
   const destinationStat = stat(destination)
 
   if (sourceStat.isDirectory()) {
-    if (destinationStat !== undefined && !destinationStat.isDirectory()) return
+    if (destinationStat !== undefined && !destinationStat.isDirectory()) return true
     mkdirSync(destination, { recursive: true, mode: sourceStat.mode & 0o777 })
     const copyRoots = roots ?? {
       destination: realpathSync(destination),
       source: realpathSync(source),
     }
+    let copied = true
     for (const entry of readdirSync(source)) {
-      copyEntry(join(source, entry), join(destination, entry), copyRoots)
+      copied = copyEntry(
+        join(source, entry),
+        join(destination, entry),
+        copyRoots,
+      ) && copied
     }
-    return
+    return copied
   }
 
   if (sourceStat.isFile()) {
-    if (destinationStat !== undefined && !destinationStat.isFile()) return
-    if (destinationStat !== undefined) return
+    if (destinationStat !== undefined && !destinationStat.isFile()) return true
+    if (destinationStat !== undefined) return true
     mkdirSync(dirname(destination), { recursive: true, mode: 0o700 })
     try {
       copyFileSync(source, destination, fsConstants.COPYFILE_EXCL)
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
     }
-    return
+    return true
   }
 
-  if (!sourceStat.isSymbolicLink() || destinationStat !== undefined) return
+  if (!sourceStat.isSymbolicLink() || destinationStat !== undefined) return true
   mkdirSync(dirname(destination), { recursive: true, mode: 0o700 })
   const targetStat = followedStat(source)
   const linkTarget = relocatedLinkTarget(source, destination, roots, targetStat)
   if (process.platform === 'win32') {
+    if (targetStat === undefined) return false
     if (targetStat?.isDirectory() === true) {
       symlinkSync(linkTarget.absolute, destination, 'junction')
     } else if (targetStat?.isFile() === true) {
@@ -189,7 +195,7 @@ function copyEntry(
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
       }
     }
-    return
+    return true
   }
   try {
     symlinkSync(
@@ -200,6 +206,7 @@ function copyEntry(
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
   }
+  return true
 }
 
 function copyDirectoryContents(
@@ -215,11 +222,16 @@ function copyDirectoryContents(
   if (sourceRoot === destinationRoot) return true
   if (containsPath(sourceRoot, destinationRoot)) return false
   const roots = { destination: destinationRoot, source: sourceRoot }
+  let copied = true
   for (const entry of readdirSync(source)) {
     if (options.exclude?.has(entry) === true) continue
-    copyEntry(join(source, entry), join(destination, entry), roots)
+    copied = copyEntry(
+      join(source, entry),
+      join(destination, entry),
+      roots,
+    ) && copied
   }
-  return true
+  return copied
 }
 
 function completeMigration(root: string, name: string): void {
@@ -249,10 +261,15 @@ export function migrateLegacyDesktopState(input: {
   const legacyDshHome = join(legacyRoot, 'dsh')
   if (stat(legacyDshHome) !== undefined
     && !copyDirectoryContents(legacyDshHome, input.ohDshHome)) return false
+  let copiedSharedEntries = true
   for (const entry of DESKTOP_SHARED_ENTRIES) {
     if (entry === 'dsh') continue
-    copyEntry(join(legacyRoot, entry), join(input.ohDshHome, entry))
+    copiedSharedEntries = copyEntry(
+      join(legacyRoot, entry),
+      join(input.ohDshHome, entry),
+    ) && copiedSharedEntries
   }
+  if (!copiedSharedEntries) return false
   if (!copyDirectoryContents(
     legacyRoot,
     desktopElectronDataRoot(input.ohDshHome),
@@ -288,13 +305,17 @@ export function migrateLegacyWebState(input: {
     const copiedLegacyDshHome = !hasLegacyDshHome
       || copyDirectoryContents(legacyDshHome, input.dataRoot)
     let foundLegacyState = hasLegacyDshHome
+    let copiedSharedEntries = true
     for (const entry of WEB_SHARED_ENTRIES) {
       const source = join(legacyDefault, entry)
       if (stat(source) === undefined) continue
       foundLegacyState = true
-      copyEntry(source, join(input.dataRoot, entry))
+      copiedSharedEntries = copyEntry(
+        source,
+        join(input.dataRoot, entry),
+      ) && copiedSharedEntries
     }
-    if (foundLegacyState && copiedLegacyDshHome) {
+    if (foundLegacyState && copiedLegacyDshHome && copiedSharedEntries) {
       completeMigration(input.dataRoot, WEB_DEFAULT_MIGRATION)
       migrated = true
     }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
 import { test } from 'node:test'
 import {
   desktopLaunchSpec,
@@ -120,6 +121,17 @@ test('macOS installed launches inherit the shared Oh-DSH state root', () => {
       '/Applications/Oh-DSH Desktop.app',
       '--args',
       '--inspect',
+    ],
+    command: '/usr/bin/open',
+  })
+  assert.deepEqual(desktopLaunchSpec([], {
+    OH_DSH_HOME: './relative-state',
+  }, 'darwin'), {
+    args: [
+      '--env',
+      `OH_DSH_HOME=${resolve('./relative-state')}`,
+      '-a',
+      'Oh-DSH Desktop',
     ],
     command: '/usr/bin/open',
   })

--- a/tests/data-root.test.ts
+++ b/tests/data-root.test.ts
@@ -211,3 +211,38 @@ test('legacy directory links are followed before migration completes', t => {
     'web',
   )
 })
+
+test('unavailable Windows junctions keep migration retryable', t => {
+  if (process.platform !== 'win32') {
+    t.skip('Windows junction behavior')
+    return
+  }
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'ohdsh-junction-retry-'))
+  t.after(() => rmSync(temporaryRoot, { recursive: true, force: true }))
+
+  const appDataRoot = join(temporaryRoot, 'app-data')
+  const legacyRoot = join(appDataRoot, 'Oh-DSH-Desktop')
+  const dependencyTarget = join(temporaryRoot, 'dependency')
+  const dependencyLink = join(legacyRoot, 'dsh', 'node_modules', 'linked')
+  const sharedRoot = join(temporaryRoot, 'shared')
+  mkdirSync(dirname(dependencyLink), { recursive: true })
+  symlinkSync(dependencyTarget, dependencyLink, 'junction')
+
+  assert.equal(migrateLegacyDesktopState({
+    appDataRoot,
+    env: {},
+    ohDshHome: sharedRoot,
+  }), false)
+
+  write(join(dependencyTarget, 'package.json'), '{"name":"linked"}\n')
+  assert.equal(migrateLegacyDesktopState({
+    appDataRoot,
+    env: {},
+    ohDshHome: sharedRoot,
+  }), true)
+  assert.equal(
+    readFileSync(join(sharedRoot, 'node_modules', 'linked', 'package.json'), 'utf8'),
+    '{"name":"linked"}\n',
+  )
+})


### PR DESCRIPTION
## Summary

- resolve relative `OH_DSH_HOME` values before launching the macOS app
- keep migrations retryable when Windows link targets are unavailable
- cover both edge cases with launcher and migration regression tests

## Verification

- `node --test tests/cli.test.ts tests/data-root.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Stack

This PR targets the branch for #52 so the review fixes remain independently
reviewable before the parent PR is merged.
