### PR TITLE
release: allow unsigned package fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   package:
@@ -49,11 +50,11 @@ jobs:
       DSH_DESKTOP_NODE_ARCH: ${{ matrix.node_arch }}
       DSH_DESKTOP_NODE_PLATFORM: ${{ matrix.node_platform }}
       npm_config_pm_on_fail: 'ignore'
-      CSC_LINK: ${{ matrix.node_platform == 'win' && secrets.WINDOWS_CSC_LINK || secrets.MACOS_CSC_LINK }}
-      CSC_KEY_PASSWORD: ${{ matrix.node_platform == 'win' && secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.MACOS_CSC_KEY_PASSWORD }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      CSC_LINK: ${{ matrix.node_platform == 'darwin' && secrets.MACOS_CSC_LINK || matrix.node_platform == 'win' && secrets.WINDOWS_CSC_LINK || '' }}
+      CSC_KEY_PASSWORD: ${{ matrix.node_platform == 'darwin' && secrets.MACOS_CSC_KEY_PASSWORD || matrix.node_platform == 'win' && secrets.WINDOWS_CSC_KEY_PASSWORD || '' }}
+      APPLE_ID: ${{ matrix.node_platform == 'darwin' && secrets.APPLE_ID || '' }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.node_platform == 'darwin' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+      APPLE_TEAM_ID: ${{ matrix.node_platform == 'darwin' && secrets.APPLE_TEAM_ID || '' }}
 
     steps:
       - name: Check out repository
@@ -79,22 +80,29 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Validate macOS signing credentials
+      - name: Select macOS signing mode
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          test -n "$CSC_LINK"
-          test -n "$CSC_KEY_PASSWORD"
-          test -n "$APPLE_ID"
-          test -n "$APPLE_APP_SPECIFIC_PASSWORD"
-          test -n "$APPLE_TEAM_ID"
+          if test -n "$CSC_LINK" && test -n "$CSC_KEY_PASSWORD" && test -n "$APPLE_ID" && test -n "$APPLE_APP_SPECIFIC_PASSWORD" && test -n "$APPLE_TEAM_ID"; then
+            echo "macOS signing and notarization are enabled." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::macOS signing credentials are incomplete; producing an ad-hoc-signed package that requires manual Gatekeeper approval."
+            printf '%s\n' 'CSC_LINK=' 'CSC_KEY_PASSWORD=' 'APPLE_ID=' 'APPLE_APP_SPECIFIC_PASSWORD=' 'APPLE_TEAM_ID=' >> "$GITHUB_ENV"
+            echo "macOS signing: ad-hoc fallback; automatic updates are unsupported." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-      - name: Validate Windows signing credentials
+      - name: Select Windows signing mode
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          test -n "$CSC_LINK"
-          test -n "$CSC_KEY_PASSWORD"
+          if test -n "$CSC_LINK" && test -n "$CSC_KEY_PASSWORD"; then
+            echo "Windows Authenticode signing is enabled." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Windows signing credentials are incomplete; producing an unsigned installer that may require manual SmartScreen approval."
+            printf '%s\n' 'CSC_LINK=' 'CSC_KEY_PASSWORD=' 'WIN_CSC_LINK=' 'WIN_CSC_KEY_PASSWORD=' >> "$GITHUB_ENV"
+            echo "Windows signing: unsigned fallback; automatic updates are unsupported." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Package desktop distribution
         run: pnpm run ${{ matrix.dist_script }}
@@ -128,8 +136,11 @@ jobs:
 
   publish:
     name: Publish GitHub release
+    if: github.event_name == 'push'
     needs: package
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/docs/usage.en.md
+++ b/docs/usage.en.md
@@ -60,6 +60,10 @@ Run the Windows installer from the Release and start **Oh-DSH Desktop**. The uni
 `bin\ohdsh.cmd` under the application resources directory; add that directory
 to `PATH` if desired.
 
+An unsigned installer may trigger Windows SmartScreen. After verifying that it
+came from the project Release, choose **More info**, then **Run anyway**. The
+installer may request administrator approval.
+
 ### Desktop online updates
 
 Choose **Oh-DSH Desktop -> Check for Updates...** from the application menu.
@@ -224,10 +228,20 @@ pnpm run dist:web       # Web-only lightweight distribution
 pnpm run dist:tui       # TUI-only terminal distribution
 ```
 
-Publishing an auto-update tag also requires GitHub Actions secrets for macOS
-signing/notarization and Windows Authenticode signing. The workflow refuses to
-publish if credentials, an installer, a blockmap, or `latest*.yml` metadata is
-missing.
+The release workflow produces formally signed packages when all GitHub Actions
+secrets for macOS signing/notarization and Windows Authenticode signing are
+available. If either credential set is incomplete, the workflow emits an
+explicit warning and falls back to an ad-hoc-signed macOS package or an
+unsigned Windows installer without blocking Web, TUI, and Desktop packaging.
+Fallback artifacts support only the manual installation described above and
+must not be treated as supporting automatic updates. Formal signing requires
+`MACOS_CSC_LINK`, `MACOS_CSC_KEY_PASSWORD`, `APPLE_ID`,
+`APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `WINDOWS_CSC_LINK`, and
+`WINDOWS_CSC_KEY_PASSWORD`. Installers, embedded or external blockmaps, and
+`latest*.yml` metadata remain strictly validated and stop the release when
+missing. Run the Release workflow manually from Actions for a four-platform
+packaging check; manual runs upload workflow artifacts without creating a
+GitHub Release.
 
 ## Data and troubleshooting
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,6 +56,9 @@ sudo apt install ./Oh-DSH-Desktop-*.deb
 运行 Release 中的 Windows 安装器并启动 **Oh-DSH Desktop**。统一 CLI 位于应用
 资源目录的 `bin\ohdsh.cmd`，可以将该目录加入 `PATH`。
 
+未签名安装器可能触发 Windows SmartScreen。确认文件来自项目 Release 后，选择
+“更多信息”再选择“仍要运行”；安装过程可能请求管理员授权。
+
 ### Desktop 在线更新
 
 在应用菜单中选择 **Oh-DSH Desktop -> 检查更新…**。更新窗口只检查
@@ -208,9 +211,15 @@ pnpm run dist:web       # Web-only 轻量版
 pnpm run dist:tui       # TUI-only 终端版
 ```
 
-发布带自动更新功能的 tag 还需要配置 GitHub Actions 的 macOS 签名/公证凭据和
-Windows Authenticode 凭据。工作流会在任意一个凭据、安装包、blockmap 或
-`latest*.yml` 缺失时停止发布。
+发布工作流在 GitHub Actions 的 macOS 签名/公证凭据和 Windows Authenticode
+凭据齐全时生成正式签名包。缺少任一组凭据时，工作流会明确警告并降级生成 macOS
+ad-hoc 签名包或 Windows 未签名安装器，而不会阻止 Web、TUI 和 Desktop 打包。
+降级产物仅支持上文所述的手动安装，不能视为支持自动更新。启用正式签名需要配置
+`MACOS_CSC_LINK`、`MACOS_CSC_KEY_PASSWORD`、`APPLE_ID`、
+`APPLE_APP_SPECIFIC_PASSWORD`、`APPLE_TEAM_ID`、`WINDOWS_CSC_LINK` 和
+`WINDOWS_CSC_KEY_PASSWORD`。安装包、内嵌或外置 blockmap、`latest*.yml` 元数据
+仍会被严格校验，缺失时停止发布。可从 Actions 手动运行 Release workflow 做四平台
+打包检查；手动运行只上传 workflow artifacts，不创建 GitHub Release。
 
 ## 数据与排错
 

--- a/scripts/update-metadata.mjs
+++ b/scripts/update-metadata.mjs
@@ -1,13 +1,14 @@
 import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import { basename, join } from 'node:path'
+import { gunzipSync, inflateRawSync } from 'node:zlib'
 import YAML from 'yaml'
 
 export const PLATFORM_RULES = Object.freeze({
-  'mac-arm64': { metadata: 'latest-mac.yml', arch: 'arm64', extension: '.zip' },
-  'mac-x64': { metadata: 'latest-mac.yml', arch: 'x64', extension: '.zip' },
-  'win-x64': { metadata: 'latest.yml', arch: 'x64', extension: '.exe' },
-  'linux-x64': { metadata: 'latest-linux.yml', arch: 'x86_64', extension: '.AppImage' },
+  'mac-arm64': { metadata: 'latest-mac.yml', arch: 'arm64', extension: '.zip', blockmap: 'external' },
+  'mac-x64': { metadata: 'latest-mac.yml', arch: 'x64', extension: '.zip', blockmap: 'external' },
+  'win-x64': { metadata: 'latest.yml', arch: 'x64', extension: '.exe', blockmap: 'external' },
+  'linux-x64': { metadata: 'latest-linux.yml', arch: 'x86_64', extension: '.AppImage', blockmap: 'embedded' },
 })
 
 function assetName(file) {
@@ -32,7 +33,39 @@ function sha512(path) {
   return createHash('sha512').update(readFileSync(path)).digest('base64')
 }
 
-function verifyFile(dir, file) {
+function parseBlockmap(data, decompress, name) {
+  let blockmap
+  try {
+    blockmap = JSON.parse(decompress(data).toString('utf8'))
+  } catch {
+    throw new Error(`invalid blockmap for ${name}`)
+  }
+  if (blockmap?.version !== '2' || !Array.isArray(blockmap.files) || blockmap.files.length === 0) {
+    throw new Error(`invalid blockmap for ${name}`)
+  }
+}
+
+function verifyExternalBlockmap(path, name) {
+  const blockmapPath = `${path}.blockmap`
+  if (!existsSync(blockmapPath)) throw new Error(`missing external blockmap: ${basename(blockmapPath)}`)
+  parseBlockmap(readFileSync(blockmapPath), gunzipSync, name)
+}
+
+function verifyEmbeddedBlockmap(path, name, expectedSize) {
+  const blockmapSize = Number(expectedSize)
+  if (!Number.isSafeInteger(blockmapSize) || blockmapSize <= 0) {
+    throw new Error(`invalid embedded blockmap size for ${name}`)
+  }
+  const data = readFileSync(path)
+  if (data.length < blockmapSize + 4) throw new Error(`truncated embedded blockmap for ${name}`)
+  const trailerSize = data.readUInt32BE(data.length - 4)
+  if (trailerSize !== blockmapSize) {
+    throw new Error(`embedded blockmap size mismatch for ${name}: metadata=${String(blockmapSize)} trailer=${String(trailerSize)}`)
+  }
+  parseBlockmap(data.subarray(data.length - blockmapSize - 4, data.length - 4), inflateRawSync, name)
+}
+
+function verifyFile(dir, file, blockmap) {
   const name = assetName(file)
   const path = join(dir, name)
   if (!existsSync(path)) throw new Error(`metadata references missing asset: ${name}`)
@@ -44,10 +77,11 @@ function verifyFile(dir, file) {
   if (file.size !== undefined && Number(file.size) !== statSync(path).size) {
     throw new Error(`size mismatch for ${name}: metadata=${String(file.size)} actual=${String(statSync(path).size)}`)
   }
-  if (file.blockMapSize !== undefined) {
-    const blockmap = `${path}.blockmap`
-    if (!existsSync(blockmap)) throw new Error(`metadata references missing blockmap: ${basename(blockmap)}`)
-    if (Number(file.blockMapSize) !== statSync(blockmap).size) throw new Error(`blockmap size mismatch for ${name}`)
+  if (blockmap === 'embedded') {
+    if (file.blockMapSize === undefined) throw new Error(`metadata asset has no embedded blockmap size: ${name}`)
+    verifyEmbeddedBlockmap(path, name, file.blockMapSize)
+  } else {
+    verifyExternalBlockmap(path, name)
   }
   return name
 }
@@ -86,7 +120,7 @@ export function verifyMetadata({ dir, version, platform }) {
     return lower.endsWith(rule.extension.toLowerCase()) && lower.includes(rule.arch.toLowerCase())
   })
   if (candidates.length !== 1) throw new Error(`expected one ${platform} updater asset, found ${String(candidates.length)}`)
-  const selected = verifyFile(dir, candidates[0])
+  const selected = verifyFile(dir, candidates[0], rule.blockmap)
   if (metadata.files.some(file => assetName(file).toLowerCase().includes('oh-dsh-web'))) {
     throw new Error(`web distribution was included in ${rule.metadata}`)
   }

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -19,6 +19,10 @@ test('tagged releases build and upload both TUI archive formats', () => {
   assert.match(workflow, /fetch-depth: 0/)
   assert.match(workflow, /fetch-tags: true/)
   assert.match(workflow, /validate-release-tag\.mjs --tag/)
+  assert.match(workflow, /workflow_dispatch:/)
+  assert.match(workflow, /if: github\.event_name == 'push'/)
+  assert.match(workflow, /macOS signing credentials are incomplete; producing an ad-hoc-signed package/)
+  assert.match(workflow, /Windows signing credentials are incomplete; producing an unsigned installer/)
 })
 
 test('release tags must match a stable package version', () => {

--- a/tests/update-metadata.test.ts
+++ b/tests/update-metadata.test.ts
@@ -1,19 +1,47 @@
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { deflateRawSync, gzipSync } from 'node:zlib'
 import { mergeMetadata, verifyMetadata } from '../scripts/update-metadata.mjs'
+
+const blockmap = Buffer.from(JSON.stringify({
+  version: '2',
+  files: [{ name: 'file', offset: 0, checksums: ['checksum'], sizes: [1] }],
+}))
+
+function sha512(data: Buffer) {
+  return createHash('sha512').update(data).digest('base64')
+}
 
 async function asset(dir: string, name: string, content: string) {
   const path = join(dir, name)
-  await writeFile(path, content)
   const data = Buffer.from(content)
+  await writeFile(path, data)
   return {
     url: `https://github.com/hust-open-atom-club/oh-dsh/releases/download/v1.2.0/${name}`,
-    sha512: createHash('sha512').update(data).digest('base64'),
+    sha512: sha512(data),
     size: data.length,
+  }
+}
+
+async function externalBlockmap(dir: string, name: string) {
+  await writeFile(join(dir, `${name}.blockmap`), gzipSync(blockmap))
+}
+
+async function appImageAsset(dir: string, name: string, content: string) {
+  const compressed = deflateRawSync(blockmap)
+  const trailer = Buffer.allocUnsafe(4)
+  trailer.writeUInt32BE(compressed.length)
+  const data = Buffer.concat([Buffer.from(content), compressed, trailer])
+  await writeFile(join(dir, name), data)
+  return {
+    url: `https://github.com/hust-open-atom-club/oh-dsh/releases/download/v1.2.0/${name}`,
+    sha512: sha512(data),
+    size: data.length,
+    blockMapSize: compressed.length,
   }
 }
 
