### PR TITLE
cli: add gui alias for Desktop

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -113,6 +113,7 @@ Run `./bin/ohdsh` from Web-only and TUI-only packages, or add it to `PATH`.
 
 ```sh
 ohdsh desktop          # Start Oh-DSH Desktop
+ohdsh gui              # Alias for Oh-DSH Desktop
 ohdsh web              # Start Oh-DSH Web
 ohdsh web --port 3080  # Choose the Web port
 ohdsh tui              # Start Oh-DSH TUI

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Web-only 与 TUI-only 包可直接运行 `./bin/ohdsh`，也可以把它加入 `
 
 ```sh
 ohdsh desktop          # 启动 Oh-DSH Desktop
+ohdsh gui              # Desktop 的启动别名
 ohdsh web              # 启动 Oh-DSH Web
 ohdsh web --port 3080  # 指定 Web 端口
 ohdsh tui              # 启动 Oh-DSH TUI

--- a/docs/usage.en.md
+++ b/docs/usage.en.md
@@ -134,12 +134,14 @@ selection, scrolling, and copy behavior.
 
 ```sh
 ohdsh desktop
+ohdsh gui
 ohdsh web
 ohdsh tui
 ```
 
 - `desktop` opens the installed app and falls back to the Electron development
   entry when run from a source checkout.
+- `gui` is an alias for `desktop`.
 - `web` starts the HTTP service and prints its URL.
 - `tui` initializes its Profile and attaches the upstream renderer to the
   current terminal.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -124,11 +124,13 @@ screen，全屏选择、滚动和复制由上游 `dsh-TUI` 处理。
 
 ```sh
 ohdsh desktop
+ohdsh gui
 ohdsh web
 ohdsh tui
 ```
 
 - `desktop` 启动已安装应用；源码仓库中回退到 Electron 开发入口。
+- `gui` 是 `desktop` 的启动别名。
 - `web` 启动 HTTP 服务并打印访问地址。
 - `tui` 初始化独立 Profile，并在当前终端中附着运行上游 renderer。
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,9 @@ import { main as runWeb } from './web.ts'
 
 const SURFACE_NAMES = ['desktop', 'web', 'tui'] as const
 type SurfaceName = typeof SURFACE_NAMES[number]
+const SURFACE_ALIASES: Readonly<Record<string, SurfaceName>> = Object.freeze({
+  gui: 'desktop',
+})
 
 export function availableSurfaces(env: NodeJS.ProcessEnv = process.env): readonly SurfaceName[] {
   const configured = env.OH_DSH_SURFACES
@@ -21,6 +24,8 @@ export function availableSurfaces(env: NodeJS.ProcessEnv = process.env): readonl
 
 export function cliHelp(env: NodeJS.ProcessEnv = process.env): string {
   const surfaces = availableSurfaces(env)
+  const aliases = Object.entries(SURFACE_ALIASES)
+    .filter(([, surface]) => surfaces.includes(surface))
   const descriptions: Record<SurfaceName, string> = {
     desktop: 'Start Oh-DSH Desktop',
     web: 'Start Oh-DSH Web',
@@ -33,6 +38,7 @@ Usage:
 
 Surfaces:
 ${surfaces.map(surface => `  ${surface.padEnd(9)} ${descriptions[surface]}`).join('\n')}
+${aliases.length === 0 ? '' : `\nAliases:\n${aliases.map(([alias, surface]) => `  ${alias.padEnd(9)} ${descriptions[surface]}`).join('\n')}`}
 
 Run "ohdsh <surface> --help" for surface options.
 `
@@ -174,19 +180,22 @@ export async function main(
   tuiRunner: TuiRunner = runTui,
 ): Promise<number> {
   const [surface, ...args] = argv
+  const selectedSurface = surface === undefined
+    ? undefined
+    : SURFACE_ALIASES[surface] ?? surface
   const help = cliHelp(env)
   if (surface === undefined || surface === '--help' || surface === '-h') {
     stdout.write(help)
     return 0
   }
-  if (SURFACE_NAMES.includes(surface as SurfaceName)
-    && !availableSurfaces(env).includes(surface as SurfaceName)) {
+  if (SURFACE_NAMES.includes(selectedSurface as SurfaceName)
+    && !availableSurfaces(env).includes(selectedSurface as SurfaceName)) {
     stderr.write(`Surface '${surface}' is not included in this Oh-DSH distribution.\n\n${help}`)
     return 2
   }
-  if (surface === 'desktop') return await desktopRunner(args, env)
-  if (surface === 'web') return await webRunner(args, env, stdout)
-  if (surface === 'tui') return await tuiRunner(args, env, stdout, stderr)
+  if (selectedSurface === 'desktop') return await desktopRunner(args, env)
+  if (selectedSurface === 'web') return await webRunner(args, env, stdout)
+  if (selectedSurface === 'tui') return await tuiRunner(args, env, stdout, stderr)
   stderr.write(`Unknown surface: ${surface}\n\n${help}`)
   return 2
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -20,7 +20,7 @@ function output(): { stream: NodeJS.WriteStream; text: () => string } {
   }
 }
 
-test('ohdsh dispatches desktop, web, and TUI through one surface command', async () => {
+test('ohdsh dispatches desktop aliases, web, and TUI through one surface command', async () => {
   const stdout = output()
   const stderr = output()
   const calls: Array<{ args: readonly string[]; surface: string }> = []
@@ -38,6 +38,17 @@ test('ohdsh dispatches desktop, web, and TUI through one surface command', async
       calls.push({ args, surface: 'web' })
       return 0
     },
+  ), 0)
+  assert.equal(await main(
+    ['gui', '--inspect'],
+    {},
+    stdout.stream,
+    stderr.stream,
+    async args => {
+      calls.push({ args, surface: 'desktop' })
+      return 0
+    },
+    async () => 0,
   ), 0)
   assert.equal(await main(
     ['web', '--port', '0'],
@@ -64,6 +75,7 @@ test('ohdsh dispatches desktop, web, and TUI through one surface command', async
   ), 0)
   assert.deepEqual(calls, [
     { args: ['--inspect'], surface: 'desktop' },
+    { args: ['--inspect'], surface: 'desktop' },
     { args: ['--port', '0'], surface: 'web' },
     { args: ['--inline'], surface: 'tui' },
   ])
@@ -89,6 +101,13 @@ test('layered distributions list and reject unavailable surfaces', async () => {
     stderr.stream,
   ), 2)
   assert.match(stderr.text(), /Surface 'desktop' is not included/)
+  assert.equal(await main(
+    ['gui'],
+    { OH_DSH_SURFACES: 'web' },
+    stdout.stream,
+    stderr.stream,
+  ), 2)
+  assert.match(stderr.text(), /Surface 'gui' is not included/)
 })
 
 test('desktop launch keeps source and installed macOS paths distinct', () => {


### PR DESCRIPTION
## Summary

- Add `ohdsh gui` as an alias for the Desktop surface.
- Resolve the alias before distribution availability checks and dispatch.
- Show the alias in launcher help only when Desktop is available.
- Document the alias in the Chinese and English usage guides.

## Why

The packaged launcher already supports `ohdsh desktop`, while user-level
launchers commonly expose `gui` as the graphical entry point. Keeping the
alias in the shared CLI makes both invocation styles resolve to the same
Desktop implementation without adding a second launcher path.

## Verification

- `git diff --check`
- `pnpm --silent run change-scope --base origin/main`
- `pnpm run typecheck`

Full automated tests and runtime smoke checks were left for CI and manual
verification, as requested.
