### PR TITLE
test: retry Windows Web smoke cleanup

### DIFF
--- a/scripts/smoke-web.mjs
+++ b/scripts/smoke-web.mjs
@@ -360,5 +360,10 @@ try {
       })
     })
   }
-  rmSync(smokeRoot, { recursive: true, force: true })
+  rmSync(smokeRoot, {
+    recursive: true,
+    force: true,
+    maxRetries: 10,
+    retryDelay: 250,
+  })
 }


### PR DESCRIPTION
## Summary

- retry recursive cleanup of the Windows Web smoke temporary directory
- keep the Web smoke assertions unchanged

## Why

The first `v0.1.5` Release run `31900376938` completed the Windows Web packaging and all Web assertions, but Windows returned `EPERM` while removing the temporary smoke directory after the child exited. The cleanup used no retries, so a transient file handle failed the whole release job.

## Verification

- package-only run [31900947294](https://github.com/hust-open-atom-club/oh-dsh/actions/runs/31900947294) passed on Linux x64, Windows x64, macOS arm64, and macOS x64
- native Windows completed Desktop/NSIS, Web, TUI, updater metadata, and artifact upload
- `pnpm run smoke:web`
- `pnpm run typecheck`
- `pnpm test` (157 passed, 5 skipped)
- `pnpm run build`