### PR TITLE
tui: render startup content as a responsive card

### DIFF
--- a/plugins/tui/renderer/LogoV2.jsx
+++ b/plugins/tui/renderer/LogoV2.jsx
@@ -1,0 +1,227 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getLang, t as tr } from '../i18n.js'
+import { Box, Text, useTerminalSize } from '../ui.js'
+
+/*! OH_DSH_STARTUP_CARD_V1 */
+
+const VERSION = (() => {
+  try {
+    const packagePath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      '..',
+      'package.json',
+    )
+    return JSON.parse(readFileSync(packagePath, 'utf8')).version ?? '0.1.0'
+  } catch {
+    return '0.1.0'
+  }
+})()
+
+const WIDE_CARD_COLUMNS = 90
+const RECENT_SESSION_LIMIT = 3
+
+const WHALE = [
+  ['                  ▄      ▄', 'purple_FOR_SUBAGENTS_ONLY'],
+  ['              ▄▄███▄  ▄██', 'purple_FOR_SUBAGENTS_ONLY'],
+  ['      ▄▄▄▄▄█████████████▀', 'blue_FOR_SUBAGENTS_ONLY'],
+  ['   ▄███████████████████', 'claude'],
+  [' ▄█████████████████████▄', 'claude'],
+  ['  ▀████████████████████▀', 'blue_FOR_SUBAGENTS_ONLY'],
+  ['     ▀▀████████████▀▀', 'purple_FOR_SUBAGENTS_ONLY'],
+  ['          ▀▀▀▀▀', 'purple_FOR_SUBAGENTS_ONLY'],
+]
+
+const COPY = {
+  en: {
+    noSessions: 'No resumable sessions in this workspace',
+    recentSessions: 'Recent sessions',
+    tips: [
+      ['Tab', 'Complete commands and paths'],
+      ['Ctrl+C ×2', 'Exit with a resumable session hint'],
+      ['/help', 'Browse commands and shortcuts'],
+      ['PgUp/PgDn', 'Scroll through the transcript'],
+    ],
+    tipsTitle: 'Tips',
+  },
+  zh: {
+    noSessions: '当前工作区暂无可恢复会话',
+    recentSessions: '最近会话',
+    tips: [
+      ['Tab', '补全命令和路径'],
+      ['Ctrl+C ×2', '退出并提示可恢复会话'],
+      ['/help', '浏览命令和快捷键'],
+      ['PgUp/PgDn', '滚动浏览对话记录'],
+    ],
+    tipsTitle: '使用提示',
+  },
+}
+
+function capitalize(value) {
+  return value.length === 0 ? value : value[0].toUpperCase() + value.slice(1)
+}
+
+function formatRelativeTime(timestamp, lang) {
+  const elapsed = Math.max(0, Date.now() - timestamp)
+  const minutes = Math.floor(elapsed / 60_000)
+  if (minutes < 1) return lang === 'zh' ? '刚刚' : 'just now'
+  if (minutes < 60) return lang === 'zh' ? `${minutes} 分钟前` : `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return lang === 'zh' ? `${hours} 小时前` : `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return lang === 'zh' ? `${days} 天前` : `${days}d ago`
+  return new Date(timestamp).toLocaleDateString(lang === 'zh' ? 'zh-CN' : 'en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function sessionLabel(session) {
+  const title = session.title.replace(/\s+/g, ' ').trim()
+  return title || `session ${String(session.id).slice(0, 8)}`
+}
+
+function CompactWhale() {
+  return (
+    <Box flexDirection="column" alignItems="center">
+      {WHALE.map(([row, color], index) => (
+        <Text key={index} color={color} wrap="truncate-end">
+          {row}
+        </Text>
+      ))}
+    </Box>
+  )
+}
+
+function IdentityPanel({ model, effort, cwd, wide }) {
+  return (
+    <Box
+      flexDirection="column"
+      alignItems={wide ? 'center' : 'flex-start'}
+      flexShrink={wide ? 0 : 1}
+      width={wide ? 34 : '100%'}
+      paddingX={2}
+      paddingY={1}
+      borderStyle="single"
+      borderColor="promptBorder"
+      borderTop={false}
+      borderLeft={false}
+      borderRight={wide}
+      borderBottom={!wide}
+    >
+      <Text bold color="claude" wrap="truncate-end">
+        {tr('logo-tagline')}
+      </Text>
+      {wide && (
+        <Box marginY={1}>
+          <CompactWhale />
+        </Box>
+      )}
+      <Text wrap="truncate-end">
+        {model}
+        {effort !== undefined && (
+          <Text dimColor>{` · ${capitalize(effort)}`}</Text>
+        )}
+      </Text>
+      <Text dimColor wrap="truncate-end">
+        {cwd}
+      </Text>
+    </Box>
+  )
+}
+
+function TipRow({ shortcut, description, wide }) {
+  return (
+    <Box flexDirection="row">
+      <Box width={wide ? 14 : 12} flexShrink={0}>
+        <Text color="claude" wrap="truncate-end">
+          {shortcut}
+        </Text>
+      </Box>
+      <Box flexGrow={1} flexShrink={1}>
+        <Text dimColor wrap="truncate-end">
+          {description}
+        </Text>
+      </Box>
+    </Box>
+  )
+}
+
+function DetailsPanel({ sessions, wide, copy, lang }) {
+  const recent = sessions.slice(0, RECENT_SESSION_LIMIT)
+  return (
+    <Box flexDirection="column" flexGrow={1} flexShrink={1}>
+      <Box flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="claude">
+          {copy.tipsTitle}
+        </Text>
+        {copy.tips.map(([shortcut, description]) => (
+          <TipRow
+            key={shortcut}
+            shortcut={shortcut}
+            description={description}
+            wide={wide}
+          />
+        ))}
+      </Box>
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        paddingX={2}
+        paddingY={1}
+        borderStyle="single"
+        borderColor="promptBorder"
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+      >
+        <Text bold color="claude">
+          {copy.recentSessions}
+        </Text>
+        {recent.length === 0 ? (
+          <Text dimColor italic>
+            {copy.noSessions}
+          </Text>
+        ) : (
+          recent.map(session => (
+            <Text key={session.id} dimColor wrap="truncate-end">
+              {sessionLabel(session)} ({formatRelativeTime(session.updatedAt, lang)})
+            </Text>
+          ))
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export function LogoV2({ model, effort, cwd, sessions = [] }) {
+  const { columns } = useTerminalSize()
+  const wide = columns >= WIDE_CARD_COLUMNS
+  const lang = getLang()
+  const copy = COPY[lang] ?? COPY.en
+  const title = process.env.OH_DSH_TUI_TITLE ?? 'Oh-DSH TUI'
+  const version = process.env.DSH_OH_TUI_VERSION ?? VERSION
+
+  return (
+    <Box flexDirection="column" marginTop={1} width="100%">
+      <Box
+        flexDirection={wide ? 'row' : 'column'}
+        width="100%"
+        borderStyle="round"
+        borderColor="promptBorder"
+        borderText={{
+          content: ` ${title} v${version} `,
+          position: 'top',
+          align: 'start',
+          offset: 1,
+        }}
+      >
+        <IdentityPanel model={model} effort={effort} cwd={cwd} wide={wide} />
+        <DetailsPanel sessions={sessions} wide={wide} copy={copy} lang={lang} />
+      </Box>
+    </Box>
+  )
+}

--- a/scripts/tui-upstream-adapter.mjs
+++ b/scripts/tui-upstream-adapter.mjs
@@ -1,7 +1,19 @@
 import { readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { transformSync } from 'esbuild'
 
 export const TUI_PRODUCT_NAME = 'Oh-DSH TUI'
+
+const STARTUP_CARD_MARKER = 'OH_DSH_STARTUP_CARD_V1'
+const STARTUP_CARD_SOURCE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'plugins',
+  'tui',
+  'renderer',
+  'LogoV2.jsx',
+)
 
 function replaceOnce(path, before, after) {
   const source = readFileSync(path, 'utf8')
@@ -30,6 +42,36 @@ function scopePreferenceFile(lib, name, declaration = 'PREFS_DIR') {
   )
 }
 
+function installStartupCard(lib) {
+  const target = join(lib, 'components', 'LogoV2.js')
+  const source = readFileSync(target, 'utf8')
+  if (source.includes(STARTUP_CARD_MARKER)) return
+
+  for (const seam of [
+    'export function LogoV2',
+    "renderBigText('DEEPSEEK'",
+    "sweep('✦ dsh-cc'",
+  ]) {
+    const first = source.indexOf(seam)
+    if (first === -1 || source.indexOf(seam, first + seam.length) !== -1) {
+      throw new Error(`TUI upstream adapter seam changed: ${target}`)
+    }
+  }
+
+  const template = readFileSync(STARTUP_CARD_SOURCE, 'utf8')
+  if (!template.includes(STARTUP_CARD_MARKER)) {
+    throw new Error(`TUI startup card marker missing: ${STARTUP_CARD_SOURCE}`)
+  }
+  const replacement = transformSync(template, {
+    format: 'esm',
+    jsx: 'automatic',
+    legalComments: 'inline',
+    loader: 'jsx',
+    target: 'es2022',
+  }).code
+  writeFileSync(target, replacement)
+}
+
 /**
  * Apply the deliberately small Oh-DSH adapter to a copied upstream package.
  * The submodule remains pristine; exact-match guards fail the build when an
@@ -37,18 +79,44 @@ function scopePreferenceFile(lib, name, declaration = 'PREFS_DIR') {
  */
 export function adaptTuiRendererPackage(packageDir) {
   const lib = join(packageDir, 'lib', 'types')
+  installStartupCard(lib)
+
+  const messageList = join(lib, 'components', 'MessageList.js')
   replaceOnce(
-    join(lib, 'components', 'LogoV2.js'),
-    "sweep('✦ dsh-cc', t, wordmarkRGB, wordmarkShimmerRGB, 60)",
-    "sweep(process.env.OH_DSH_TUI_TITLE ?? 'Oh-DSH TUI', t, wordmarkRGB, wordmarkShimmerRGB, 60)",
+    messageList,
+    'export function LogoHeader({ model, effort, cwd, }) {',
+    'export function LogoHeader({ model, effort, cwd, sessions, }) {',
   )
   replaceOnce(
-    join(lib, 'components', 'LogoV2.js'),
-    "'  v' + VERSION",
-    "'  v' + (process.env.DSH_OH_TUI_VERSION ?? VERSION)",
+    messageList,
+    '_jsx(LogoV2, { model: model, effort: effort, cwd: cwd })',
+    '_jsx(LogoV2, { model: model, effort: effort, cwd: cwd, sessions: sessions })',
+  )
+
+  const chat = join(lib, 'screens', 'Chat.js')
+  replaceOnce(
+    chat,
+    '    const [themeName, setTheme] = useTheme();',
+    `    const [themeName, setTheme] = useTheme();
+    React.useEffect(() => {
+        let active = true;
+        void channel.listSessions().then(sessions => {
+            if (active) {
+                setResumeSessions(sessions.filter(session => session.id !== channel.agentId));
+            }
+        });
+        return () => {
+            active = false;
+        };
+    }, [channel, channel.agentId]);`,
   )
   replaceOnce(
-    join(lib, 'screens', 'Chat.js'),
+    chat,
+    '_jsx(LogoHeader, { model: channel.model, effort: channel.reasoningEffort, cwd: channel.cwd })',
+    '_jsx(LogoHeader, { model: channel.model, effort: channel.reasoningEffort, cwd: channel.cwd, sessions: resumeSessions.slice(0, 3) })',
+  )
+  replaceOnce(
+    chat,
     'useTerminalTitle(`${titlePrefix} 🐋 ${channel.sessionTitle}`);',
     "useTerminalTitle(`${titlePrefix} ${process.env.OH_DSH_TUI_TITLE ?? 'Oh-DSH TUI'} · ${channel.sessionTitle}`);",
   )
@@ -126,7 +194,7 @@ export function adaptTuiRendererPackage(packageDir) {
   )
 
   replaceOnce(
-    join(lib, 'screens', 'Chat.js'),
+    chat,
     '`${userHome}\\\\.dsh-cc\\\\cordis.yml`',
     '`${process.env.OH_DSH_TUI_CONFIG_HOME ?? `${userHome}\\\\.ohdsh\\\\tui`}\\\\cordis.yml`',
   )

--- a/tests/tui.test.ts
+++ b/tests/tui.test.ts
@@ -171,8 +171,18 @@ test('TUI upstream adapter removes legacy terminal branding and scopes storage',
   })
   try {
     adaptTuiRendererPackage(root)
-    assert.match(readFileSync(join(lib, 'components', 'LogoV2.js'), 'utf8'), /Oh-DSH TUI/)
-    assert.match(readFileSync(join(lib, 'components', 'LogoV2.js'), 'utf8'), /DSH_OH_TUI_VERSION/)
+    const logo = readFileSync(join(lib, 'components', 'LogoV2.js'), 'utf8')
+    assert.match(logo, /OH_DSH_STARTUP_CARD_V1/)
+    assert.match(logo, /Oh-DSH TUI/)
+    assert.match(logo, /DSH_OH_TUI_VERSION/)
+    assert.match(logo, /Recent sessions/)
+    assert.match(logo, /borderText/)
+    assert.doesNotMatch(logo, /renderBigText|useAnimationFrame/)
+    const messageList = readFileSync(
+      join(lib, 'components', 'MessageList.js'),
+      'utf8',
+    )
+    assert.match(messageList, /sessions: sessions/)
     assert.match(readFileSync(join(lib, 'screens', 'Chat.js'), 'utf8'), /Oh-DSH TUI/)
     assert.match(readFileSync(join(lib, 'customTheme.js'), 'utf8'), /OH_DSH_TUI_CONFIG_HOME/)
     assert.match(readFileSync(join(lib, 'themePrefs.js'), 'utf8'), /OH_DSH_TUI_CONFIG_HOME/)
@@ -189,6 +199,8 @@ test('TUI upstream adapter removes legacy terminal branding and scopes storage',
     assert.match(channel, /oh-dsh-tui-export-/)
     assert.doesNotMatch(channel, /dsh-cc-export-|join\(userHome, '\.dsh-cc\//)
     const chat = readFileSync(join(lib, 'screens', 'Chat.js'), 'utf8')
+    assert.match(chat, /channel\.listSessions\(\)/)
+    assert.match(chat, /sessions: resumeSessions\.slice\(0, 3\)/)
     assert.doesNotMatch(chat, /userHome}\\\\\.dsh-cc/)
     const themeProvider = readFileSync(
       join(lib, 'components', 'design-system', 'ThemeProvider.js'),


### PR DESCRIPTION
## Summary

- replace the oversized animated splash with an Oh-DSH startup card
- show product identity, model metadata, shortcuts, and the three most recent
  resumable sessions for the active workspace
- switch between a two-column wide layout and a compact stacked layout below
  90 terminal columns
- preserve English and Chinese UI modes and reuse the active TUI theme colors

## Why

The previous splash devoted most of its space to branding while hiding useful
startup context. The card keeps the Oh-DSH identity but makes the first screen
an actionable workspace overview.

## Impact

- TUI startup presentation only; Desktop and Web surfaces are unchanged
- the pinned `upstream/dsh-TUI` checkout remains untouched
- the existing downstream adapter installs the readable JSX template with
  exact seam guards and loads session previews after the initial render

## Verification

- `pnpm run typecheck`
- `pnpm test` (163 passed, 5 platform-gated skips)
- `pnpm run build`
- `pnpm run build:dsh`
- `pnpm run stage:dsh`
- `pnpm run check:plugins`
- `node scripts/build-tui.mjs`
- manual Ink render at 120 columns in English and 72 columns in Chinese
