### PR TITLE
runtime: resolve shared home edge cases

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { posix, win32 } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { OH_DSH_HOME_ENV } from './data-root.ts'
+import { OH_DSH_HOME_ENV, resolveOhDshHome } from './data-root.ts'
 import { UsageError } from './errors.ts'
 import { main as runTui } from './tui.ts'
 import { main as runWeb } from './web.ts'
@@ -83,7 +83,7 @@ function macOpenEnvironment(env: NodeJS.ProcessEnv): string[] {
   const ohDshHome = env[OH_DSH_HOME_ENV]
   return ohDshHome === undefined || ohDshHome === ''
     ? []
-    : ['--env', `${OH_DSH_HOME_ENV}=${ohDshHome}`]
+    : ['--env', `${OH_DSH_HOME_ENV}=${resolveOhDshHome(env)}`]
 }
 
 /** Resolve one desktop launch without starting a process. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { posix, win32 } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { OH_DSH_HOME_ENV, resolveOhDshHome } from './data-root.ts'
+import { OH_DSH_HOME_ENV } from './data-root.ts'
 import { UsageError } from './errors.ts'
 import { main as runTui } from './tui.ts'
 import { main as runWeb } from './web.ts'
@@ -83,7 +83,7 @@ function macOpenEnvironment(env: NodeJS.ProcessEnv): string[] {
   const ohDshHome = env[OH_DSH_HOME_ENV]
   return ohDshHome === undefined || ohDshHome === ''
     ? []
-    : ['--env', `${OH_DSH_HOME_ENV}=${resolveOhDshHome(env)}`]
+    : ['--env', `${OH_DSH_HOME_ENV}=${posix.resolve(ohDshHome)}`]
 }
 
 /** Resolve one desktop launch without starting a process. */

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -47,6 +47,22 @@ const WEB_SHARED_ENTRIES = new Set([
   'skins.json',
 ])
 
+/** Outcome of a legacy-state migration attempt. */
+export interface LegacyStateMigrationResult {
+  complete: boolean
+  migrated: boolean
+}
+
+const NO_MIGRATION: LegacyStateMigrationResult = {
+  complete: true,
+  migrated: false,
+}
+
+const INCOMPLETE_MIGRATION: LegacyStateMigrationResult = {
+  complete: false,
+  migrated: false,
+}
+
 /** Resolve the default Oh-DSH state root for one user account. */
 export function defaultOhDshHome(userHome: string = homedir()): string {
   return join(userHome, DEFAULT_OH_DSH_HOME_DIRECTORY)
@@ -250,17 +266,21 @@ export function migrateLegacyDesktopState(input: {
   appDataRoot: string
   env?: NodeJS.ProcessEnv
   ohDshHome: string
-}): boolean {
-  if (hasOhDshHomeOverride(input.env ?? process.env)) return false
-  if (existsSync(migrationMarker(input.ohDshHome, DESKTOP_MIGRATION))) return false
+}): LegacyStateMigrationResult {
+  if (hasOhDshHomeOverride(input.env ?? process.env)) return NO_MIGRATION
+  if (existsSync(migrationMarker(input.ohDshHome, DESKTOP_MIGRATION))) {
+    return NO_MIGRATION
+  }
 
   const legacyRoot = join(input.appDataRoot, LEGACY_DESKTOP_DATA_DIRECTORY)
   const legacyStat = followedStat(legacyRoot)
-  if (legacyStat === undefined || !legacyStat.isDirectory()) return false
+  if (legacyStat === undefined || !legacyStat.isDirectory()) return NO_MIGRATION
 
   const legacyDshHome = join(legacyRoot, 'dsh')
   if (stat(legacyDshHome) !== undefined
-    && !copyDirectoryContents(legacyDshHome, input.ohDshHome)) return false
+    && !copyDirectoryContents(legacyDshHome, input.ohDshHome)) {
+    return INCOMPLETE_MIGRATION
+  }
   let copiedSharedEntries = true
   for (const entry of DESKTOP_SHARED_ENTRIES) {
     if (entry === 'dsh') continue
@@ -269,14 +289,14 @@ export function migrateLegacyDesktopState(input: {
       join(input.ohDshHome, entry),
     ) && copiedSharedEntries
   }
-  if (!copiedSharedEntries) return false
+  if (!copiedSharedEntries) return INCOMPLETE_MIGRATION
   if (!copyDirectoryContents(
     legacyRoot,
     desktopElectronDataRoot(input.ohDshHome),
     { exclude: DESKTOP_SHARED_ENTRIES },
-  )) return false
+  )) return INCOMPLETE_MIGRATION
   completeMigration(input.ohDshHome, DESKTOP_MIGRATION)
