### PR TITLE
docs: rename upstream dependencies to plugin recommendations and add dshfind

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -165,13 +165,14 @@ or only TUI with `pnpm run dist:tui`.
 - [Installation, operations, and troubleshooting](./docs/usage.en.md)
 - [Architecture, design, and plugin boundaries](./docs/design.en.md)
 
-## Upstream dependencies
+## Plugin recommendations
 
-| Upstream repository | Role in Oh-DSH |
+| Recommended project | Description |
 | --- | --- |
 | [DeepSeek Harness](https://github.com/deepseek-harness/deepseek-harness) | DSH runtime, sessions, and plugin loader |
 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | **Direct upstream plugin for Oh-DSH TUI**, providing terminal rendering, interaction, and commands |
 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | Git review, files, and PTY host capabilities |
+| [dshfind](https://dshfind.com/) | DSH plugin marketplace and learning community with plugin, ecosystem, and DeepSeek Harness peripheral recommendations |
 
 Oh-DSH preserves upstream implementations and attribution, then provides the
 unified launcher, Profiles, data root, cross-surface skins, interface

--- a/README.md
+++ b/README.md
@@ -162,13 +162,14 @@ Web 使用 `pnpm run dist:web`；只打包 TUI 使用 `pnpm run dist:tui`。
 - [安装、操作与排错](./docs/usage.md)
 - [架构设计与插件边界](./docs/design.md)
 
-## 上游依赖
+## 插件推荐
 
-| 上游仓库 | Oh-DSH 中的用途 |
+| 推荐项目 | 说明 |
 | --- | --- |
 | [DeepSeek Harness](https://github.com/deepseek-harness/deepseek-harness) | DSH runtime、会话与插件加载器 |
 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | **Oh-DSH TUI 的直接上游插件**，提供终端渲染、交互和命令体系 |
 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | Git Review、文件与 PTY Host 能力 |
+| [dshfind](https://dshfind.com/) | DSH 插件超市与学习社区，提供插件、生态与 DeepSeek Harness 周边推荐 |
 
 Oh-DSH 保留上游实现与署名，并在其上提供统一启动器、Profile、数据目录、
 跨端皮肤、界面适配和发行打包。详细边界见[设计文档](./docs/design.md)。


### PR DESCRIPTION
## Changes

- Rename the "Upstream dependencies" section to "Plugin recommendations" in both `README.md` and `README.en.md`
- Update the table headers to "Recommended project | Description"
- Add a new recommendation: [dshfind](https://dshfind.com/) — a DSH plugin marketplace and learning community with plugin, ecosystem, and DeepSeek Harness peripheral recommendations