@@ -21,6 +49,8 @@ test('metadata verification selects one architecture and validates SHA-512', asy
   const dir = await mkdtemp(join(tmpdir(), 'oh-dsh-metadata-'))
   const arm = await asset(dir, 'Oh-DSH-Desktop-1.2.0-arm64.zip', 'arm')
   const x64 = await asset(dir, 'Oh-DSH-Desktop-1.2.0-x64.zip', 'x64')
+  await externalBlockmap(dir, 'Oh-DSH-Desktop-1.2.0-arm64.zip')
+  await externalBlockmap(dir, 'Oh-DSH-Desktop-1.2.0-x64.zip')
   await writeFile(join(dir, 'latest-mac.yml'), [
     'version: 1.2.0',
     'files:',
@@ -31,6 +61,38 @@ test('metadata verification selects one architecture and validates SHA-512', asy
   assert.equal(result.selected, arm.url.split('/').pop())
   await writeFile(join(dir, 'Oh-DSH-Desktop-1.2.0-arm64.zip'), 'tampered')
   assert.throws(() => verifyMetadata({ dir, version: '1.2.0', platform: 'mac-arm64' }), /sha512 mismatch/)
+})
+
+test('metadata verification accepts an embedded AppImage blockmap', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'oh-dsh-metadata-'))
+  const name = 'Oh-DSH-Desktop-1.2.0-x86_64.AppImage'
+  const app = await appImageAsset(dir, name, 'app')
+  const metadata = () => [
+    'version: 1.2.0',
+    'files:',
+    `  - ${JSON.stringify(app)}`,
+  ].join('\n')
+  await writeFile(join(dir, 'latest-linux.yml'), metadata())
+  const result = verifyMetadata({ dir, version: '1.2.0', platform: 'linux-x64' })
+  assert.equal(result.selected, name)
+
+  const data = await readFile(join(dir, name))
+  data.writeUInt32BE(app.blockMapSize + 1, data.length - 4)
+  app.sha512 = sha512(data)
+  await writeFile(join(dir, name), data)
+  await writeFile(join(dir, 'latest-linux.yml'), metadata())
+  assert.throws(() => verifyMetadata({ dir, version: '1.2.0', platform: 'linux-x64' }), /embedded blockmap size mismatch/)
+})
+
+test('metadata verification requires external desktop blockmaps', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'oh-dsh-metadata-'))
+  const app = await asset(dir, 'Oh-DSH-Desktop-1.2.0-arm64.zip', 'app')
+  await writeFile(join(dir, 'latest-mac.yml'), [
+    'version: 1.2.0',
+    'files:',
+    `  - ${JSON.stringify(app)}`,
+  ].join('\n'))
+  assert.throws(() => verifyMetadata({ dir, version: '1.2.0', platform: 'mac-arm64' }), /missing external blockmap/)
 })
 
 test('metadata merge combines macOS architectures and rejects version conflicts', () => {
@@ -44,7 +106,7 @@ test('metadata merge combines macOS architectures and rejects version conflicts'
 test('metadata verification rejects web distribution assets', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'oh-dsh-metadata-'))
   await mkdir(join(dir, 'nested'))
-  const app = await asset(dir, 'Oh-DSH-Desktop-1.2.0-x86_64.AppImage', 'app')
+  const app = await appImageAsset(dir, 'Oh-DSH-Desktop-1.2.0-x86_64.AppImage', 'app')
   const web = await asset(dir, 'oh-dsh-web-1.2.0-linux-x64.zip', 'web')
   await writeFile(join(dir, 'latest-linux.yml'), [
     'version: 1.2.0',


### PR DESCRIPTION
## Summary

- allow release packaging to fall back to ad-hoc macOS signing and an unsigned Windows installer when signing secrets are incomplete
- keep platform credentials isolated and emit explicit workflow warnings for fallback artifacts
- validate embedded AppImage blockmaps separately from external macOS and Windows blockmaps
- add a manual four-platform package-only Release workflow run
- document manual installation and the limits of unsigned fallback artifacts in both languages

## Root cause

The v0.1.5 Release run failed for two independent reasons:

- the repository has no configured signing secrets, so both macOS jobs and the Windows job stopped before packaging
- Linux produced a valid AppImage with an embedded blockmap, but the validator incorrectly required a sibling `.blockmap` file

The previous validator also did not require the external blockmaps produced for macOS ZIP and Windows NSIS artifacts.

## Impact

A complete credential set still enables normal macOS signing/notarization or Windows Authenticode signing. An incomplete set is cleared before packaging so the existing ad-hoc/unsigned fallback is deterministic and visibly reported.

Fallback artifacts are intended for manual installation only; automatic updates remain unsupported until formal signing credentials are provisioned.

Manual workflow dispatches package and upload all platform artifacts without creating a GitHub Release, allowing a dry run before moving a public tag.

## Verification

- `pnpm run typecheck`
- `pnpm test` — 161 tests, 156 passed, 5 platform-specific skips
- `pnpm run build`
- focused release workflow and updater metadata tests — 7 passed
- release workflow YAML parse and unsigned fallback shell execution
- full unsigned macOS arm64 package build
- strict verification of the resulting ad-hoc app signature
- validation of generated macOS updater metadata and external ZIP blockmap

Related failed run: https://github.com/hust-open-atom-club/oh-dsh/actions/runs/31891357516