### PR TITLE
feat: add human-approval guardrails to system prompts

### DIFF
--- a/plugins/shared/guardrails.ts
+++ b/plugins/shared/guardrails.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared human-approval guardrails for Oh-DSH surfaces.
+ *
+ * These are deliberately additive system-prompt sections: they reduce model
+ * proactivity without removing tools, and they apply regardless of which
+ * DeepSeek Harness preset or model (for example DeepSeek V4 Flash or Pro) a
+ * session is running on.
+ */
+
+/** Prompt guidance that asks the model to pause before shared/external actions. */
+export function humanApprovalGuidance(): string {
+  return `You are helpful but not overly eager. Do not perform high-impact or externally visible actions without first asking the Human and receiving explicit approval.
+
+If the user states a need or goal without explicitly asking you to execute it, do not assume that is authorization to perform every possible follow-up action. Clarify the intended scope or propose a plan first.
+
+Examples that always require explicit approval before execution:
+- sending email, chat messages, or other communications to other people;
+- creating, editing, closing, commenting on, or merging issues and pull requests;
+- pushing, force-pushing, rebasing, or otherwise updating remote repositories;
+- publishing, deploying, releasing, or changing shared/remote state;
+- deleting or overwriting shared data or resources;
+- any action that could affect collaborators, project health, or other users.
+
+For these external actions, even a direct request is not automatic permission to dispatch. Prepare the concrete change or draft locally, show the Human what will happen, and wait for final approval before executing.
+
+For clearly requested local work — reading files, editing local code, running tests, drafting content, preparing local commits or local patches — proceed normally without asking unnecessarily. The key distinction is local preparation versus shared/external execution. When a request is ambiguous, or when the next step would affect people or shared state outside the current workspace, stop and ask for explicit Human approval before continuing. Use ask_user_question (or a plain question) to get that approval and wait for the answer.`
+}

--- a/plugins/shared/guardrails.ts
+++ b/plugins/shared/guardrails.ts
@@ -2,9 +2,10 @@
  * Shared human-approval guardrails for Oh-DSH surfaces.
  *
  * These are deliberately additive system-prompt sections: they reduce model
- * proactivity without removing tools, and they apply regardless of which
- * DeepSeek Harness preset or model (for example DeepSeek V4 Flash or Pro) a
- * session is running on.
+ * proactivity without removing tools. They apply to the standard, Code, and
+ * Cordis agent presets, and to models such as DeepSeek V4 Flash or Pro. The
+ * minimal preset uses a complete persona that suppresses global sections, so
+ * this guardrail intentionally does not apply there.
  */
 
 /** Prompt guidance that asks the model to pause before shared/external actions. */

--- a/plugins/tui/src/index.ts
+++ b/plugins/tui/src/index.ts
@@ -4,6 +4,7 @@ import {
   OH_DSH_SURFACE_SERVICE,
   type OhDshSurface,
 } from '../../shared/surface.ts'
+import { humanApprovalGuidance } from '../../shared/guardrails.ts'
 
 interface SystemPromptService {
   section(entry: { name: string; order: number; text: () => string }): unknown
@@ -48,6 +49,11 @@ export function apply(ctx: HostContext): void {
       name: 'app:oh-dsh-tui-surface',
       order: -98,
       text: () => tuiPrompt(surface),
+    })
+    promptCtx.systemPrompt.section({
+      name: 'app:oh-dsh-human-approval',
+      order: -90,
+      text: () => humanApprovalGuidance(),
     })
   })
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,6 +8,7 @@ import {
   OH_DSH_SURFACE_SERVICE,
   type OhDshSurface,
 } from '../plugins/shared/surface.ts'
