### PR TITLE
summary: float the pinned session card

### DIFF
--- a/plugins/pinned-summary/package.json
+++ b/plugins/pinned-summary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/pinned-summary",
   "version": "0.1.4",
-  "description": "Layout-reserving current-session summary panel for Oh-DSH Desktop",
+  "description": "Floating current-session summary popover for Oh-DSH Desktop",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/pinned-summary/src/client.ts
+++ b/plugins/pinned-summary/src/client.ts
@@ -1,4 +1,4 @@
-/** Layout-reserving pinned summary derived from the active DSH session. */
+/** Floating pinned summary derived from the active DSH session. */
 
 import type { LocaleService, Translate } from '../../shared/i18n.ts'
 import { localeTag } from '../../shared/i18n.ts'
@@ -59,31 +59,35 @@ const OPEN_KEY = 'oh-dsh-desktop.pinned-summary.open'
 
 const SUMMARY_CSS = `
 html {
-  --oh-dsh-pinned-summary-width: 288px;
-}
-
-html[data-oh-dsh-summary-pinned='true'] #root {
-  box-sizing: border-box;
-  padding-right: calc(var(--oh-dsh-pinned-summary-width) + 24px);
+  --oh-dsh-pinned-summary-width: 304px;
 }
 
 [data-oh-dsh-pinned-summary] {
   position: fixed;
   z-index: 9000;
-  top: calc(var(--oh-dsh-titlebar-height, 40px) + 12px);
-  right: 12px;
-  height: calc((100vh - var(--oh-dsh-titlebar-height, 40px) - 24px) / 2);
-  width: var(--oh-dsh-pinned-summary-width);
+  display: flex;
+  flex-direction: column;
+  top: calc(var(--oh-dsh-titlebar-height, 40px) + 8px);
+  right: 14px;
+  width: min(var(--oh-dsh-pinned-summary-width), calc(100vw - 28px));
+  height: auto;
+  max-height: min(
+    420px,
+    calc(100vh - var(--oh-dsh-titlebar-height, 40px) - 20px)
+  );
   box-sizing: border-box;
   overflow: hidden;
   border: 1px solid var(--dsw-alias-border-l1);
-  border-radius: 22px;
+  border-radius: 16px;
   background: var(--dsw-alias-bg-base);
   color: var(--dsw-alias-label-primary);
-  box-shadow: 0 14px 42px rgb(0 0 0 / 9%);
+  box-shadow:
+    0 18px 48px rgb(0 0 0 / 14%),
+    0 2px 10px rgb(0 0 0 / 6%);
   opacity: 0;
   pointer-events: none;
-  transform: translateX(calc(100% + 24px));
+  transform: translateY(-8px) scale(0.98);
+  transform-origin: top right;
   visibility: hidden;
   transition:
     opacity 140ms var(--ds-ease-in-out, ease),
@@ -95,15 +99,16 @@ html[data-oh-dsh-summary-pinned='true'] #root {
 [data-oh-dsh-pinned-summary][data-open='true'] {
   opacity: 1;
   pointer-events: auto;
-  transform: translateX(0);
+  transform: translateY(0) scale(1);
   visibility: visible;
   transition-delay: 0s;
 }
 
 [data-oh-dsh-summary-header] {
   display: flex;
+  flex: 0 0 44px;
   align-items: center;
-  height: 48px;
+  height: 44px;
   padding: 0 10px 0 15px;
   border-bottom: 1px solid var(--dsw-alias-border-l2);
   box-sizing: border-box;
@@ -131,8 +136,9 @@ html[data-oh-dsh-summary-pinned='true'] #root {
 }
 
 [data-oh-dsh-summary-body] {
-  height: calc(100% - 48px);
-  padding: 14px 15px 16px;
+  flex: 0 1 auto;
+  min-height: 0;
+  padding: 12px 15px 14px;
   box-sizing: border-box;
   overflow: auto;
 }
@@ -172,8 +178,10 @@ html[data-oh-dsh-summary-pinned='true'] #root {
 }
 
 @media (max-width: 900px) {
-  html[data-oh-dsh-summary-pinned='true'] #root { padding-right: 0; }
-  [data-oh-dsh-pinned-summary] { box-shadow: -20px 0 48px rgb(0 0 0 / 14%); }
+  [data-oh-dsh-pinned-summary] {
+    right: 8px;
+    width: min(var(--oh-dsh-pinned-summary-width), calc(100vw - 16px));
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -249,8 +257,16 @@ class PinnedSummaryService implements PinnedSummary {
   #unsubscribeList: (() => void) | undefined
   #unsubscribeSession: (() => void) | undefined
   #unsubscribeLocale: (() => void) | undefined
-  readonly #narrowViewport = window.matchMedia('(max-width: 900px)')
-  readonly #handleViewportChange = (): void => { this.applyState() }
+  readonly #handleDocumentPointerDown = (event: PointerEvent): void => {
+    if (!this.#open || this.#panel === undefined) return
+    const target = event.target
+    if (!(target instanceof Node) || this.#panel.contains(target)) return
+    if (target instanceof Element && target.closest('.oh-dsh-panel-toolbar') !== null) return
+    this.setOpen(false)
+  }
+  readonly #handleDocumentKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape' && this.#open) this.setOpen(false)
+  }
 
   constructor(
     sessions: SessionsService,
@@ -270,6 +286,7 @@ class PinnedSummaryService implements PinnedSummary {
 
     const panel = document.createElement('aside')
     panel.dataset.ohDshPinnedSummary = 'true'
+    panel.setAttribute('role', 'dialog')
     panel.setAttribute('aria-label', this.#t('summary.label'))
     panel.innerHTML = `
       <header data-oh-dsh-summary-header>
