### PR TITLE
website: present Oh-DSH across three surfaces

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,13 +6,13 @@
         <meta name="theme-color" content="#080b12">
         <meta
             name="description"
-            content="Oh-DSH Desktop 是构建在 DeepSeek Harness 之上的可安装、可扩展桌面工作台。"
+            content="Oh-DSH 以一套 DSH runtime 提供 Desktop、Web UI 与 TUI 三种开发体验。"
         >
         <meta property="og:type" content="website">
-        <meta property="og:title" content="Oh-DSH Desktop">
+        <meta property="og:title" content="Oh-DSH">
         <meta
             property="og:description"
-            content="把 Chat、终端、文件、代码审查和插件带到同一个桌面工作台。"
+            content="一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。"
         >
         <meta property="og:url" content="https://dsh.openatom.club/">
         <meta
@@ -20,7 +20,7 @@
             content="https://dsh.openatom.club/assets/oh-dsh-desktop-landing.png"
         >
         <meta name="twitter:card" content="summary_large_image">
-        <title>Oh-DSH Desktop</title>
+        <title>Oh-DSH</title>
         <link rel="stylesheet" href="site.css">
         <script src="site.js" defer></script>
     </head>
@@ -70,8 +70,15 @@
                     </div>
 
                     <div class="hero-copy">
-                        <h1 id="hero-title" data-i18n="title">
-                            让 Harness 成为你的桌面工作流
+                        <h1 id="hero-title" class="hero-title">
+                            <span data-i18n="sloganRuntime">一套 DSH runtime，</span>
+                            <span
+                                class="hero-title-surfaces"
+                                data-i18n="sloganSurfaces"
+                            >
+                                Desktop、Web 与 TUI
+                            </span>
+                            <span data-i18n="sloganExperience">三种开发体验。</span>
                         </h1>
                         <div class="hero-actions">
                             <a
@@ -83,6 +90,37 @@
                                 下载最新版
                             </a>
                         </div>
+                    </div>
+                </section>
+
+                <section
+                    class="surface-support"
+                    aria-labelledby="surface-support-title"
+                >
+                    <div class="surface-heading">
+                        <p class="section-label" data-i18n="surfaceLabel">
+                            全端支持
+                        </p>
+                        <h2 id="surface-support-title" data-i18n="surfaceTitle">
+                            同一套 DSH，适配三种开发场景
+                        </h2>
+                    </div>
+                    <div class="surface-grid">
+                        <article class="surface-card">
+                            <span class="surface-index" aria-hidden="true">01</span>
+                            <h3>Desktop</h3>
+                            <p data-i18n="desktopDetail">完整的本地开发工作台</p>
+                        </article>
+                        <article class="surface-card">
+                            <span class="surface-index" aria-hidden="true">02</span>
+                            <h3>Web UI</h3>
+                            <p data-i18n="webDetail">随时从浏览器接入工作区</p>
+                        </article>
+                        <article class="surface-card">
+                            <span class="surface-index" aria-hidden="true">03</span>
+                            <h3>TUI</h3>
+                            <p data-i18n="tuiDetail">在终端里保持专注与速度</p>
+                        </article>
                     </div>
                 </section>
             </main>

--- a/website/site.css
+++ b/website/site.css
@@ -12,6 +12,12 @@
     --accent-strong: #a9c4ff;
 }
 
+html:lang(zh-CN) {
+    font-family:
+        -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB",
+        "Microsoft YaHei", ui-sans-serif, sans-serif;
+}
+
 * {
     box-sizing: border-box;
 }