-  return true
+  return { complete: true, migrated: true }
 }
 
 /**
@@ -286,13 +306,15 @@ export function migrateLegacyDesktopState(input: {
 export function migrateLegacyWebState(input: {
   dataRoot: string
   legacyDefaultDataRoot?: string
-}): boolean {
+}): LegacyStateMigrationResult {
   let migrated = false
   const flatMarker = migrationMarker(input.dataRoot, WEB_FLAT_MIGRATION)
   if (!existsSync(flatMarker)) {
     const flatSource = join(input.dataRoot, 'dsh')
     if (stat(flatSource) !== undefined) {
-      if (!copyDirectoryContents(flatSource, input.dataRoot)) return false
+      if (!copyDirectoryContents(flatSource, input.dataRoot)) {
+        return { complete: false, migrated }
+      }
       completeMigration(input.dataRoot, WEB_FLAT_MIGRATION)
       migrated = true
     }
@@ -307,7 +329,7 @@ export function migrateLegacyWebState(input: {
     const hasLegacyDshHome = stat(legacyDshHome) !== undefined
     const copiedLegacyDshHome = !hasLegacyDshHome
       || copyDirectoryContents(legacyDshHome, input.dataRoot)
-    if (!copiedLegacyDshHome) return migrated
+    if (!copiedLegacyDshHome) return { complete: false, migrated }
     let foundLegacyState = hasLegacyDshHome
     let copiedSharedEntries = true
     for (const entry of WEB_SHARED_ENTRIES) {
@@ -319,10 +341,11 @@ export function migrateLegacyWebState(input: {
         join(input.dataRoot, entry),
       ) && copiedSharedEntries
     }
+    if (!copiedSharedEntries) return { complete: false, migrated }
     if (foundLegacyState && copiedSharedEntries) {
       completeMigration(input.dataRoot, WEB_DEFAULT_MIGRATION)
       migrated = true
     }
   }
-  return migrated
+  return { complete: true, migrated }
 }

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -145,41 +145,47 @@ function copyEntry(
   source: string,
   destination: string,
   roots?: CopyRoots,
-): void {
+): boolean {
   const sourceStat = stat(source)
-  if (sourceStat === undefined) return
+  if (sourceStat === undefined) return true
   const destinationStat = stat(destination)
 
   if (sourceStat.isDirectory()) {
-    if (destinationStat !== undefined && !destinationStat.isDirectory()) return
+    if (destinationStat !== undefined && !destinationStat.isDirectory()) return true
     mkdirSync(destination, { recursive: true, mode: sourceStat.mode & 0o777 })
     const copyRoots = roots ?? {
       destination: realpathSync(destination),
       source: realpathSync(source),
     }
+    let copied = true
     for (const entry of readdirSync(source)) {
-      copyEntry(join(source, entry), join(destination, entry), copyRoots)
+      copied = copyEntry(
+        join(source, entry),
+        join(destination, entry),
+        copyRoots,
+      ) && copied
     }
-    return
+    return copied
   }
 
   if (sourceStat.isFile()) {
-    if (destinationStat !== undefined && !destinationStat.isFile()) return
-    if (destinationStat !== undefined) return
+    if (destinationStat !== undefined && !destinationStat.isFile()) return true
+    if (destinationStat !== undefined) return true
     mkdirSync(dirname(destination), { recursive: true, mode: 0o700 })
     try {
       copyFileSync(source, destination, fsConstants.COPYFILE_EXCL)
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
     }
-    return
+    return true
   }
 
-  if (!sourceStat.isSymbolicLink() || destinationStat !== undefined) return
+  if (!sourceStat.isSymbolicLink() || destinationStat !== undefined) return true
   mkdirSync(dirname(destination), { recursive: true, mode: 0o700 })
   const targetStat = followedStat(source)
   const linkTarget = relocatedLinkTarget(source, destination, roots, targetStat)
   if (process.platform === 'win32') {
+    if (targetStat === undefined) return false
     if (targetStat?.isDirectory() === true) {
       symlinkSync(linkTarget.absolute, destination, 'junction')
     } else if (targetStat?.isFile() === true) {
@@ -189,7 +195,7 @@ function copyEntry(
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
       }
     }
-    return
+    return true
   }
   try {
     symlinkSync(
@@ -200,6 +206,7 @@ function copyEntry(
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
   }
+  return true
 }
 
 function copyDirectoryContents(
@@ -215,11 +222,16 @@ function copyDirectoryContents(
   if (sourceRoot === destinationRoot) return true
   if (containsPath(sourceRoot, destinationRoot)) return false
   const roots = { destination: destinationRoot, source: sourceRoot }
+  let copied = true
   for (const entry of readdirSync(source)) {
     if (options.exclude?.has(entry) === true) continue
-    copyEntry(join(source, entry), join(destination, entry), roots)
+    copied = copyEntry(
+      join(source, entry),
+      join(destination, entry),
+      roots,
+    ) && copied
   }
-  return true
+  return copied
 }
 
 function completeMigration(root: string, name: string): void {
@@ -249,10 +261,15 @@ export function migrateLegacyDesktopState(input: {
   const legacyDshHome = join(legacyRoot, 'dsh')
   if (stat(legacyDshHome) !== undefined
     && !copyDirectoryContents(legacyDshHome, input.ohDshHome)) return false
+  let copiedSharedEntries = true
   for (const entry of DESKTOP_SHARED_ENTRIES) {
     if (entry === 'dsh') continue
-    copyEntry(join(legacyRoot, entry), join(input.ohDshHome, entry))
+    copiedSharedEntries = copyEntry(
+      join(legacyRoot, entry),
+      join(input.ohDshHome, entry),
+    ) && copiedSharedEntries
   }
+  if (!copiedSharedEntries) return false
   if (!copyDirectoryContents(
     legacyRoot,
     desktopElectronDataRoot(input.ohDshHome),
@@ -288,13 +305,17 @@ export function migrateLegacyWebState(input: {
     const copiedLegacyDshHome = !hasLegacyDshHome
       || copyDirectoryContents(legacyDshHome, input.dataRoot)
     let foundLegacyState = hasLegacyDshHome
+    let copiedSharedEntries = true
     for (const entry of WEB_SHARED_ENTRIES) {
       const source = join(legacyDefault, entry)
       if (stat(source) === undefined) continue
       foundLegacyState = true
-      copyEntry(source, join(input.dataRoot, entry))
+      copiedSharedEntries = copyEntry(
+        source,
+        join(input.dataRoot, entry),
+      ) && copiedSharedEntries
     }
-    if (foundLegacyState && copiedLegacyDshHome) {
+    if (foundLegacyState && copiedLegacyDshHome && copiedSharedEntries) {
       completeMigration(input.dataRoot, WEB_DEFAULT_MIGRATION)
       migrated = true
     }

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -289,10 +289,13 @@ export function migrateLegacyWebState(input: {
 }): boolean {
   let migrated = false
   const flatMarker = migrationMarker(input.dataRoot, WEB_FLAT_MIGRATION)
-  if (!existsSync(flatMarker)
-    && copyDirectoryContents(join(input.dataRoot, 'dsh'), input.dataRoot)) {
-    completeMigration(input.dataRoot, WEB_FLAT_MIGRATION)
-    migrated = true
+  if (!existsSync(flatMarker)) {
+    const flatSource = join(input.dataRoot, 'dsh')
+    if (stat(flatSource) !== undefined) {
+      if (!copyDirectoryContents(flatSource, input.dataRoot)) return false
+      completeMigration(input.dataRoot, WEB_FLAT_MIGRATION)
+      migrated = true
+    }
   }
 
   const legacyDefault = input.legacyDefaultDataRoot

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -307,6 +307,7 @@ export function migrateLegacyWebState(input: {
     const hasLegacyDshHome = stat(legacyDshHome) !== undefined
     const copiedLegacyDshHome = !hasLegacyDshHome
       || copyDirectoryContents(legacyDshHome, input.dataRoot)
+    if (!copiedLegacyDshHome) return migrated
     let foundLegacyState = hasLegacyDshHome
     let copiedSharedEntries = true
     for (const entry of WEB_SHARED_ENTRIES) {
@@ -318,7 +319,7 @@ export function migrateLegacyWebState(input: {
         join(input.dataRoot, entry),
       ) && copiedSharedEntries
     }
-    if (foundLegacyState && copiedLegacyDshHome && copiedSharedEntries) {
+    if (foundLegacyState && copiedSharedEntries) {
       completeMigration(input.dataRoot, WEB_DEFAULT_MIGRATION)
       migrated = true
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -843,11 +843,17 @@ async function bootstrap(): Promise<void> {
   app.setName(PRODUCT_NAME)
   const ohDshHome = resolveOhDshHome(process.env)
   const electronDataRoot = desktopElectronDataRoot(ohDshHome)
-  migrateLegacyDesktopState({
+  const migration = migrateLegacyDesktopState({
     appDataRoot: app.getPath('appData'),
     env: process.env,
     ohDshHome,
   })
+  if (!migration.complete) {
+    throw new Error(
+      `legacy Desktop state migration under ${ohDshHome} is incomplete; `
+      + 'restore unavailable link targets and restart',
+    )
+  }
   mkdirSync(electronDataRoot, { recursive: true, mode: 0o700 })
   app.setPath('userData', electronDataRoot)
   app.setAboutPanelOptions({

--- a/src/web.ts
+++ b/src/web.ts
@@ -231,12 +231,18 @@ export async function main(
   }
 
   mkdirSync(dataRoot, { recursive: true, mode: 0o700 })
-  migrateLegacyWebState({
+  const migration = migrateLegacyWebState({
     dataRoot,
     ...(!hasOhDshHomeOverride(env) && dataRoot === defaultDataRoot
       ? { legacyDefaultDataRoot: legacyWebDataRoot() }
       : {}),
   })
+  if (!migration.complete) {
+    throw new Error(
+      `legacy Web state migration under ${dataRoot} is incomplete; `
+      + 'restore unavailable link targets and retry',
+    )
+  }
   ensureWebProfile(dataRoot)
 
   const logTail: string[] = []

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
 import { test } from 'node:test'
 import {
   desktopLaunchSpec,
@@ -120,6 +121,17 @@ test('macOS installed launches inherit the shared Oh-DSH state root', () => {
       '/Applications/Oh-DSH Desktop.app',
       '--args',
       '--inspect',
+    ],
+    command: '/usr/bin/open',
+  })
+  assert.deepEqual(desktopLaunchSpec([], {
+    OH_DSH_HOME: './relative-state',
+  }, 'darwin'), {
+    args: [
+      '--env',
+      `OH_DSH_HOME=${resolve('./relative-state')}`,
+      '-a',
+      'Oh-DSH Desktop',
     ],
     command: '/usr/bin/open',
   })

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { resolve } from 'node:path'
+import { posix } from 'node:path'
 import { test } from 'node:test'
 import {
   desktopLaunchSpec,
@@ -129,7 +129,7 @@ test('macOS installed launches inherit the shared Oh-DSH state root', () => {
   }, 'darwin'), {
     args: [
       '--env',
-      `OH_DSH_HOME=${resolve('./relative-state')}`,
+      `OH_DSH_HOME=${posix.resolve('./relative-state')}`,
       '-a',
       'Oh-DSH Desktop',
     ],

--- a/tests/data-root.test.ts
+++ b/tests/data-root.test.ts
@@ -20,6 +20,10 @@ import {
   resolveOhDshHome,
 } from '../src/data-root.ts'
 
+const MIGRATED = { complete: true, migrated: true }
+const NO_MIGRATION = { complete: true, migrated: false }
+const INCOMPLETE_MIGRATION = { complete: false, migrated: false }
+
 function write(path: string, value: string): void {
   mkdirSync(dirname(path), { recursive: true })
   writeFileSync(path, value)
@@ -54,11 +58,11 @@ test('legacy Desktop state migrates once without replacing shared state', t => {
   write(join(legacyRoot, 'Local Storage', 'leveldb', 'state'), 'legacy ui')
   write(join(sharedRoot, 'desktop', 'Local Storage', 'leveldb', 'state'), 'new ui')
 
-  assert.equal(migrateLegacyDesktopState({
+  assert.deepEqual(migrateLegacyDesktopState({
     appDataRoot,
     env: {},
     ohDshHome: sharedRoot,
-  }), true)
+  }), MIGRATED)
   assert.equal(
     readFileSync(join(sharedRoot, 'sessions', 'legacy.json'), 'utf8'),
     'legacy',
@@ -79,11 +83,11 @@ test('legacy Desktop state migrates once without replacing shared state', t => {
   assert.equal(existsSync(join(legacyRoot, 'dsh', 'sessions', 'legacy.json')), true)
 
   write(join(legacyRoot, 'dsh', 'sessions', 'late.json'), 'late')
-  assert.equal(migrateLegacyDesktopState({
+  assert.deepEqual(migrateLegacyDesktopState({
     appDataRoot,
     env: {},
     ohDshHome: sharedRoot,
-  }), false)
+  }), NO_MIGRATION)
   assert.equal(existsSync(join(sharedRoot, 'sessions', 'late.json')), false)
 })
 
@@ -101,10 +105,10 @@ test('legacy Web roots flatten once without replacing shared state', t => {
   write(join(legacyDefaultRoot, 'sidebar.json'), 'legacy sidebar')
   write(join(sharedRoot, 'skins.json'), 'current skin')
 
-  assert.equal(migrateLegacyWebState({
+  assert.deepEqual(migrateLegacyWebState({
     dataRoot: sharedRoot,
     legacyDefaultDataRoot: legacyDefaultRoot,
-  }), true)
+  }), MIGRATED)
   assert.equal(
     readFileSync(join(sharedRoot, 'sessions', 'current.json'), 'utf8'),
     'current',
@@ -128,10 +132,10 @@ test('legacy Web roots flatten once without replacing shared state', t => {
   write(join(sharedRoot, 'dsh', 'sessions', 'late-flat.json'), 'late')
   write(join(legacyDefaultRoot, 'dsh', 'sessions', 'late-default.json'), 'late')
   write(join(legacyDefaultRoot, 'sidebar.json'), 'late sidebar')
-  assert.equal(migrateLegacyWebState({
+  assert.deepEqual(migrateLegacyWebState({
     dataRoot: sharedRoot,
     legacyDefaultDataRoot: legacyDefaultRoot,
-  }), false)
+  }), NO_MIGRATION)
   assert.equal(existsSync(join(sharedRoot, 'sessions', 'late-flat.json')), false)
   assert.equal(existsSync(join(sharedRoot, 'sessions', 'late-default.json')), false)
   assert.equal(
@@ -174,11 +178,11 @@ test('legacy directory links are followed before migration completes', t => {
     process.platform === 'win32' ? 'junction' : 'dir',
   )
 
-  assert.equal(migrateLegacyDesktopState({
+  assert.deepEqual(migrateLegacyDesktopState({
     appDataRoot,
     env: {},
     ohDshHome: sharedDesktopRoot,
-  }), true)
+  }), MIGRATED)
   assert.equal(
     readFileSync(join(sharedDesktopRoot, 'sessions', 'desktop.json'), 'utf8'),
     'desktop',
@@ -205,7 +209,10 @@ test('legacy directory links are followed before migration completes', t => {
     process.platform === 'win32' ? 'junction' : 'dir',
   )
 
-  assert.equal(migrateLegacyWebState({ dataRoot: sharedWebRoot }), true)
+  assert.deepEqual(
+    migrateLegacyWebState({ dataRoot: sharedWebRoot }),
+    MIGRATED,
+  )
   assert.equal(
     readFileSync(join(sharedWebRoot, 'sessions', 'web.json'), 'utf8'),
     'web',
@@ -229,18 +236,18 @@ test('unavailable Windows junctions keep migration retryable', t => {
   mkdirSync(dirname(dependencyLink), { recursive: true })
   symlinkSync(dependencyTarget, dependencyLink, 'junction')
 
-  assert.equal(migrateLegacyDesktopState({
+  assert.deepEqual(migrateLegacyDesktopState({
     appDataRoot,
     env: {},
     ohDshHome: sharedRoot,
-  }), false)
+  }), INCOMPLETE_MIGRATION)
 
   write(join(dependencyTarget, 'package.json'), '{"name":"linked"}\n')
-  assert.equal(migrateLegacyDesktopState({
+  assert.deepEqual(migrateLegacyDesktopState({
     appDataRoot,
     env: {},
     ohDshHome: sharedRoot,
-  }), true)
+  }), MIGRATED)
   assert.equal(
     readFileSync(join(sharedRoot, 'node_modules', 'linked', 'package.json'), 'utf8'),
     '{"name":"linked"}\n',
@@ -267,17 +274,17 @@ test('incomplete Web flattening blocks lower-priority imports', t => {
     '{"name":"lower-priority"}\n',
   )
 
-  assert.equal(migrateLegacyWebState({
+  assert.deepEqual(migrateLegacyWebState({
     dataRoot: sharedRoot,
     legacyDefaultDataRoot: legacyRoot,
-  }), false)
+  }), INCOMPLETE_MIGRATION)
   assert.equal(existsSync(join(sharedRoot, 'node_modules', 'linked')), false)
 
   write(join(dependencyTarget, 'package.json'), '{"name":"preferred"}\n')
-  assert.equal(migrateLegacyWebState({
+  assert.deepEqual(migrateLegacyWebState({
     dataRoot: sharedRoot,
     legacyDefaultDataRoot: legacyRoot,
-  }), true)
+  }), MIGRATED)
   assert.equal(
     readFileSync(join(sharedRoot, 'node_modules', 'linked', 'package.json'), 'utf8'),
     '{"name":"preferred"}\n',
@@ -301,17 +308,17 @@ test('incomplete legacy Web DSH blocks top-level preference imports', t => {
   symlinkSync(preferenceTarget, preferenceLink, 'junction')
   write(join(legacyRoot, 'sidebar.json', 'value'), 'lower-priority')
 
-  assert.equal(migrateLegacyWebState({
+  assert.deepEqual(migrateLegacyWebState({
     dataRoot: sharedRoot,
     legacyDefaultDataRoot: legacyRoot,
-  }), false)
+  }), INCOMPLETE_MIGRATION)
   assert.equal(existsSync(join(sharedRoot, 'sidebar.json')), false)
 
   write(join(preferenceTarget, 'value'), 'preferred')
-  assert.equal(migrateLegacyWebState({
+  assert.deepEqual(migrateLegacyWebState({
     dataRoot: sharedRoot,
     legacyDefaultDataRoot: legacyRoot,
-  }), true)
+  }), MIGRATED)
   assert.equal(
     readFileSync(join(sharedRoot, 'sidebar.json', 'value'), 'utf8'),
     'preferred',

--- a/tests/data-root.test.ts
+++ b/tests/data-root.test.ts
@@ -283,3 +283,37 @@ test('incomplete Web flattening blocks lower-priority imports', t => {
     '{"name":"preferred"}\n',
   )
 })
+
+test('incomplete legacy Web DSH blocks top-level preference imports', t => {
+  if (process.platform !== 'win32') {
+    t.skip('Windows junction behavior')
+    return
+  }
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'ohdsh-web-default-retry-'))
+  t.after(() => rmSync(temporaryRoot, { recursive: true, force: true }))
+
+  const sharedRoot = join(temporaryRoot, 'shared')
+  const legacyRoot = join(temporaryRoot, 'legacy-web')
+  const preferenceTarget = join(temporaryRoot, 'preferred-sidebar')
+  const preferenceLink = join(legacyRoot, 'dsh', 'sidebar.json')
+  mkdirSync(dirname(preferenceLink), { recursive: true })
+  symlinkSync(preferenceTarget, preferenceLink, 'junction')
+  write(join(legacyRoot, 'sidebar.json', 'value'), 'lower-priority')
+
+  assert.equal(migrateLegacyWebState({
+    dataRoot: sharedRoot,
+    legacyDefaultDataRoot: legacyRoot,
+  }), false)
+  assert.equal(existsSync(join(sharedRoot, 'sidebar.json')), false)
+
+  write(join(preferenceTarget, 'value'), 'preferred')
+  assert.equal(migrateLegacyWebState({
+    dataRoot: sharedRoot,
+    legacyDefaultDataRoot: legacyRoot,
+  }), true)
+  assert.equal(
+    readFileSync(join(sharedRoot, 'sidebar.json', 'value'), 'utf8'),
+    'preferred',
+  )
+})

--- a/tests/data-root.test.ts
+++ b/tests/data-root.test.ts
@@ -246,3 +246,40 @@ test('unavailable Windows junctions keep migration retryable', t => {
     '{"name":"linked"}\n',
   )
 })
+
+test('incomplete Web flattening blocks lower-priority imports', t => {
+  if (process.platform !== 'win32') {
+    t.skip('Windows junction behavior')
+    return
+  }
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'ohdsh-web-retry-'))
+  t.after(() => rmSync(temporaryRoot, { recursive: true, force: true }))
+
+  const sharedRoot = join(temporaryRoot, 'shared')
+  const legacyRoot = join(temporaryRoot, 'legacy-web')
+  const dependencyTarget = join(temporaryRoot, 'dependency')
+  const dependencyLink = join(sharedRoot, 'dsh', 'node_modules', 'linked')
+  mkdirSync(dirname(dependencyLink), { recursive: true })
+  symlinkSync(dependencyTarget, dependencyLink, 'junction')
+  write(
+    join(legacyRoot, 'dsh', 'node_modules', 'linked', 'package.json'),
+    '{"name":"lower-priority"}\n',
+  )
+
+  assert.equal(migrateLegacyWebState({
+    dataRoot: sharedRoot,
+    legacyDefaultDataRoot: legacyRoot,
+  }), false)
+  assert.equal(existsSync(join(sharedRoot, 'node_modules', 'linked')), false)
+
+  write(join(dependencyTarget, 'package.json'), '{"name":"preferred"}\n')
+  assert.equal(migrateLegacyWebState({
+    dataRoot: sharedRoot,
+    legacyDefaultDataRoot: legacyRoot,
+  }), true)
+  assert.equal(
+    readFileSync(join(sharedRoot, 'node_modules', 'linked', 'package.json'), 'utf8'),
+    '{"name":"preferred"}\n',
+  )
+})

--- a/tests/data-root.test.ts
+++ b/tests/data-root.test.ts
@@ -211,3 +211,38 @@ test('legacy directory links are followed before migration completes', t => {
     'web',
   )
 })
+
+test('unavailable Windows junctions keep migration retryable', t => {
+  if (process.platform !== 'win32') {
+    t.skip('Windows junction behavior')
+    return
+  }
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'ohdsh-junction-retry-'))
+  t.after(() => rmSync(temporaryRoot, { recursive: true, force: true }))
+
+  const appDataRoot = join(temporaryRoot, 'app-data')
+  const legacyRoot = join(appDataRoot, 'Oh-DSH-Desktop')
+  const dependencyTarget = join(temporaryRoot, 'dependency')
+  const dependencyLink = join(legacyRoot, 'dsh', 'node_modules', 'linked')
+  const sharedRoot = join(temporaryRoot, 'shared')
+  mkdirSync(dirname(dependencyLink), { recursive: true })
+  symlinkSync(dependencyTarget, dependencyLink, 'junction')
+
+  assert.equal(migrateLegacyDesktopState({
+    appDataRoot,
+    env: {},
+    ohDshHome: sharedRoot,
+  }), false)
+
+  write(join(dependencyTarget, 'package.json'), '{"name":"linked"}\n')
+  assert.equal(migrateLegacyDesktopState({
+    appDataRoot,
+    env: {},
+    ohDshHome: sharedRoot,
+  }), true)
+  assert.equal(
+    readFileSync(join(sharedRoot, 'node_modules', 'linked', 'package.json'), 'utf8'),
+    '{"name":"linked"}\n',
+  )
+})

--- a/tests/web-profile.test.ts
+++ b/tests/web-profile.test.ts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict'
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -234,4 +236,43 @@ test('web launcher resolves a relative data root before spawning the runtime', a
     process.chdir(previous)
     rmSync(temp, { recursive: true, force: true })
   }
+})
+
+test('web launcher defers profile setup until migration can finish', async t => {
+  if (process.platform !== 'win32') {
+    t.skip('Windows junction behavior')
+    return
+  }
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'ohdsh-web-start-retry-'))
+  t.after(() => rmSync(temporaryRoot, { recursive: true, force: true }))
+
+  const dataRoot = join(temporaryRoot, 'state')
+  const packaged = join(temporaryRoot, 'package')
+  const nodeBinary = join(packaged, 'node-runtime', 'node.exe')
+  const cliEntry = join(packaged, 'dsh-runtime', 'lib', 'bin.js')
+  const unavailableTarget = join(temporaryRoot, 'unavailable-profiles')
+  const legacyProfiles = join(dataRoot, 'dsh', 'profiles')
+  mkdirSync(dirname(nodeBinary), { recursive: true })
+  mkdirSync(dirname(cliEntry), { recursive: true })
+  mkdirSync(dirname(legacyProfiles), { recursive: true })
+  writeFileSync(nodeBinary, '')
+  writeFileSync(cliEntry, '')
+  symlinkSync(unavailableTarget, legacyProfiles, 'junction')
+
+  let runtimeCreated = false
+  await assert.rejects(
+    main(
+      ['--data', dataRoot],
+      { DSH_OH_WEB_ROOT: packaged, PATH: process.env.PATH },
+      { isTTY: false } as NodeJS.WriteStream,
+      options => {
+        runtimeCreated = true
+        return new DshRuntimeSupervisor(options)
+      },
+    ),
+    /legacy Web state migration .* is incomplete/,
+  )
+  assert.equal(runtimeCreated, false)
+  assert.equal(existsSync(join(dataRoot, 'profiles')), false)
 })


### PR DESCRIPTION
## Summary

- resolve relative `OH_DSH_HOME` values before launching the macOS app
- keep migrations retryable when Windows link targets are unavailable
- cover both edge cases with launcher and migration regression tests

## Verification

- `node --test tests/cli.test.ts tests/data-root.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Context

These fixes address the final review findings from #52. They were reviewed in
stacked PR #55, then rebased onto `main` because #52 had already merged.