@@ -292,7 +309,8 @@ class PinnedSummaryService implements PinnedSummary {
     this.#source = required(panel, '[data-oh-dsh-summary-source]')
     this.#text = required(panel, '[data-oh-dsh-summary-text]')
     this.#close.addEventListener('click', () => { this.setOpen(false) })
-    this.#narrowViewport.addEventListener('change', this.#handleViewportChange)
+    document.addEventListener('pointerdown', this.#handleDocumentPointerDown)
+    document.addEventListener('keydown', this.#handleDocumentKeyDown)
     this.#unsubscribeList = this.#sessions.list.subscribe(() => { this.bindAndRender() })
     this.#unsubscribeLocale = this.#locale.subscribe(() => {
       this.renderChrome()
@@ -307,14 +325,11 @@ class PinnedSummaryService implements PinnedSummary {
     this.#unsubscribeList?.()
     this.#unsubscribeSession?.()
     this.#unsubscribeLocale?.()
-    this.#narrowViewport.removeEventListener('change', this.#handleViewportChange)
+    document.removeEventListener('pointerdown', this.#handleDocumentPointerDown)
+    document.removeEventListener('keydown', this.#handleDocumentKeyDown)
     this.#panel?.remove()
     this.#style?.remove()
     delete document.documentElement.dataset.ohDshSummaryPinned
-    if (document.documentElement.dataset.ohDshRightPanelOwner === 'pinned-summary') {
-      delete document.documentElement.dataset.ohDshRightPanelOwner
-      document.getElementById('root')?.style.removeProperty('padding-right')
-    }
   }
 
   isOpen(): boolean {
@@ -346,19 +361,8 @@ class PinnedSummaryService implements PinnedSummary {
     }
     if (this.#open) {
       html.dataset.ohDshSummaryPinned = 'true'
-      html.dataset.ohDshRightPanelOwner = 'pinned-summary'
-      const appRoot = document.getElementById('root')
-      if (appRoot !== null) {
-        appRoot.style.paddingRight = this.#narrowViewport.matches
-          ? '0px'
-          : 'calc(var(--oh-dsh-pinned-summary-width) + 24px)'
-      }
     } else {
       delete html.dataset.ohDshSummaryPinned
-      if (html.dataset.ohDshRightPanelOwner === 'pinned-summary') {
-        delete html.dataset.ohDshRightPanelOwner
-        document.getElementById('root')?.style.removeProperty('padding-right')
-      }
     }
   }
 
@@ -425,7 +429,7 @@ class PinnedSummaryService implements PinnedSummary {
   }
 }
 
-/** Provide the pinned-summary service and its layout-reserving DOM surface. */
+/** Provide the pinned-summary service and its floating DOM surface. */
 export function apply(ctx: ClientContext): void {
   const locale = ctx.get('locale') as LocaleService
   const t: Translate<PinnedSummaryMessage> = locale.bind('oh-dsh.pinned-summary')

--- a/plugins/pinned-summary/src/client.ts
+++ b/plugins/pinned-summary/src/client.ts
@@ -261,7 +261,8 @@ class PinnedSummaryService implements PinnedSummary {
     if (!this.#open || this.#panel === undefined) return
     const target = event.target
     if (!(target instanceof Node) || this.#panel.contains(target)) return
-    if (target instanceof Element && target.closest('.oh-dsh-panel-toolbar') !== null) return
+    if (target instanceof Element
+      && target.closest('[data-oh-dsh-summary-toggle]') !== null) return
     this.setOpen(false)
   }
   readonly #handleDocumentKeyDown = (event: KeyboardEvent): void => {

--- a/plugins/sidebar/src/client/plugin.tsx
+++ b/plugins/sidebar/src/client/plugin.tsx
@@ -593,6 +593,7 @@ function DesktopPanelToolbar({
         : (
           <button
             type="button"
+            data-oh-dsh-summary-toggle=""
             aria-label={t('summary.toggle')}
             aria-pressed={summaryOpen}
             title={t('summary.title')}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -10,6 +10,10 @@ const productVersion = resolveProductVersion(root)
 const versionDefine = {
   __OH_DSH_BUILD_VERSION__: JSON.stringify(productVersion),
 }
+const nodeEsmRequireBanner = [
+  "import { createRequire as __ohDshCreateRequire } from 'node:module';",
+  'const require = __ohDshCreateRequire(import.meta.url);',
+].join('\n')
 rmSync(dist, { recursive: true, force: true })
 mkdirSync(dist, { recursive: true })
 
@@ -39,6 +43,7 @@ const builds = [
     platform: 'node',
     format: 'esm',
     external: ['electron'],
+    banner: { js: nodeEsmRequireBanner },
   }),
   build({
     ...shared,
@@ -171,6 +176,12 @@ for (const plugin of pluginPackages) {
 }
 
 await Promise.all(builds)
+
+const mainBundle = readFileSync(join(dist, 'main.js'), 'utf8')
+if (mainBundle.includes('Dynamic require of')
+  && !mainBundle.includes('__ohDshCreateRequire(import.meta.url)')) {
+  throw new Error('desktop main bundle has dynamic requires without an ESM require bridge')
+}
 
 copyFileSync(join(root, 'src', 'splash.html'), join(dist, 'splash.html'))
 copyFileSync(join(root, 'src', 'update.html'), join(dist, 'update.html'))

--- a/tests/right-panel-layout.test.ts
+++ b/tests/right-panel-layout.test.ts
@@ -45,6 +45,9 @@ test('review, pinned summary, and embedded side tools keep distinct layouts', ()
     summary,
     /document\.addEventListener\('pointerdown', this\.#handleDocumentPointerDown\)/,
   )
+  assert.match(workspace, /data-oh-dsh-summary-toggle=""/)
+  assert.match(summary, /closest\('\[data-oh-dsh-summary-toggle\]'\)/)
+  assert.doesNotMatch(summary, /closest\('\.oh-dsh-panel-toolbar'\)/)
   assert.match(summary, /event\.key === 'Escape'/)
   assert.doesNotMatch(workspace, /aria-label="Toggle review panel"/)
   assert.match(workspace, /className="oh-dsh-review-view"/)

--- a/tests/right-panel-layout.test.ts
+++ b/tests/right-panel-layout.test.ts
@@ -32,10 +32,20 @@ test('review, pinned summary, and embedded side tools keep distinct layouts', ()
   assert.match(workspace, /if \(open\) this\.pinnedSummary\.setOpen\(false\)/)
   assert.match(workspace, /if \(this\.state\.open\) this\.pinnedSummary\.setOpen\(false\)/)
   assert.match(workspace, /ohDshRightPanelOwner = 'sidebar'/)
-  assert.match(summary, /ohDshRightPanelOwner = 'pinned-summary'/)
-  assert.match(summary, /calc\(var\(--oh-dsh-pinned-summary-width\) \+ 24px\)/)
-  assert.match(summary, /height: calc\(\(100vh - var\(--oh-dsh-titlebar-height, 40px\) - 24px\) \/ 2\);/)
-  assert.doesNotMatch(summary, /height: min\(360px/)
+  assert.doesNotMatch(summary, /ohDshRightPanelOwner = 'pinned-summary'/)
+  assert.doesNotMatch(summary, /#root\s*\{[^}]*padding-right:/s)
+  assert.match(summary, /height: auto;/)
+  assert.match(summary, /max-height: min\(/)
+  assert.match(summary, /transform: translateY\(-8px\) scale\(0\.98\);/)
+  assert.match(
+    summary,
+    /\[data-oh-dsh-summary-body\]\s*\{[^}]*flex: 0 1 auto;[^}]*min-height: 0;[^}]*overflow: auto;/s,
+  )
+  assert.match(
+    summary,
+    /document\.addEventListener\('pointerdown', this\.#handleDocumentPointerDown\)/,
+  )
+  assert.match(summary, /event\.key === 'Escape'/)
   assert.doesNotMatch(workspace, /aria-label="Toggle review panel"/)
   assert.match(workspace, /className="oh-dsh-review-view"/)
   assert.doesNotMatch(workspace, /oh-dsh-review-panel/)


### PR DESCRIPTION
## Summary

- show Pinned Summary as a floating dropdown without resizing chat
- size the card to its content with a bounded scroll area
- close the popover on outside clicks or Escape

## Verification

- pnpm run typecheck
- node --test tests/right-panel-layout.test.ts tests/plugin.test.ts
- pnpm test
- pnpm build