@@ -165,7 +171,7 @@ a:focus-visible {
 
 .hero {
     display: grid;
-    grid-template-columns: minmax(0, 1.75fr) minmax(320px, 0.65fr);
+    grid-template-columns: minmax(0, 1.55fr) minmax(400px, 0.75fr);
     gap: clamp(44px, 5vw, 96px);
     align-items: start;
     min-height: calc(100vh - 154px);
@@ -213,16 +219,44 @@ a:focus-visible {
 }
 
 .hero-copy {
-    max-width: 460px;
+    max-width: 500px;
 }
 
-h1 {
-    max-width: 12ch;
+.hero-title {
+    display: grid;
+    gap: 0.06em;
     margin: 0;
-    font-size: clamp(48px, 5vw, 82px);
-    line-height: 1.02;
-    letter-spacing: -0.055em;
-    text-wrap: balance;
+    font-size: clamp(38px, 3vw, 52px);
+    font-weight: 680;
+    line-height: 1.08;
+    letter-spacing: -0.045em;
+}
+
+.hero-title > span {
+    display: block;
+    white-space: nowrap;
+}
+
+.hero-title-surfaces {
+    margin: 0.28em 0 0.22em;
+    color: var(--accent-strong);
+    font-size: 0.4em;
+    font-weight: 740;
+    line-height: 1.2;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+html:lang(zh-CN) .hero-title {
+    font-size: clamp(40px, 3.2vw, 52px);
+    font-weight: 650;
+    line-height: 1.15;
+    letter-spacing: -0.04em;
+}
+
+html:lang(zh-CN) .hero-title-surfaces {
+    font-size: 0.38em;
+    letter-spacing: 0.035em;
 }
 
 .hero-actions {
@@ -254,6 +288,79 @@ h1 {
     background: #ffffff;
     box-shadow: 0 18px 38px rgba(0, 0, 0, 0.38);
     transform: translateY(-2px);
+}
+
+.surface-support {
+    padding: 0 0 clamp(88px, 9vw, 150px);
+}
+
+.surface-heading {
+    display: grid;
+    grid-template-columns: minmax(150px, 0.45fr) minmax(0, 1.55fr);
+    gap: 32px;
+    align-items: start;
+    padding: 30px 0 38px;
+    border-top: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+.section-label {
+    margin: 5px 0 0;
+    color: var(--accent-strong);
+    font-size: 12px;
+    font-weight: 720;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.surface-heading h2 {
+    max-width: 18ch;
+    margin: 0;
+    font-size: clamp(30px, 3vw, 48px);
+    line-height: 1.12;
+    letter-spacing: -0.045em;
+    text-wrap: balance;
+}
+
+html:lang(zh-CN) .surface-heading h2 {
+    font-weight: 650;
+    line-height: 1.24;
+    letter-spacing: -0.035em;
+}
+
+.surface-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.surface-card {
+    min-height: 168px;
+    padding: 24px;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid var(--surface-border);
+    border-radius: 16px;
+    backdrop-filter: blur(18px);
+}
+
+.surface-index {
+    color: var(--quiet);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.08em;
+}
+
+.surface-card h3 {
+    margin: 30px 0 0;
+    font-size: 20px;
+    font-weight: 680;
+    letter-spacing: -0.025em;
+}
+
+.surface-card p {
+    margin: 8px 0 0;
+    color: var(--muted);
+    font-size: 14px;
+    line-height: 1.6;
 }
 
 .site-footer {
@@ -399,7 +506,7 @@ h1 {
 
 @media (max-width: 1120px) {
     .hero {
-        grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.85fr);
+        grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.9fr);
         gap: 42px;
     }
 }
@@ -429,9 +536,18 @@ h1 {
         grid-row: 2;
     }
 
-    h1 {
-        max-width: 11ch;
-        font-size: clamp(46px, 12vw, 68px);
+    .hero-title,
+    html:lang(zh-CN) .hero-title {
+        font-size: clamp(40px, 8vw, 56px);
+    }
+
+    .surface-heading {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+
+    .surface-heading h2 {
+        max-width: 22ch;
     }
 }
 
@@ -450,6 +566,19 @@ h1 {
 
     .download-dialog {
         padding: 30px 22px 22px;
+    }
+
+    .hero-title,
+    html:lang(zh-CN) .hero-title {
+        font-size: 36px;
+    }
+
+    .surface-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .surface-card {
+        min-height: 138px;
     }
 
     .site-footer {

--- a/website/site.js
+++ b/website/site.js
@@ -6,7 +6,15 @@ const releaseApiUrl =
 const translations = {
     "zh-CN": {
         star: "星标",
-        title: "让 Harness 成为你的桌面工作流",
+        pageTitle: "Oh-DSH｜一套 Runtime，三种开发体验",
+        sloganRuntime: "一套 DSH runtime，",
+        sloganSurfaces: "Desktop、Web 与 TUI",
+        sloganExperience: "三种开发体验。",
+        surfaceLabel: "全端支持",
+        surfaceTitle: "同一套 DSH，适配三种开发场景",
+        desktopDetail: "完整的本地开发工作台",
+        webDetail: "随时从浏览器接入工作区",
+        tuiDetail: "在终端里保持专注与速度",
         downloadLatest: "下载最新版",
         downloadMac: "下载 macOS 版",
         downloadWindows: "下载 Windows 版",
@@ -22,11 +30,19 @@ const translations = {
         footer: "开放、可组合的 DeepSeek Harness 工作台",
         screenshotAlt: "Oh-DSH Desktop 深色界面，包含工作区、对话和插件入口",
         pageDescription:
-            "Oh-DSH Desktop 是构建在 DeepSeek Harness 之上的可安装、可扩展桌面工作台。",
+            "Oh-DSH 以一套 DSH runtime 提供 Desktop、Web UI 与 TUI 三种开发体验。",
     },
     en: {
         star: "Star",
-        title: "Make Harness part of your desktop workflow",
+        pageTitle: "Oh-DSH — One Runtime, Three Interfaces",
+        sloganRuntime: "One DSH runtime.",
+        sloganSurfaces: "Desktop · Web · TUI",
+        sloganExperience: "Three ways to build.",
+        surfaceLabel: "Three surfaces",
+        surfaceTitle: "The same DSH, shaped for every workflow",
+        desktopDetail: "A complete local development workbench",
+        webDetail: "Open your workspace from any browser",
+        tuiDetail: "Stay focused and fast in the terminal",
         downloadLatest: "Download latest",
         downloadMac: "Download for macOS",
         downloadWindows: "Download for Windows",
@@ -43,7 +59,7 @@ const translations = {
         screenshotAlt:
             "Oh-DSH Desktop dark interface with workspace, conversation, and plugin navigation",
         pageDescription:
-            "Oh-DSH Desktop is an installable, extensible workbench built on DeepSeek Harness.",
+            "Oh-DSH brings Desktop, Web UI, and TUI together on one DSH runtime.",
     },
 };
 
@@ -146,6 +162,7 @@ function applyLanguage(language) {
     });
 
     elements.descriptionMeta.content = copy.pageDescription;
+    document.title = copy.pageTitle;
     elements.downloadTrigger.textContent = copy[downloadCopyKey()];
     elements.platformLabel.textContent = platformName(language);
     elements.languageToggle.textContent = language === "zh-CN" ? "EN" : "中";


### PR DESCRIPTION
## Summary

- present the product as Oh-DSH instead of a desktop-only experience
- use localized browser titles and the one-runtime, three-surface slogan
- add a compact Desktop, Web UI, and TUI capability overview
- tune Chinese typography and responsive headline layout

## Why

Oh-DSH now supports three interaction surfaces on the same runtime. The
landing page should describe the full product while keeping the primary
download action prominent.

## Validation

- `pnpm run typecheck`
- `pnpm test` (157 passed, 5 platform-specific skips)
- `pnpm run build:pages`
- desktop preview at 1440x900 in Chinese and English
- mobile preview at 390x844 without horizontal overflow
