### PR TITLE
fix(terminal): refine card sizing and web session-log spacing

### DIFF
--- a/plugins/panel-controls/src/terminal/TerminalPanel.tsx
+++ b/plugins/panel-controls/src/terminal/TerminalPanel.tsx
@@ -139,7 +139,7 @@ export function TerminalPanel({ locale, t: translate, store, scopeKey, cwd, acti
                   event.stopPropagation()
                   store.dispatch({ type: 'remove-tab', id: tab.id })
                 }}
-              >×</button>
+              >✕</button>
             </span>
           ))}
           <button
@@ -166,7 +166,7 @@ export function TerminalPanel({ locale, t: translate, store, scopeKey, cwd, acti
             onClick={() => { store.dispatch({ type: 'toggle-collapsed' }) }}
             title={state.collapsed ? t('terminal.expand') : t('terminal.collapse')}
             aria-label={state.collapsed ? t('terminal.expand') : t('terminal.collapse')}
-          >{state.collapsed ? '⌃' : '⌄'}</button>
+          >✕</button>
         </div>
       </div>
       {settingsOpen && (

--- a/plugins/panel-controls/src/terminal/plugin.tsx
+++ b/plugins/panel-controls/src/terminal/plugin.tsx
@@ -69,7 +69,8 @@ function currentSession(sessions: SessionsService): { scopeKey: string; cwd: str
 }
 
 function findConversationColumn(): HTMLElement | null {
-  return document.querySelector<HTMLElement>('[data-phase]')?.parentElement ?? null
+  const scrollBody = document.querySelector<HTMLElement>('[data-conversation-scroll]')
+  return scrollBody?.closest('[data-phase]')?.parentElement ?? null
 }
 
 class DesktopPanelService implements DesktopPanels {

--- a/plugins/panel-controls/src/terminal/terminal.css
+++ b/plugins/panel-controls/src/terminal/terminal.css
@@ -1,5 +1,6 @@
 .oh-dsh-terminal-dock {
   position: relative;
+  z-index: 10;
   flex: none;
   display: flex;
   flex-direction: column;
@@ -11,18 +12,21 @@
   -webkit-app-region: no-drag;
 }
 
+.oh-dsh-terminal-dock[data-collapsed] {
+  display: none;
+}
+
 .oh-dsh-terminal-bar {
   flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  height: 34px;
+  height: 36px;
   padding: 0 8px;
   box-sizing: border-box;
-  border-bottom: 1px solid var(--dsw-alias-border-l1, rgb(0 0 0 / 7%));
   background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-base, #fff));
-  font-size: 11px;
+  font-size: 14px;
 }
 
 .oh-dsh-terminal-tabs {
@@ -39,8 +43,8 @@
   align-items: center;
   gap: 5px;
   max-width: 180px;
-  height: 24px;
-  padding: 0 6px;
+  height: 32px;
+  padding: 0 8px;
   box-sizing: border-box;
   border-radius: 6px;
   color: var(--dsw-alias-label-secondary, #57606a);
@@ -60,8 +64,8 @@
 
 .oh-dsh-terminal-status {
   flex: none;
-  width: 5px;
-  height: 5px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--dsw-alias-label-dimmed, #8c959f);
 }
@@ -89,8 +93,8 @@
 .oh-dsh-terminal-tab-close {
   display: grid;
   place-items: center;
-  width: 15px;
-  height: 15px;
+  width: 18px;
+  height: 18px;
   padding: 0;
   border-radius: 4px;
   background: transparent;
@@ -107,13 +111,13 @@
 
 .oh-dsh-terminal-add {
   flex: none;
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   border-radius: 6px;
   background: transparent;
   color: var(--dsw-alias-label-secondary, #57606a);
-  font-size: 15px;
+  font-size: 17px;
 }
 
 .oh-dsh-terminal-hint {
@@ -132,19 +136,19 @@
 .oh-dsh-terminal-actions { gap: 2px; }
 
 .oh-dsh-terminal-action {
-  width: 27px;
-  height: 24px;
+  width: 32px;
+  height: 30px;
   padding: 0;
   border-radius: 6px;
   background: transparent;
   color: var(--dsw-alias-label-secondary, #57606a);
-  font-size: 11px;
+  font-size: 14px;
 }
 
 .oh-dsh-terminal-settings {
   position: absolute;
   z-index: 8;
-  top: 46px;
+  top: 45px;
   right: 8px;
   display: grid;
   gap: 12px;
@@ -160,7 +164,7 @@
 
 .oh-dsh-terminal-dock[data-collapsed] .oh-dsh-terminal-settings {
   top: auto;
-  bottom: 38px;
+  bottom: 40px;
 }
 
 .oh-dsh-terminal-settings-header,
@@ -213,7 +217,7 @@
   position: relative;
   z-index: 1;
   flex: none;
-  height: 8px;
+  height: 4px;
   background: var(--dsw-alias-bg-layer-1, #fff);
   cursor: ns-resize;
   touch-action: none;
@@ -221,10 +225,10 @@
 
 .oh-dsh-terminal-resize::after {
   position: absolute;
-  top: 2px;
+  top: 1px;
   left: 50%;
   width: 32px;
-  height: 3px;
+  height: 2px;
   border-radius: 99px;
   background: var(--dsw-alias-label-dimmed, #8c959f);
   content: '';

--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -12,6 +12,86 @@ interface ClientContext {
   }
 }
 
+const WEB_CHROME_CSS = `
+html[data-oh-dsh-web='true'] [class*='sessionLogButton'] {
+  position: relative;
+}
+`
+
+function applySessionLogShift(): void {
+  const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
+  if (button === null) return
+
+  // Prefer the actual right-side card group in the header. The Session log
+  // button is usually in headerUtilities, while the cards/icons live in the
+  // preceding headerActions group.
+  let rightWidth = 0
+
+  // If the cards are rendered as siblings after the button, sum their widths.
+  let sibling = button.nextElementSibling
+  while (sibling instanceof HTMLElement) {
+    rightWidth += sibling.getBoundingClientRect().width
+    sibling = sibling.nextElementSibling
+  }
+
+  // Also measure the headerActions group when it is the right-side card row.
+  const utilities = button.closest<HTMLElement>('[class*="headerUtilities"]')
+  const titleCluster = utilities?.previousElementSibling
+  const actions = titleCluster?.querySelector<HTMLElement>('[class*="headerActions"]')
+  if (actions !== null && actions !== undefined) {
+    rightWidth = Math.max(rightWidth, actions.getBoundingClientRect().width)
+  }
+
+  // Move left by the total width of the cards on the right, plus a 10px gap.
+  button.style.transform = `translateX(-${rightWidth + 10}px)`
+}
+
+function installWebChrome(): () => void {
+  const style = document.createElement('style')
+  style.dataset.ohDshWebChrome = 'true'
+  style.textContent = WEB_CHROME_CSS
+  document.head.append(style)
+  document.documentElement.dataset.ohDshWeb = 'true'
+
+  let mutationObserver: MutationObserver | undefined
+  let resizeObserver: ResizeObserver | undefined
+  let frame = 0
+
+  const apply = (): void => {
+    cancelAnimationFrame(frame)
+    frame = requestAnimationFrame(() => {
+      applySessionLogShift()
+      const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
+      const container = button?.parentElement
+      if (container !== undefined && container !== null) {
+        resizeObserver?.disconnect()
+        resizeObserver = new ResizeObserver(() => {
+          cancelAnimationFrame(frame)
+          frame = requestAnimationFrame(applySessionLogShift)
+        })
+        resizeObserver.observe(container)
+      }
+    })
+  }
+
+  mutationObserver = new MutationObserver(apply)
+  mutationObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class'],
+  })
+  apply()
+
+  return () => {
+    cancelAnimationFrame(frame)
+    mutationObserver?.disconnect()
+    resizeObserver?.disconnect()
+    style.remove()
+    delete document.documentElement.dataset.ohDshWeb
+  }
+}
+
 /** Enroll the web shell identity and the client-plane surface contract. */
 export function apply(ctx: ClientContext): void {
   // The unified three-surface contract, client plane: the web shell.
@@ -19,9 +99,13 @@ export function apply(ctx: ClientContext): void {
     kind: 'web',
   } satisfies OhDshSurfaceView), undefined)
   ctx.effect(() => {
+    const removeChrome = installWebChrome()
     const originalTitle = document.title
     document.title = 'Oh-DSH Web'
-    return () => { document.title = originalTitle }
+    return () => {
+      removeChrome()
+      document.title = originalTitle
+    }
   }, 'oh-dsh-web: shell identity')
   ctx.effect(() => {
     const headlineCopy = new Set([

--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -18,9 +18,16 @@ html[data-oh-dsh-web='true'] [class*='sessionLogButton'] {
 }
 `
 
+const ORIGINAL_TRANSFORM_KEY = 'ohDshOriginalTransform'
+
 function applySessionLogShift(): void {
   const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
   if (button === null) return
+
+  // Remember the host's original inline transform so cleanup can restore it.
+  if (button.dataset[ORIGINAL_TRANSFORM_KEY] === undefined) {
+    button.dataset[ORIGINAL_TRANSFORM_KEY] = button.style.transform || ''
+  }
 
   // Prefer the actual right-side card group in the header. The Session log
   // button is usually in headerUtilities, while the cards/icons live in the
@@ -87,6 +94,13 @@ function installWebChrome(): () => void {
     cancelAnimationFrame(frame)
     mutationObserver?.disconnect()
     resizeObserver?.disconnect()
+    for (const button of document.querySelectorAll<HTMLElement>('[class*="sessionLogButton"]')) {
+      const original = button.dataset[ORIGINAL_TRANSFORM_KEY]
+      if (original !== undefined) {
+        button.style.transform = original
+        delete button.dataset[ORIGINAL_TRANSFORM_KEY]
+      }
+    }
     style.remove()
     delete document.documentElement.dataset.ohDshWeb
   }


### PR DESCRIPTION
## Summary

- Make the terminal tab card taller and enlarge the tab-bar font.
- Remove the horizontal divider below the terminal bar.
- Replace the collapse chevron with a close action that fully hides the terminal dock when collapsed.
- Mount the terminal dock from the conversation scroll body so Web UI does not attach it to unrelated `data-phase` elements.
- In Web UI, keep the Session log button above the terminal surface and shift it left by the measured width of the right-side header cards plus a 10px gap.

## Verification

- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`
- `pnpm run stage:dsh`
- Verified locally in the Web UI that the Session log button is shifted by the computed right-card width + 10px.