### PR TITLE
fix: stop marketplace previews from inheriting a deleted pnpm store

### DIFF
--- a/plugins/plugin-marketplace/src/host/platform.ts
+++ b/plugins/plugin-marketplace/src/host/platform.ts
@@ -36,6 +36,13 @@ export interface DshCommandInput {
   args: string[]
   dshHome: string
   sandboxRoot: string
+  /**
+   * Set to `false` to run without the write-restricted seatbelt. Used to
+   * re-home the live profile's node_modules against the persistent home
+   * store after a preview is applied; sandboxed runs keep their store inside
+   * the preview root, which is deleted with the preview.
+   */
+  sandboxed?: boolean
 }
 
 export interface BundleBuildInput {
@@ -577,18 +584,20 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
   }
 
   async runDsh(input: DshCommandInput): Promise<void> {
+    const sandboxed = input.sandboxed !== false
     const temporary = join(input.sandboxRoot, '.tmp')
-    mkdirSync(temporary, { recursive: true, mode: 0o700 })
+    if (sandboxed) mkdirSync(temporary, { recursive: true, mode: 0o700 })
     const env = withGitHubCredentials({
       ...this.#options.env,
       DSH_DESKTOP_APP_DATA: input.sandboxRoot,
-      DSH_DESKTOP_PREVIEW: '1',
+      ...(sandboxed ? { DSH_DESKTOP_PREVIEW: '1', TMPDIR: temporary } : {}),
       DSH_HOME: input.dshHome,
-      TMPDIR: temporary,
     }, this.#ghPath)
     const nodeArguments = [this.#options.cliEntry, ...input.args]
     const sandbox = '/usr/bin/sandbox-exec'
-    const command = process.platform === 'darwin' && existsSync(sandbox) ? sandbox : this.#options.nodeBinary
+    const command = sandboxed && process.platform === 'darwin' && existsSync(sandbox)
+      ? sandbox
+      : this.#options.nodeBinary
     const args = command === sandbox
       ? ['-p', previewSandboxPolicy(input.sandboxRoot), this.#options.nodeBinary, ...nodeArguments]
       : nodeArguments

--- a/plugins/plugin-marketplace/src/host/transaction-manager.ts
+++ b/plugins/plugin-marketplace/src/host/transaction-manager.ts
@@ -691,7 +691,12 @@ export class PluginMarketplaceManager {
     } finally {
       this.#busy = false
     }
-    return this.getSnapshot()
+    const snapshot = this.getSnapshot()
+    // The snapshot above already reports this dispatch's outcome. Clear the
+    // error so later read-only snapshots (search/status polls) do not keep
+    // surfacing a stale failure from a previous dispatch.
+    this.#error = null
+    return snapshot
   }
 
   private async refresh(force = false): Promise<void> {
@@ -900,6 +905,17 @@ export class PluginMarketplaceManager {
     const candidateProfile = join(candidateHome, 'profiles', this.#options.profile)
     copyDirectory(this.#profileDir, candidateProfile)
     try {
+      // A live profile can carry a `node_modules` whose `.modules.yaml` points
+      // at a pnpm store that no longer exists: applying a preview deletes the
+      // preview root (and its store) while the applied profile keeps the
+      // store reference, so every later preview copy inherits a tree pnpm
+      // refuses with ERR_PNPM_UNEXPECTED_STORE. Drop the copied tree and
+      // lockfile for actions that run pnpm anyway, so pnpm rebuilds them
+      // against the preview's own store.
+      if (plan.action === 'install' || plan.action === 'update' || plan.action === 'uninstall') {
+        removeWithin(candidateProfile, join(candidateProfile, 'node_modules'), this.#warn)
+        rmSync(join(candidateProfile, 'pnpm-lock.yaml'), { force: true })
+      }
       const candidateState = readMarketplaceState(candidateProfile)
       const current = candidateState.entries
       const remaining = current.filter(entry => entry.pluginId !== plan.pluginId)
@@ -1093,6 +1109,24 @@ export class PluginMarketplaceManager {
         const liveCache = join(this.#options.dshHome, 'cache', 'repository-plugins')
         mkdirSync(dirname(liveCache), { recursive: true, mode: 0o700 })
         cpSync(candidateCache, liveCache, { recursive: true, preserveTimestamps: true })
+      }
+      // The applied profile's node_modules was linked from the preview's
+      // store, which is deleted with the preview root below. Re-home it
+      // against the persistent home store (unsandboxed) so the live profile
+      // never references a vanished store. Best effort: the hard links keep
+      // the tree usable even if this fails, and the dsh CLI self-heals the
+      // store reference on the next pnpm command.
+      try {
+        removeWithin(this.#profileDir, join(this.#profileDir, 'node_modules'), this.#warn)
+        rmSync(join(this.#profileDir, 'pnpm-lock.yaml'), { force: true })
+        await this.#options.platform.runDsh({
+          args: ['plugin', '--profile', this.#options.profile, 'install', '--ignore-scripts'],
+          dshHome: this.#options.dshHome,
+          sandboxRoot: this.#options.appDataPath,
+          sandboxed: false,
+        })
+      } catch (error) {
+        this.#options.onWarn?.(`applied profile store could not be re-homed: ${message(error)}`)
       }
       await this.#options.runtime.startLive()
     } catch (error) {

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -877,6 +877,46 @@ test('marketplace closes when an empty baseline activates a new session', () => 
   assert.deepEqual(transition.state, { current: 'new-session', ready: true })
 })
 
+test('preview strips a stale pnpm store reference from the copied profile', async () => {
+  const setup = fixture()
+  try {
+    // Simulate a live profile whose node_modules references a store that no
+    // longer exists (a previously applied preview deleted its store). pnpm
+    // refuses such trees with ERR_PNPM_UNEXPECTED_STORE.
+    const modulesDir = join(setup.profileDir, 'node_modules')
+    mkdirSync(modulesDir, { recursive: true })
+    writeFileSync(join(modulesDir, '.modules.yaml'), 'storeDir: "/deleted/preview/.pnpm-store/v11"\n')
+    writeFileSync(join(setup.profileDir, 'pnpm-lock.yaml'), 'lockfileVersion: "9.0"\n')
+
+    let snapshot = await setup.manager.dispatch({ type: 'refresh' })
+    assert.equal(snapshot.error, null)
+    snapshot = await setup.manager.dispatch({ type: 'inspect', action: 'install', pluginId: 'bundle-demo' })
+    assert.equal(snapshot.error, null)
+    snapshot = await setup.manager.dispatch({ type: 'preview', allowBuildScripts: true })
+    assert.equal(snapshot.error, null)
+
+    // The copied candidate must not keep the stale tree: the preview's pnpm
+    // commands would fail on it, and the applied profile would again
+    // reference a store deleted with the preview.
+    const candidate = join(
+      setup.appDataPath,
+      'plugin-marketplace',
+      'previews',
+      snapshot.preview?.transactionId ?? '',
+      'dsh',
+      'profiles',
+      'desktop',
+    )
+    assert.equal(existsSync(join(candidate, 'node_modules')), false)
+    assert.equal(existsSync(join(candidate, 'pnpm-lock.yaml')), false)
+    // The live profile keeps its (stale) tree untouched — only the copy is
+    // stripped for rebuild.
+    assert.equal(existsSync(join(setup.profileDir, 'node_modules')), true)
+  } finally {
+    setup.cleanup()
+  }
+})
+
 test('bundle preview remains isolated until apply and supports undo', async () => {
   const setup = fixture()
   try {
@@ -920,8 +960,14 @@ test('bundle preview remains isolated until apply and supports undo', async () =
       liveAfter.dependencies['@example/bundle-demo'],
       /plugin-marketplace\/previews/,
     )
-    assert.equal(setup.platform.commands.length, 2)
+    assert.equal(setup.platform.commands.length, 3)
     assert.deepEqual(setup.platform.commands[1]?.args.slice(-2), ['install', '--ignore-scripts'])
+    // After apply, the live profile's node_modules is re-homed against the
+    // persistent store: an unsandboxed install on the live profile, so the
+    // profile never keeps referencing the preview store deleted below.
+    assert.deepEqual(setup.platform.commands[2]?.args.slice(-2), ['install', '--ignore-scripts'])
+    assert.equal(setup.platform.commands[2]?.sandboxed, false)
+    assert.equal(setup.platform.commands[2]?.dshHome, setup.dshHome)
     assert.equal(setup.runtime.liveStops, 1)
     assert.equal(setup.runtime.liveStarts, 1)
 


### PR DESCRIPTION
## Problem

After applying a marketplace preview, every subsequent plugin install fails with `dsh: pnpm failed in profile directory ...`:

1. Preview installs run pnpm inside the preview root; under the write-restricted seatbelt pnpm's store lands inside the preview root (`<previews>/<tx>/.pnpm-store/v11`) and `node_modules/.modules.yaml` records that path.
2. `applyPreview()` renames the candidate profile into the live profile and then deletes the whole preview root — store included — while the applied profile keeps referencing it.
3. Every later `preview()` copies this poisoned profile; pnpm refuses the copied tree with `ERR_PNPM_UNEXPECTED_STORE` and the marketplace is broken for all plugins (verified on a fresh machine: first install works, every one after the first apply fails).

The live profile itself also keeps referencing a store that no longer exists (it only works by accident of hard links).

## Fix

- **`preview()`**: for install/update/uninstall, strip `node_modules` + `pnpm-lock.yaml` from the copied candidate profile so the preview's pnpm commands always start from a clean tree and rebuild against the preview's own store.
- **`applyPreview()`**: after the candidate becomes the live profile, re-home its `node_modules` against the persistent home store with an unsandboxed `dsh plugin install` (new `sandboxed: false` option on `DshCommandInput`), so the live profile never references a store that is about to be deleted. Best effort: failure only warns — the hard links keep the tree usable, and the dsh CLI self-heals on the next pnpm command.
- **`dispatch()`**: clear `#error` after returning the snapshot that reports it, so later read-only snapshots (search/status) stop surfacing a stale failure from an older dispatch.

## Tests

- New regression test: a live profile with a stale `.modules.yaml` store reference gets its preview copy stripped (live profile untouched).
- Updated the apply flow test to assert the post-apply re-home command (`sandboxed: false`, live `dshHome`).
- `pnpm typecheck` clean; marketplace suite 34/34 passing (the 1 TUI failure in the full suite is pre-existing on main).
