### PR TITLE
release: omit empty signing variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,6 @@ jobs:
       DSH_DESKTOP_NODE_ARCH: ${{ matrix.node_arch }}
       DSH_DESKTOP_NODE_PLATFORM: ${{ matrix.node_platform }}
       npm_config_pm_on_fail: 'ignore'
-      CSC_LINK: ${{ matrix.node_platform == 'darwin' && secrets.MACOS_CSC_LINK || matrix.node_platform == 'win' && secrets.WINDOWS_CSC_LINK || '' }}
-      CSC_KEY_PASSWORD: ${{ matrix.node_platform == 'darwin' && secrets.MACOS_CSC_KEY_PASSWORD || matrix.node_platform == 'win' && secrets.WINDOWS_CSC_KEY_PASSWORD || '' }}
-      APPLE_ID: ${{ matrix.node_platform == 'darwin' && secrets.APPLE_ID || '' }}
-      APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.node_platform == 'darwin' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-      APPLE_TEAM_ID: ${{ matrix.node_platform == 'darwin' && secrets.APPLE_TEAM_ID || '' }}
 
     steps:
       - name: Check out repository
@@ -83,28 +78,59 @@ jobs:
       - name: Select macOS signing mode
         if: runner.os == 'macOS'
         shell: bash
+        env:
+          MACOS_CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          MACOS_CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          MACOS_APPLE_ID: ${{ secrets.APPLE_ID }}
+          MACOS_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          MACOS_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          if test -n "$CSC_LINK" && test -n "$CSC_KEY_PASSWORD" && test -n "$APPLE_ID" && test -n "$APPLE_APP_SPECIFIC_PASSWORD" && test -n "$APPLE_TEAM_ID"; then
+          if test -n "$MACOS_CSC_LINK" && test -n "$MACOS_CSC_KEY_PASSWORD" && test -n "$MACOS_APPLE_ID" && test -n "$MACOS_APPLE_APP_SPECIFIC_PASSWORD" && test -n "$MACOS_APPLE_TEAM_ID"; then
+            echo 'DSH_DESKTOP_SIGNING=enabled' >> "$GITHUB_ENV"
             echo "macOS signing and notarization are enabled." >> "$GITHUB_STEP_SUMMARY"
           else
+            echo 'DSH_DESKTOP_SIGNING=fallback' >> "$GITHUB_ENV"
             echo "::warning::macOS signing credentials are incomplete; producing an ad-hoc-signed package that requires manual Gatekeeper approval."
-            printf '%s\n' 'CSC_LINK=' 'CSC_KEY_PASSWORD=' 'APPLE_ID=' 'APPLE_APP_SPECIFIC_PASSWORD=' 'APPLE_TEAM_ID=' >> "$GITHUB_ENV"
             echo "macOS signing: ad-hoc fallback; automatic updates are unsupported." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Select Windows signing mode
         if: runner.os == 'Windows'
         shell: bash
+        env:
+          WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          WINDOWS_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
         run: |
-          if test -n "$CSC_LINK" && test -n "$CSC_KEY_PASSWORD"; then
+          if test -n "$WINDOWS_CSC_LINK" && test -n "$WINDOWS_CSC_KEY_PASSWORD"; then
+            echo 'DSH_DESKTOP_SIGNING=enabled' >> "$GITHUB_ENV"
             echo "Windows Authenticode signing is enabled." >> "$GITHUB_STEP_SUMMARY"
           else
+            echo 'DSH_DESKTOP_SIGNING=fallback' >> "$GITHUB_ENV"
             echo "::warning::Windows signing credentials are incomplete; producing an unsigned installer that may require manual SmartScreen approval."
-            printf '%s\n' 'CSC_LINK=' 'CSC_KEY_PASSWORD=' 'WIN_CSC_LINK=' 'WIN_CSC_KEY_PASSWORD=' >> "$GITHUB_ENV"
             echo "Windows signing: unsigned fallback; automatic updates are unsupported." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Package desktop distribution
+      - name: Package signed macOS desktop distribution
+        if: runner.os == 'macOS' && env.DSH_DESKTOP_SIGNING == 'enabled'
+        env:
+          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: pnpm run ${{ matrix.dist_script }}
+
+      - name: Package signed Windows desktop distribution
+        if: runner.os == 'Windows' && env.DSH_DESKTOP_SIGNING == 'enabled'
+        env:
+          CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
+        run: pnpm run ${{ matrix.dist_script }}
+
+      - name: Package desktop distribution without release credentials
+        if: env.DSH_DESKTOP_SIGNING != 'enabled'
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
         run: pnpm run ${{ matrix.dist_script }}
 
       - name: Package Oh-DSH-Web distribution

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
 import { validateReleaseTag } from '../scripts/validate-release-tag.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -23,6 +24,30 @@ test('tagged releases build and upload both TUI archive formats', () => {
   assert.match(workflow, /if: github\.event_name == 'push'/)
   assert.match(workflow, /macOS signing credentials are incomplete; producing an ad-hoc-signed package/)
   assert.match(workflow, /Windows signing credentials are incomplete; producing an unsigned installer/)
+
+  const config = parse(workflow)
+  const packageJob = config.jobs.package
+  assert.equal('CSC_LINK' in packageJob.env, false)
+  assert.equal('CSC_KEY_PASSWORD' in packageJob.env, false)
+
+  const fallbackStep = packageJob.steps.find(
+    (step: { name?: string }) =>
+      step.name === 'Package desktop distribution without release credentials',
+  )
+  assert.equal(fallbackStep.if, "env.DSH_DESKTOP_SIGNING != 'enabled'")
+  assert.equal(fallbackStep.env.CSC_IDENTITY_AUTO_DISCOVERY, 'false')
+
+  const signedMacStep = packageJob.steps.find(
+    (step: { name?: string }) =>
+      step.name === 'Package signed macOS desktop distribution',
+  )
+  assert.match(signedMacStep.env.CSC_LINK, /secrets\.MACOS_CSC_LINK/)
+
+  const signedWindowsStep = packageJob.steps.find(
+    (step: { name?: string }) =>
+      step.name === 'Package signed Windows desktop distribution',
+  )
+  assert.match(signedWindowsStep.env.CSC_LINK, /secrets\.WINDOWS_CSC_LINK/)
 })
 
 test('release tags must match a stable package version', () => {


### PR DESCRIPTION
## Summary

- keep signing credentials out of the package job environment
- expose credentials only to complete signed macOS or Windows package steps
- run Linux and unsigned fallback packaging without `CSC_LINK`
- add a workflow regression check for credential scoping

## Root cause

The package-only Release run exposed a distinction between an unset variable
and an empty variable. Missing GitHub secrets were rendered as an empty
job-level `CSC_LINK`. electron-builder resolved that empty value to the
repository directory and failed with `not a file` on both macOS runners.

This follow-up to #64 makes the unsigned fallback truly credential-free while
preserving signed packaging whenever the full platform credential set exists.

## Impact

Repositories without signing secrets can produce ad-hoc macOS packages and
unsigned Windows packages. Repositories with complete credentials continue to
use formal signing and macOS notarization.

## Verification

- `node --test tests/release-workflow.test.ts`
- `pnpm run typecheck`
- `pnpm test` (157 passed, 5 platform-specific skipped)
- `pnpm run build`
- macOS arm64 package with all signing variables unset and
  `CSC_IDENTITY_AUTO_DISCOVERY=false`
- strict local code-signature verification (ad-hoc, no Team ID)
- macOS updater metadata and blockmap verification

Diagnostic package-only run: https://github.com/hust-open-atom-club/oh-dsh/actions/runs/31894499512