### PR TITLE
website: add an interactive particle atmosphere

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="theme-color" content="#080b12">
+        <meta name="theme-color" content="#020a13">
         <meta
             name="description"
             content="Oh-DSH 以一套 DSH runtime 提供 Desktop、Web UI 与 TUI 三种开发体验。"
@@ -25,6 +25,11 @@
         <script src="site.js" defer></script>
     </head>
     <body>
+        <canvas
+            class="harness-particles"
+            data-harness-particles
+            aria-hidden="true"
+        ></canvas>
         <div class="page-shell">
             <header class="site-header">
                 <a class="brand" href="./" aria-label="Oh-DSH home">

--- a/website/site.css
+++ b/website/site.css
@@ -4,12 +4,12 @@
         Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
         "PingFang SC", "Microsoft YaHei", sans-serif;
     font-synthesis: none;
-    --background: #080b12;
-    --surface-border: rgba(255, 255, 255, 0.11);
-    --text: #f6f7fb;
-    --muted: #a5acbb;
-    --quiet: #767e8f;
-    --accent-strong: #a9c4ff;
+    --background: #020a13;
+    --surface-border: rgba(151, 196, 255, 0.14);
+    --text: #edf5ff;
+    --muted: #a9bfd8;
+    --quiet: #718daa;
+    --accent-strong: #96bdff;
 }
 
 html:lang(zh-CN) {
@@ -28,28 +28,94 @@ html {
 }
 
 body {
+    position: relative;
+    isolation: isolate;
     min-height: 100vh;
     margin: 0;
     overflow-x: hidden;
     color: var(--text);
-    background:
-        radial-gradient(circle at 28% 46%, rgba(40, 87, 172, 0.17), transparent 32rem),
-        radial-gradient(circle at 81% 18%, rgba(64, 91, 151, 0.12), transparent 28rem),
-        linear-gradient(145deg, #090c13 0%, #0b0f18 48%, #070a10 100%);
+    background: linear-gradient(180deg, #061522 0%, var(--background) 100%);
 }
 
 body::before {
     position: fixed;
-    inset: 0;
-    z-index: -1;
+    inset: -34%;
+    z-index: 0;
     content: "";
     pointer-events: none;
-    opacity: 0.26;
+    opacity: 0.78;
+    background:
+        conic-gradient(
+            from 214deg at 46% 48%,
+            transparent 0 14%,
+            rgba(70, 125, 216, 0.12) 18%,
+            rgba(105, 164, 255, 0.4) 22%,
+            transparent 29% 53%,
+            rgba(69, 142, 215, 0.3) 59%,
+            rgba(137, 184, 255, 0.18) 63%,
+            transparent 70% 100%
+        ),
+        radial-gradient(
+            ellipse at 32% 38%,
+            rgba(75, 141, 229, 0.34),
+            transparent 33%
+        ),
+        radial-gradient(
+            ellipse at 72% 58%,
+            rgba(38, 111, 187, 0.3),
+            transparent 30%
+        );
+    filter: blur(58px) saturate(1.16);
+    animation: harness-current-drift 24s ease-in-out infinite alternate;
+    will-change: transform;
+}
+
+body::after {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    content: "";
+    pointer-events: none;
+    opacity: 0.32;
     background-image:
-        linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
-    background-size: 56px 56px;
-    mask-image: linear-gradient(to bottom, black, transparent 82%);
+        linear-gradient(rgba(164, 201, 249, 0.07) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(164, 201, 249, 0.07) 1px, transparent 1px);
+    background-position: center;
+    background-size: 68px 68px;
+    mask-image: radial-gradient(
+        ellipse 76% 72% at 49% 42%,
+        black 7%,
+        transparent 84%
+    );
+}
+
+.harness-particles {
+    position: fixed;
+    z-index: 2;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    opacity: 0.72;
+    mask-image: radial-gradient(
+        ellipse 78% 74% at 49% 43%,
+        black 5%,
+        transparent 86%
+    );
+}
+
+@keyframes harness-current-drift {
+    0% {
+        transform: translate3d(-4%, -3%, 0) rotate(-7deg) scale(1.02);
+    }
+
+    52% {
+        transform: translate3d(3%, 2%, 0) rotate(3deg) scale(1.1);
+    }
+
+    100% {
+        transform: translate3d(1%, 5%, 0) rotate(8deg) scale(1.05);
+    }
 }
 
 a {
@@ -69,6 +135,8 @@ a:focus-visible {
 }
 
 .page-shell {
+    position: relative;
+    z-index: 3;
     width: min(1760px, 100%);
     min-height: 100vh;
     margin: 0 auto;
@@ -80,7 +148,7 @@ a:focus-visible {
     align-items: center;
     justify-content: space-between;
     min-height: 96px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    border-bottom: 1px solid rgba(151, 196, 255, 0.09);
 }
 
 .brand,
@@ -118,7 +186,7 @@ a:focus-visible {
     color: var(--text);
     font-size: 13px;
     font-weight: 650;
-    background: rgba(255, 255, 255, 0.055);
+    background: rgba(7, 24, 39, 0.7);
     border: 1px solid var(--surface-border);
     border-radius: 9px;
     transition:
@@ -127,8 +195,8 @@ a:focus-visible {
 }
 
 .github-star:hover {
-    background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(16, 43, 64, 0.82);
+    border-color: rgba(151, 196, 255, 0.24);
 }
 
 .github-star svg {
@@ -156,7 +224,7 @@ a:focus-visible {
     font: inherit;
     font-weight: 650;
     cursor: pointer;
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(7, 24, 39, 0.7);
     border: 1px solid var(--surface-border);
     border-radius: 999px;
     transition:
@@ -165,8 +233,8 @@ a:focus-visible {
 }
 
 .language-toggle:hover {
-    background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(16, 43, 64, 0.82);
+    border-color: rgba(151, 196, 255, 0.24);
 }
 
 .hero {
@@ -192,7 +260,7 @@ a:focus-visible {
     z-index: -1;
     height: 18%;
     content: "";
-    background: #05070c;
+    background: #01070e;
     filter: blur(34px);
     opacity: 0.9;
 }
@@ -201,7 +269,7 @@ a:focus-visible {
     position: absolute;
     inset: 18% 14%;
     z-index: -2;
-    background: rgba(65, 116, 220, 0.38);
+    background: rgba(70, 137, 224, 0.42);
     filter: blur(90px);
     border-radius: 50%;
 }
@@ -317,7 +385,7 @@ html:lang(zh-CN) .hero-title-surfaces {
     min-width: 0;
     min-height: 78px;
     padding: 14px;
-    background: rgba(255, 255, 255, 0.035);
+    background: rgba(7, 24, 39, 0.62);
     border: 1px solid var(--surface-border);
     border-radius: 12px;
     backdrop-filter: blur(12px);
@@ -345,7 +413,7 @@ html:lang(zh-CN) .hero-title-surfaces {
     min-height: 72px;
     color: var(--quiet);
     font-size: 12px;
-    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    border-top: 1px solid rgba(151, 196, 255, 0.09);
 }
 
 .download-dialog {
@@ -354,15 +422,15 @@ html:lang(zh-CN) .hero-title-surfaces {
     overflow: visible;
     color: var(--text);
     background:
-        radial-gradient(circle at 90% 4%, rgba(84, 128, 220, 0.18), transparent 13rem),
-        #10141d;
-    border: 1px solid rgba(255, 255, 255, 0.14);
+        radial-gradient(circle at 90% 4%, rgba(84, 142, 226, 0.24), transparent 13rem),
+        #071827;
+    border: 1px solid rgba(151, 196, 255, 0.18);
     border-radius: 22px;
     box-shadow: 0 36px 100px rgba(0, 0, 0, 0.65);
 }
 
 .download-dialog::backdrop {
-    background: rgba(3, 5, 9, 0.72);
+    background: rgba(1, 6, 12, 0.76);
     backdrop-filter: blur(9px);
 }
 
@@ -558,5 +626,14 @@ html:lang(zh-CN) .hero-title-surfaces {
     *::after {
         scroll-behavior: auto !important;
         transition-duration: 0.01ms !important;
+    }
+
+    body::before {
+        animation: none;
+        transform: rotate(-2deg) scale(1.05);
+    }
+
+    .harness-particles {
+        opacity: 0.44;
     }
 }

--- a/website/site.js
+++ b/website/site.js
@@ -67,9 +67,116 @@ const elements = {
     downloadTrigger: document.querySelector("[data-download-trigger]"),
     languageToggle: document.querySelector("[data-language-toggle]"),
     platformLabel: document.querySelector("[data-platform-label]"),
+    particles: document.querySelector("[data-harness-particles]"),
     starCount: document.querySelector("[data-star-count]"),
     starDownload: document.querySelector("[data-star-download]"),
 };
+
+function installHarnessParticles(canvas) {
+    const context = canvas?.getContext("2d", { alpha: true });
+    if (!context) return;
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const pointer = { active: false, x: 0, y: 0 };
+    let frame;
+    let height = 0;
+    let particles = [];
+    let width = 0;
+
+    function randomFactory() {
+        let state = 0x4f484453;
+        return () => {
+            state = Math.imul(state ^ (state >>> 15), 1 | state);
+            state ^= state + Math.imul(state ^ (state >>> 7), 61 | state);
+            return ((state ^ (state >>> 14)) >>> 0) / 4294967296;
+        };
+    }
+
+    function resize() {
+        const scale = Math.min(window.devicePixelRatio || 1, 2);
+        width = window.innerWidth;
+        height = window.innerHeight;
+        canvas.width = Math.round(width * scale);
+        canvas.height = Math.round(height * scale);
+        context.setTransform(scale, 0, 0, scale, 0, 0);
+
+        const random = randomFactory();
+        const count = Math.max(120, Math.min(620, Math.floor((width * height) / 3200)));
+        particles = Array.from({ length: count }, () => ({
+            x: random() * width,
+            y: random() * height,
+            phase: random() * Math.PI * 2,
+            radius: 0.45 + random() * 0.75,
+            opacity: 0.14 + random() * 0.38,
+        }));
+        if (reducedMotion.matches) draw(performance.now());
+    }
+
+    function draw(time) {
+        context.clearRect(0, 0, width, height);
+        context.fillStyle = "#a6cdff";
+
+        for (const particle of particles) {
+            let offsetX = Math.sin(time * 0.00022 + particle.phase) * 1.3;
+            let offsetY = Math.cos(time * 0.00018 + particle.phase) * 1.1;
+            let strength = 0;
+
+            if (pointer.active && !reducedMotion.matches) {
+                const deltaX = particle.x - pointer.x;
+                const deltaY = particle.y - pointer.y;
+                const distance = Math.hypot(deltaX, deltaY);
+                if (distance < 190 && distance > 0) {
+                    strength = (1 - distance / 190) ** 2;
+                    offsetX += (deltaX / distance) * strength * 22;
+                    offsetY += (deltaY / distance) * strength * 22;
+                }
+            }
+
+            context.globalAlpha = Math.min(0.9, particle.opacity + strength * 0.55);
+            context.beginPath();
+            context.arc(
+                particle.x + offsetX,
+                particle.y + offsetY,
+                particle.radius + strength * 0.75,
+                0,
+                Math.PI * 2,
+            );
+            context.fill();
+        }
+        context.globalAlpha = 1;
+    }
+
+    function animate(time) {
+        draw(time);
+        frame = reducedMotion.matches || document.hidden
+            ? undefined
+            : requestAnimationFrame(animate);
+    }
+
+    function restart() {
+        if (frame !== undefined) cancelAnimationFrame(frame);
+        frame = undefined;
+        draw(performance.now());
+        if (!reducedMotion.matches && !document.hidden) {
+            frame = requestAnimationFrame(animate);
+        }
+    }
+
+    window.addEventListener("resize", resize, { passive: true });
+    window.addEventListener("pointermove", (event) => {
+        if (event.pointerType === "touch") return;
+        pointer.active = true;
+        pointer.x = event.clientX;
+        pointer.y = event.clientY;
+    }, { passive: true });
+    document.documentElement.addEventListener("pointerleave", () => {
+        pointer.active = false;
+    });
+    document.addEventListener("visibilitychange", restart);
+    reducedMotion.addEventListener("change", restart);
+    resize();
+    restart();
+}
 
 const storageKey = "oh-dsh-site-language";
 const platform = detectPlatform(navigator);
@@ -265,3 +372,4 @@ if (typeof fetch === "function") {
 }
 
 applyLanguage(preferredLanguage());
+installHarnessParticles(elements.particles);


### PR DESCRIPTION
## Summary

- add an original deep-ocean atmosphere to the GitHub Pages landing page
- render a subtle grid and pointer-reactive particle field behind all content
- preserve accessibility with reduced-motion behavior and non-blocking layers

## Why

The existing landing page used a mostly static dark background. This gives the
site a more distinctive Oh-DSH visual identity while keeping the download,
language, and GitHub controls clear and interactive.

The effect is intentionally limited to the website. Desktop, Web UI, TUI, and
the shared skin catalog are unchanged.

## Verification

- `node --check website/site.js`
- `pnpm run build:pages`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`
- verified layer ordering, pointer interaction, and rendering in the in-app
  browser
