### PR TITLE
marketplace: make catalog refresh resilient

### DIFF
--- a/plugins/plugin-marketplace/src/client/plugin.tsx
+++ b/plugins/plugin-marketplace/src/client/plugin.tsx
@@ -706,7 +706,7 @@ function MarketplaceSurface({ bridge, locale, translate, view }: {
   const t = useTranslate(locale, translate)
   const viewState = useSyncExternalStore(view.subscribe, view.getSnapshot)
   const [snapshot, setSnapshot] = useState<MarketplaceSnapshot | null>(null)
-  const [pending, setPending] = useState(false)
+  const [pending, setPending] = useState(true)
   const [localError, setLocalError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState<
@@ -729,6 +729,8 @@ function MarketplaceSurface({ bridge, locale, translate, view }: {
 
   useEffect(() => {
     let alive = true
+    setPending(true)
+    setLocalError(null)
     void bridge.pluginMarketplace.getSnapshot().then(initial => {
       if (!alive) return
       setSnapshot(initial)
@@ -737,6 +739,8 @@ function MarketplaceSurface({ bridge, locale, translate, view }: {
       if (alive && refreshed !== undefined) setSnapshot(refreshed)
     }).catch((error: unknown) => {
       if (alive) setLocalError(error instanceof Error ? error.message : String(error))
+    }).finally(() => {
+      if (alive) setPending(false)
     })
     return () => { alive = false }
   }, [bridge])

--- a/plugins/plugin-marketplace/src/client/plugin.tsx
+++ b/plugins/plugin-marketplace/src/client/plugin.tsx
@@ -795,7 +795,7 @@ function MarketplaceSurface({ bridge, locale, translate, view }: {
                   {t('undo-last-apply')}
                 </button>
               )}
-              <button className="oh-marketplace-button" disabled={pending} onClick={() => { void run({ type: 'refresh' }) }} type="button">
+              <button className="oh-marketplace-button" disabled={pending} onClick={() => { void run({ type: 'refresh', force: true }) }} type="button">
                 {pending ? t('working') : t('refresh')}
               </button>
               <button
@@ -823,7 +823,7 @@ function MarketplaceSurface({ bridge, locale, translate, view }: {
               <button
                 className="oh-marketplace-button"
                 disabled={pending}
-                onClick={() => { resetView(); void run({ type: 'refresh' }) }}
+                onClick={() => { resetView(); void run({ type: 'refresh', force: true }) }}
                 type="button"
               >
                 {t('reset-and-reload')}

--- a/plugins/plugin-marketplace/src/host/platform.ts
+++ b/plugins/plugin-marketplace/src/host/platform.ts
@@ -20,6 +20,7 @@ import {
   sep,
   win32,
 } from 'node:path'
+import { parseMarketplaceCatalog } from '../catalog.ts'
 import type { MarketplaceAuthStatus } from '../protocol.ts'
 import {
   MARKETPLACE_CATALOG_PATH,
@@ -137,6 +138,7 @@ function readCatalogCache(path: string | null, locator: string): CatalogCache | 
       || !Object.hasOwn(value, 'document')) {
       return null
     }
+    parseMarketplaceCatalog(value.document)
     return {
       document: value.document,
       etag: value.etag as string | null,
@@ -493,6 +495,7 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
       }
       if (!response.ok) throw new Error(`GitHub Raw catalog request failed with HTTP ${String(response.status)}`)
       const document = JSON.parse(await response.text()) as unknown
+      parseMarketplaceCatalog(document)
       save(document, response.headers.get('etag'))
       return document
     } catch (error) {
@@ -507,6 +510,7 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
           'Accept: application/vnd.github.raw+json',
         ], { cwd: this.#options.cwd, env: this.#options.env, timeoutMs: 30_000 })
         const document = JSON.parse(result.stdout) as unknown
+        parseMarketplaceCatalog(document)
         save(document, null)
         return document
       } catch (authenticatedError) {

--- a/plugins/plugin-marketplace/src/host/platform.ts
+++ b/plugins/plugin-marketplace/src/host/platform.ts
@@ -4,6 +4,7 @@ import {
   accessSync,
   existsSync,
   mkdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   writeFileSync,
@@ -47,10 +48,14 @@ export interface MarketplacePlatform {
   authStatus(): Promise<MarketplaceAuthResult>
   buildBundle(input: BundleBuildInput): Promise<void>
   cloneRepository(repository: string, commit: string, target: string): Promise<void>
-  loadCatalog(): Promise<unknown>
+  loadCatalog(options?: LoadCatalogOptions): Promise<unknown>
   readRepositoryFile(repository: string, path: string, commit: string): Promise<string | null>
   resolveCommit(repository: string): Promise<string>
   runDsh(input: DshCommandInput): Promise<void>
+}
+
+export interface LoadCatalogOptions {
+  force?: boolean
 }
 
 export interface ProductionMarketplacePlatformOptions {
@@ -59,6 +64,7 @@ export interface ProductionMarketplacePlatformOptions {
   env: NodeJS.ProcessEnv
   fetch?: typeof globalThis.fetch
   nodeBinary: string
+  now?: () => number
   pnpmEntry: string
   onLog?: (message: string) => void
 }
@@ -70,6 +76,20 @@ interface CommandOptions {
 }
 
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+export const MARKETPLACE_CATALOG_CACHE_TTL_MS = 2 * 60 * 60 * 1000
+const CATALOG_CACHE_VERSION = 1
+
+interface CatalogCache {
+  document: unknown
+  etag: string | null
+  fetchedAt: number
+  locator: string
+  version: 1
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
 
 function validateRepository(repository: string): void {
   if (!/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/.test(repository)) {
@@ -77,13 +97,64 @@ function validateRepository(repository: string): void {
   }
 }
 
-function repositoryContentPath(repository: string, path: string): string {
-  validateRepository(repository)
+function repositoryPathSegments(path: string): string[] {
   const segments = path.split('/').filter(Boolean)
   if (segments.length === 0 || segments.some(segment => segment === '.' || segment === '..')) {
     throw new Error(`invalid repository file path: ${JSON.stringify(path)}`)
   }
+  return segments
+}
+
+function repositoryContentPath(repository: string, path: string): string {
+  validateRepository(repository)
+  const segments = repositoryPathSegments(path)
   return `repos/${repository}/contents/${segments.map(encodeURIComponent).join('/')}`
+}
+
+function repositoryRawUrl(repository: string, path: string): string {
+  validateRepository(repository)
+  const segments = repositoryPathSegments(path)
+  return `https://raw.githubusercontent.com/${repository}/HEAD/${segments.map(encodeURIComponent).join('/')}`
+}
+
+function catalogCachePath(environment: NodeJS.ProcessEnv): string | null {
+  const appDataPath = environment.DSH_DESKTOP_APP_DATA
+  if (appDataPath === undefined || appDataPath === '') return null
+  return join(appDataPath, 'plugin-marketplace', 'catalog-cache.json')
+}
+
+function readCatalogCache(path: string | null, locator: string): CatalogCache | null {
+  if (path === null) return null
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as unknown
+    if (!isRecord(value)
+      || value.version !== CATALOG_CACHE_VERSION
+      || value.locator !== locator
+      || typeof value.fetchedAt !== 'number'
+      || !Number.isFinite(value.fetchedAt)
+      || value.fetchedAt < 0
+      || (value.etag !== null && typeof value.etag !== 'string')
+      || !Object.hasOwn(value, 'document')) {
+      return null
+    }
+    return {
+      document: value.document,
+      etag: value.etag as string | null,
+      fetchedAt: value.fetchedAt,
+      locator,
+      version: CATALOG_CACHE_VERSION,
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeCatalogCache(path: string | null, cache: CatalogCache): void {
+  if (path === null) return
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
+  const temporary = `${path}.tmp-${String(process.pid)}`
+  writeFileSync(temporary, JSON.stringify(cache) + '\n', { mode: 0o600 })
+  renameSync(temporary, path)
 }
 
 function commandError(command: string, args: readonly string[], stderr: string, stdout: string): Error {
@@ -365,7 +436,7 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
     }
   }
 
-  async loadCatalog(): Promise<unknown> {
+  async loadCatalog(options: LoadCatalogOptions = {}): Promise<unknown> {
     const locator = this.#options.env.OH_DSH_MARKETPLACE_CATALOG
       ?? `${MARKETPLACE_CATALOG_REPOSITORY}/${MARKETPLACE_CATALOG_PATH}`
     const match = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/(.+)$/.exec(locator)
@@ -373,20 +444,57 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
       throw new Error('OH_DSH_MARKETPLACE_CATALOG must be owner/repository/path')
     }
     validateRepository(match[1] ?? '')
+    const repository = match[1] ?? ''
     const path = match[2] ?? ''
-    const contentPath = repositoryContentPath(match[1] ?? '', path)
+    const contentPath = repositoryContentPath(repository, path)
+    const cachePath = catalogCachePath(this.#options.env)
+    const cached = readCatalogCache(cachePath, locator)
+    const now = this.#options.now?.() ?? Date.now()
+    const age = cached === null ? Number.POSITIVE_INFINITY : now - cached.fetchedAt
+    if (options.force !== true && cached !== null
+      && age >= 0 && age < MARKETPLACE_CATALOG_CACHE_TTL_MS) {
+      this.#options.onLog?.('marketplace catalog: using fresh local cache')
+      return cached.document
+    }
+    const save = (document: unknown, etag: string | null): void => {
+      try {
+        writeCatalogCache(cachePath, {
+          document,
+          etag,
+          fetchedAt: now,
+          locator,
+          version: CATALOG_CACHE_VERSION,
+        })
+      } catch (error) {
+        this.#options.onLog?.(`marketplace catalog: failed to update local cache: ${String(error)}`)
+      }
+    }
+    const stale = (cache: CatalogCache, reason: unknown): unknown => {
+      this.#options.onLog?.(`marketplace catalog: using stale local cache after refresh failed: ${String(reason)}`)
+      return cache.document
+    }
     const request = this.#options.fetch ?? globalThis.fetch
     let publicError: unknown
     try {
-      const response = await request(`https://api.github.com/${contentPath}`, {
-        headers: {
-          accept: 'application/vnd.github.raw+json',
-          'user-agent': 'oh-dsh-desktop',
-        },
+      const headers: Record<string, string> = {
+        accept: 'application/json',
+        'user-agent': 'oh-dsh-desktop',
+      }
+      if (cached?.etag !== null && cached?.etag !== undefined) {
+        headers['if-none-match'] = cached.etag
+      }
+      const response = await request(repositoryRawUrl(repository, path), {
+        headers,
         signal: AbortSignal.timeout(30_000),
       })
-      if (!response.ok) throw new Error(`GitHub public catalog request failed with HTTP ${String(response.status)}`)
-      return JSON.parse(await response.text()) as unknown
+      if (response.status === 304 && cached !== null) {
+        save(cached.document, response.headers.get('etag') ?? cached.etag)
+        return cached.document
+      }
+      if (!response.ok) throw new Error(`GitHub Raw catalog request failed with HTTP ${String(response.status)}`)
+      const document = JSON.parse(await response.text()) as unknown
+      save(document, response.headers.get('etag'))
+      return document
     } catch (error) {
       publicError = error
     }
@@ -395,16 +503,21 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
         const result = await runCommand(this.#ghPath, [
           'api',
           contentPath,
-          '--jq',
-          '.content',
-        ], { env: this.#options.env, timeoutMs: 30_000 })
-        return JSON.parse(Buffer.from(result.stdout.replaceAll(/\s/g, ''), 'base64').toString('utf8')) as unknown
+          '-H',
+          'Accept: application/vnd.github.raw+json',
+        ], { cwd: this.#options.cwd, env: this.#options.env, timeoutMs: 30_000 })
+        const document = JSON.parse(result.stdout) as unknown
+        save(document, null)
+        return document
       } catch (authenticatedError) {
-        throw new Error(
+        const failure = new Error(
           `failed to load marketplace catalog anonymously (${String(publicError)}) or with GitHub CLI (${String(authenticatedError)})`,
         )
+        if (cached !== null) return stale(cached, failure)
+        throw failure
       }
     }
+    if (cached !== null) return stale(cached, publicError)
     throw new Error(`failed to load public marketplace catalog: ${String(publicError)}`)
   }
 

--- a/plugins/plugin-marketplace/src/host/transaction-manager.ts
+++ b/plugins/plugin-marketplace/src/host/transaction-manager.ts
@@ -662,7 +662,7 @@ export class PluginMarketplaceManager {
     try {
       switch (command.type) {
         case 'refresh':
-          await this.refresh()
+          await this.refresh(command.force === true)
           break
         case 'inspect':
           await this.inspect(command.action, command.pluginId)
@@ -694,10 +694,10 @@ export class PluginMarketplaceManager {
     return this.getSnapshot()
   }
 
-  private async refresh(): Promise<void> {
+  private async refresh(force = false): Promise<void> {
     this.#auth = await this.#options.platform.authStatus()
     const installed = readMarketplaceState(this.#profileDir).entries
-    const catalog = parseMarketplaceCatalog(await this.#options.platform.loadCatalog(), installed)
+    const catalog = parseMarketplaceCatalog(await this.#options.platform.loadCatalog({ force }), installed)
     this.#catalog = catalog.plugins
     this.#catalogGeneratedAt = catalog.generatedAt
     this.#latestCommits.clear()

--- a/plugins/plugin-marketplace/src/protocol.ts
+++ b/plugins/plugin-marketplace/src/protocol.ts
@@ -158,7 +158,7 @@ export interface MarketplaceSnapshot {
 }
 
 export type MarketplaceCommand =
-  | { type: 'refresh' }
+  | { type: 'refresh'; force?: boolean }
   | { type: 'inspect'; action: MarketplaceAction; pluginId: string }
   | { type: 'prepare'; action: MarketplaceAction; pluginId: string }
   | {
@@ -185,8 +185,15 @@ export function parseMarketplaceCommand(value: unknown): MarketplaceCommand {
   if (!isRecord(value) || typeof value.type !== 'string') {
     throw new Error('marketplace command must be an object with a type')
   }
-  if (value.type === 'refresh' || value.type === 'discard'
-    || value.type === 'apply' || value.type === 'undo') {
+  if (value.type === 'refresh') {
+    if (value.force !== undefined && typeof value.force !== 'boolean') {
+      throw new Error('invalid marketplace refresh command')
+    }
+    return value.force === undefined
+      ? { type: 'refresh' }
+      : { type: 'refresh', force: value.force }
+  }
+  if (value.type === 'discard' || value.type === 'apply' || value.type === 'undo') {
     return { type: value.type }
   }
   if (value.type === 'inspect' || value.type === 'prepare') {

--- a/src/marketplace-tools.ts
+++ b/src/marketplace-tools.ts
@@ -226,7 +226,9 @@ export function mountMarketplaceAgentTools(
       refresh: { type: 'boolean', description: 'Refresh the GitHub catalog before searching.' },
     },
     async execute(args) {
-      const info = await snapshot(credentials, args.refresh === true ? { type: 'refresh' } : undefined)
+      const info = await snapshot(credentials, args.refresh === true
+        ? { type: 'refresh', force: true }
+        : undefined)
       const query = typeof args.query === 'string' ? args.query.trim().toLowerCase() : ''
       const status = typeof args.status === 'string' ? args.status : 'all'
       const category = typeof args.category === 'string' ? args.category : null

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -489,6 +489,43 @@ test('catalog cache survives restarts, revalidates with ETags, and expires after
   }
 })
 
+test('catalog cache rejects unsupported documents before reuse', async () => {
+  const appDataPath = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-invalid-cache-'))
+  const command = join(appDataPath, 'api')
+  const cachePath = join(appDataPath, 'plugin-marketplace', 'catalog-cache.json')
+  let document: unknown = { schema: 'unsupported/v1' }
+  let requests = 0
+  const createPlatform = (): ProductionMarketplacePlatform => new ProductionMarketplacePlatform({
+    cliEntry: '/unused/dsh.mjs',
+    cwd: appDataPath,
+    env: {
+      DSH_DESKTOP_APP_DATA: appDataPath,
+      DSH_DESKTOP_GH_PATH: process.execPath,
+      OH_DSH_MARKETPLACE_CATALOG: 'public-owner/public-catalog/data/plugins.json',
+      PATH: '',
+    },
+    fetch: async (): Promise<Response> => {
+      requests += 1
+      return new Response(JSON.stringify(document), { status: 200 })
+    },
+    nodeBinary: process.execPath,
+    now: () => 1_000,
+    pnpmEntry: '/unused/pnpm.mjs',
+  })
+
+  try {
+    writeFileSync(command, 'process.exit(1)\n')
+    await assert.rejects(createPlatform().loadCatalog(), /unsupported plugin catalog/)
+    assert.equal(existsSync(cachePath), false)
+
+    document = catalogDocument()
+    assert.deepEqual(await createPlatform().loadCatalog(), catalogDocument())
+    assert.equal(requests, 2)
+  } finally {
+    rmSync(appDataPath, { recursive: true, force: true })
+  }
+})
+
 test('GitHub CLI fallback reads raw catalogs larger than one megabyte', async () => {
   const root = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-gh-raw-'))
   const command = join(root, 'api')

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -812,6 +812,16 @@ test('marketplace navigation preserves the Settings footer geometry', () => {
   assert.doesNotMatch(client, /parent\.insertBefore\(this\.#entry, settings\)/)
 })
 
+test('marketplace startup disables manual refresh until refresh settles', () => {
+  const client = readFileSync(new URL(
+    '../plugins/plugin-marketplace/src/client/plugin.tsx',
+    import.meta.url,
+  ), 'utf8')
+  assert.match(client, /const \[pending, setPending\] = useState\(true\)/)
+  assert.match(client, /\.finally\(\(\) => \{\s*if \(alive\) setPending\(false\)\s*\}\)/)
+  assert.match(client, /disabled=\{pending\}[\s\S]{0,160}type: 'refresh', force: true/)
+})
+
 test('marketplace closes after ready session navigation, not during startup', () => {
   let state = initialSessionNavigationState()
   let transition = transitionSessionNavigation(state, {

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -8,11 +8,13 @@ import { parseMarketplaceCatalog } from '../plugins/plugin-marketplace/src/catal
 import type {
   BundleBuildInput,
   DshCommandInput,
+  LoadCatalogOptions,
   MarketplaceAuthResult,
   MarketplacePlatform,
 } from '../plugins/plugin-marketplace/src/host/platform.ts'
 import {
   findGitHubCli,
+  MARKETPLACE_CATALOG_CACHE_TTL_MS,
   previewScriptCommand,
   ProductionMarketplacePlatform,
   withGitHubCredentials,
@@ -85,6 +87,7 @@ class FakePlatform implements MarketplacePlatform {
     scripts: string[]
   }> = []
   readonly commands: DshCommandInput[] = []
+  readonly catalogLoads: LoadCatalogOptions[] = []
   catalog: unknown = catalogDocument()
   latestCommit = COMMIT
   bundleName = '@example/bundle-demo'
@@ -106,7 +109,8 @@ class FakePlatform implements MarketplacePlatform {
     mkdirSync(target, { recursive: true })
   }
 
-  async loadCatalog(): Promise<unknown> {
+  async loadCatalog(options: LoadCatalogOptions = {}): Promise<unknown> {
+    this.catalogLoads.push(options)
     return this.catalog
   }
 
@@ -426,8 +430,107 @@ test('public catalogs load anonymously without GitHub CLI', async () => {
   assert.deepEqual(await platform.loadCatalog(), catalogDocument())
   assert.equal(
     requested,
-    'https://api.github.com/repos/public-owner/public-catalog/contents/data/plugins.json',
+    'https://raw.githubusercontent.com/public-owner/public-catalog/HEAD/data/plugins.json',
   )
+})
+
+test('catalog cache survives restarts, revalidates with ETags, and expires after two hours', async () => {
+  const appDataPath = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-catalog-cache-'))
+  let now = 1_000
+  let requests = 0
+  let transportFails = false
+  const conditionalHeaders: Array<string | null> = []
+  const createPlatform = (): ProductionMarketplacePlatform => new ProductionMarketplacePlatform({
+    cliEntry: '/unused/dsh.mjs',
+    cwd: appDataPath,
+    env: {
+      DSH_DESKTOP_APP_DATA: appDataPath,
+      DSH_DESKTOP_GH_PATH: process.execPath,
+      OH_DSH_MARKETPLACE_CATALOG: 'public-owner/public-catalog/data/plugins.json',
+      PATH: '',
+    },
+    fetch: async (_input, init): Promise<Response> => {
+      requests += 1
+      conditionalHeaders.push(new Headers(init?.headers).get('if-none-match'))
+      if (transportFails) throw new Error('offline')
+      if (requests === 2) {
+        return new Response(null, { headers: { etag: '"catalog-v1"' }, status: 304 })
+      }
+      return new Response(JSON.stringify(catalogDocument()), {
+        headers: { etag: '"catalog-v1"' },
+        status: 200,
+      })
+    },
+    nodeBinary: process.execPath,
+    now: () => now,
+    pnpmEntry: '/unused/pnpm.mjs',
+  })
+
+  try {
+    writeFileSync(join(appDataPath, 'api'), 'process.exit(1)\n')
+    assert.deepEqual(await createPlatform().loadCatalog(), catalogDocument())
+    now += MARKETPLACE_CATALOG_CACHE_TTL_MS - 1
+    assert.deepEqual(await createPlatform().loadCatalog(), catalogDocument())
+    assert.equal(requests, 1)
+
+    assert.deepEqual(await createPlatform().loadCatalog({ force: true }), catalogDocument())
+    assert.equal(requests, 2)
+    assert.deepEqual(conditionalHeaders, [null, '"catalog-v1"'])
+
+    now += MARKETPLACE_CATALOG_CACHE_TTL_MS
+    assert.deepEqual(await createPlatform().loadCatalog(), catalogDocument())
+    assert.equal(requests, 3)
+
+    transportFails = true
+    assert.deepEqual(await createPlatform().loadCatalog({ force: true }), catalogDocument())
+    assert.equal(requests, 4)
+  } finally {
+    rmSync(appDataPath, { recursive: true, force: true })
+  }
+})
+
+test('GitHub CLI fallback reads raw catalogs larger than one megabyte', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-marketplace-gh-raw-'))
+  const command = join(root, 'api')
+  const catalogPath = join(root, 'catalog.json')
+  const argumentsPath = join(root, 'arguments.json')
+  const largeCatalog = {
+    ...catalogDocument() as Record<string, unknown>,
+    padding: 'x'.repeat(1024 * 1024),
+  }
+  try {
+    const serializedCatalog = JSON.stringify(largeCatalog)
+    assert.ok(Buffer.byteLength(serializedCatalog) > 1024 * 1024)
+    writeFileSync(catalogPath, serializedCatalog)
+    writeFileSync(command, [
+      "const { readFileSync, writeFileSync } = require('node:fs')",
+      "writeFileSync(process.env.OH_DSH_TEST_GH_ARGS, JSON.stringify(process.argv.slice(2)))",
+      "process.stdout.write(readFileSync(process.env.OH_DSH_TEST_CATALOG))",
+      '',
+    ].join('\n'))
+    const platform = new ProductionMarketplacePlatform({
+      cliEntry: '/unused/dsh.mjs',
+      cwd: root,
+      env: {
+        DSH_DESKTOP_GH_PATH: process.execPath,
+        OH_DSH_MARKETPLACE_CATALOG: 'public-owner/public-catalog/data/plugins.json',
+        OH_DSH_TEST_CATALOG: catalogPath,
+        OH_DSH_TEST_GH_ARGS: argumentsPath,
+      },
+      fetch: async (): Promise<Response> => new Response('rate limited', { status: 403 }),
+      nodeBinary: process.execPath,
+      pnpmEntry: '/unused/pnpm.mjs',
+    })
+
+    assert.deepEqual(await platform.loadCatalog(), largeCatalog)
+    assert.deepEqual(JSON.parse(readFileSync(argumentsPath, 'utf8')), [
+      'repos/public-owner/public-catalog/contents/data/plugins.json',
+      '-H',
+      'Accept: application/vnd.github.raw+json',
+    ])
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 })
 
 test('production bundle build runs approved hooks in its own workspace', {
@@ -542,10 +645,11 @@ test('refresh keeps public catalogs available when GitHub CLI is unavailable', a
       detail: 'GitHub CLI is unavailable',
       status: 'missing-cli',
     })
-    const snapshot = await setup.manager.dispatch({ type: 'refresh' })
+    const snapshot = await setup.manager.dispatch({ type: 'refresh', force: true })
     assert.equal(snapshot.auth.status, 'missing-cli')
     assert.equal(snapshot.catalog.length, 6)
     assert.equal(snapshot.error, null)
+    assert.deepEqual(setup.platform.catalogLoads, [{ force: true }])
   } finally {
     setup.cleanup()
   }


### PR DESCRIPTION
## Summary

- cache the marketplace catalog for two hours in desktop app data
- revalidate stale entries with ETags and retain stale data when offline
- make explicit UI and Agent refreshes bypass the cache TTL
- read authenticated fallback responses as raw JSON

## Why

Catalog discovery previously fetched the network on every refresh and had no
offline fallback. Its GitHub Contents API fallback also depended on the encoded
`content` field, which is unavailable for files larger than 1 MiB.

The new cache reduces repeated requests, keeps the marketplace usable during
transient failures, and lets large organization catalogs use an authenticated
raw response.

## User impact

Normal startup and navigation reuse a fresh catalog. The Refresh actions still
request current data immediately, while stale cached data remains available if
both anonymous and authenticated transports fail.

## Validation

- `pnpm run typecheck`
- `pnpm test` (152 passed, 5 platform-specific skips)
- `pnpm build`

https://github.com/hust-open-atom-club/oh-dsh/issues/54