### PR TITLE
docs(agents): scope DCO checks to commits in the current PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,10 @@ See `docs/design.en.md` and `docs/design.md` for detailed boundaries.
 - Keep each commit atomic and use `<module>: <subject>`.
 - Include a body explaining why and impact. Keep every body line at most 72
   characters.
-- Sign every commit with the contributor's own DCO using `git commit -s`:
-  `Signed-off-by: Name <email>`.
+- Sign every commit the current PR introduces with the contributor's own DCO
+  using `git commit -s`: `Signed-off-by: Name <email>`.
+- Scope DCO checks to the current PR: require sign-off only for commits the
+  PR introduces; never re-check commits already in the base history.
 - An optional `Assisted-by: <tool>` trailer may disclose AI assistance. It is
   not a DCO, must not identify a fictional person, and is never required.
 - Preserve upstream licenses, notices, links, and downstream attribution.


### PR DESCRIPTION
## Changes

- Clarify in `AGENTS.md` that DCO sign-off is required only for commits the current PR introduces.
- Explicitly scope DCO checks away from pre-existing commits in the base history.

## Why

The previous wording made review tooling flag historical commits instead of only the commits a PR adds. This change keeps DCO enforcement focused on the current PR.