+import { humanApprovalGuidance } from '../plugins/shared/guardrails.ts'
 
 interface SystemPromptService {
   section(entry: {
@@ -91,6 +92,11 @@ export function apply(ctx: HostContext): void {
       name: 'app:oh-dsh-desktop-surface',
       order: -98,
       text: () => desktopPrompt(capability),
+    })
+    promptCtx.systemPrompt.section({
+      name: 'app:oh-dsh-human-approval',
+      order: -90,
+      text: () => humanApprovalGuidance(),
     })
   })
 

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -101,7 +101,7 @@ test('desktop Host plugin publishes capability, prompt, and bash environment', (
   process.env.DSH_DESKTOP_PROFILE = 'desktop'
   process.env.DSH_DESKTOP_VERSION = '9.8.7'
   let capability: unknown
-  let prompt = ''
+  const sections: { text: () => string }[] = []
   let resolvedEnvironment: Record<string, string> = {}
   const context = {
     effect: <T>(effect: () => T): T => effect(),
@@ -115,7 +115,7 @@ test('desktop Host plugin publishes capability, prompt, and bash environment', (
       if (names[0] === 'systemPrompt') {
         callback({
           systemPrompt: {
-            section: (section: { text: () => string }) => { prompt = section.text() },
+            section: (section: { text: () => string }) => { sections.push(section) },
           },
         })
       }
@@ -145,7 +145,11 @@ test('desktop Host plugin publishes capability, prompt, and bash environment', (
       profile: 'desktop',
       version: '9.8.7',
     })
+    const prompt = sections.map(section => section.text()).join('\n')
     assert.match(prompt, /Oh-DSH Desktop/)
+    assert.match(prompt, /explicit approval/)
+    assert.match(prompt, /remote repositories/)
+    assert.match(prompt, /ask_user_question/)
     assert.doesNotMatch(prompt, /ChatGPT|OpenAI/)
     assert.deepEqual(resolvedEnvironment, {
       DSH_DESKTOP: '1',

--- a/tests/surface.test.ts
+++ b/tests/surface.test.ts
@@ -70,3 +70,20 @@ test('every bundled plugin adapts explicitly per surface', () => {
   assert.match(tuiHost, /OH_DSH_SURFACE_SERVICE/)
   assert.match(tuiHost, /Oh-DSH TUI/)
 })
+
+test('every Oh-DSH surface host adds the human-approval guardrail', () => {
+  const hosts = [
+    'src/plugin.ts',
+    'web/src/index.ts',
+    'plugins/tui/src/index.ts',
+  ]
+  for (const file of hosts) {
+    const source = readFileSync(join(root, file), 'utf8')
+    assert.match(source, /humanApprovalGuidance/)
+    assert.match(source, /app:oh-dsh-human-approval/)
+  }
+  const shared = readFileSync(join(root, 'plugins/shared/guardrails.ts'), 'utf8')
+  assert.match(shared, /ask_user_question/)
+  assert.match(shared, /remote repositories/)
+  assert.match(shared, /explicit approval/)
+})

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -4,6 +4,7 @@ import {
   OH_DSH_SURFACE_SERVICE,
   type OhDshSurface,
 } from '../../plugins/shared/surface.ts'
+import { humanApprovalGuidance } from '../../plugins/shared/guardrails.ts'
 
 interface SystemPromptService {
   section(entry: {
@@ -73,6 +74,11 @@ export function apply(ctx: HostContext): void {
       name: 'app:oh-dsh-web-surface',
       order: -98,
       text: () => webPrompt(surface),
+    })
+    promptCtx.systemPrompt.section({
+      name: 'app:oh-dsh-human-approval',
+      order: -90,
+      text: () => humanApprovalGuidance(),
     })
   })
 


### PR DESCRIPTION
## Summary

Adds a shared system-prompt guardrail to Oh-DSH Desktop, Web, and TUI surfaces.

The new prompt section asks DeepSeek V4 Flash/Pro to be less proactive and to
obtain explicit Human approval before high-impact or externally visible actions,
including:

- sending email or messages to other people
- creating/editing/closing/commenting on issues or PRs
- pushing or updating remote repositories
- publishing, deploying, releasing, or changing shared/remote state
- deleting or overwriting shared data/resources
- any action that could affect collaborators or other users

It still allows normal local work (reading files, editing local code, running
tests, preparing local commits) without unnecessary confirmation.

## Changes

- Adds `plugins/shared/guardrails.ts` with the shared prompt text.
- Registers `app:oh-dsh-human-approval` in Desktop, Web, and TUI host plugins.
- Updates tests to verify the guardrail is present in all three surfaces.

## Verification

- `pnpm run typecheck` passes
- `pnpm test` passes
- `pnpm run build` passes

Note: this covers standard, Code, and Cordis agent presets. The minimal preset
uses a complete persona and is intentionally not changed in this PR.