### PR TITLE
ci: retry submodule checkout after transient failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,30 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          submodules: recursive
+
+      - name: Initialize submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+          attempts=5
+          backoff=5
+          for ((attempt = 1; attempt <= attempts; attempt++)); do
+            echo "::group::Submodule checkout attempt ${attempt}/${attempts}"
+            if git submodule sync --recursive \
+              && git -c protocol.version=2 submodule update --init --force --recursive; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::Submodule checkout attempt ${attempt}/${attempts} failed"
+            git submodule deinit --force --all >/dev/null 2>&1 || true
+            git clean -ffd -- upstream >/dev/null 2>&1 || true
+            if (( attempt < attempts )); then
+              sleep "$((attempt * backoff))"
+            fi
+          done
+          echo "::error::Submodule checkout failed after ${attempts} attempts"
+          exit 1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -81,7 +104,30 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          submodules: recursive
+
+      - name: Initialize submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+          attempts=5
+          backoff=5
+          for ((attempt = 1; attempt <= attempts; attempt++)); do
+            echo "::group::Submodule checkout attempt ${attempt}/${attempts}"
+            if git submodule sync --recursive \
+              && git -c protocol.version=2 submodule update --init --force --recursive; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::Submodule checkout attempt ${attempt}/${attempts} failed"
+            git submodule deinit --force --all >/dev/null 2>&1 || true
+            git clean -ffd -- upstream >/dev/null 2>&1 || true
+            if (( attempt < attempts )); then
+              sleep "$((attempt * backoff))"
+            fi
+          done
+          echo "::error::Submodule checkout failed after ${attempts} attempts"
+          exit 1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Scope

`Core checks (macOS x64)` in run
[31909744415](https://github.com/hust-open-atom-club/oh-dsh/actions/runs/31909744415/job/95072912342)
failed inside `actions/checkout@v6` because recursive submodule cloning
hit a transient DNS failure (`Could not resolve host: github.com`). Git
retries each failed clone once immediately and then aborts, so the job
failed even though the superproject checkout and every other matrix job
succeeded.

This PR splits superproject checkout from submodule initialization in
`.github/workflows/ci.yml`. A new `Initialize submodules` step retries
`git submodule sync && git -c protocol.version=2 submodule update --init
--force --recursive` up to 5 times with 5/10/15/20 second backoff and
cleans partial clones between attempts. The step is added to both the
core matrix job and the runtime smoke job and uses `shell: bash`, which
is available on all four platforms.

## Verification

- `actionlint .github/workflows/ci.yml` passes.
- The edited workflow parses as YAML, and the retry script passes
  `bash -n` under macOS Bash 3.2.
- Reproduced the failed-clone state in a throwaway clone (including a
  mixed partial-clone case) and recovered with the new script; both
  submodules land on their pinned commits.
- CI will run for this PR across macOS arm64/x64, Linux x64, and
  Windows x64.
