### PR TITLE
linux: restore packaged Landlock launcher

### DIFF
--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -85,7 +85,7 @@ let
     pnpmDeps = pkgs.fetchPnpmDeps {
       inherit pname version src;
       fetcherVersion = 4;
-      hash = "sha256-fxLfVxTAqQrLdYmuRgQhiUm3WT4lhqBBecAfZ7745JU=";
+      hash = "sha256-P4vlfU8sdQXprLEvp9hkb5O3CIExvJcxkSqjDDczQak=";
     };
 
     nativeBuildInputs = [

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "electron-updater": "6.8.9",
     "semver": "7.7.4"
   },
+  "optionalDependencies": {
+    "@deepseek-ai/node-addon-landlock-run-linux-x64": "0.1.1"
+  },
   "devDependencies": {
     "@types/node": "^24.10.0",
     "@types/semver": "7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,10 @@ importers:
       yaml:
         specifier: 2.8.1
         version: 2.8.1
+    optionalDependencies:
+      '@deepseek-ai/node-addon-landlock-run-linux-x64':
+        specifier: 0.1.1
+        version: 0.1.1
 
   plugins/better-sidebar-runtime:
     dependencies:
@@ -1091,6 +1095,12 @@ packages:
       '@deepseek-ai/dsh-session-persistence': ^0.1.0-rc.6
       '@deepseek-ai/dsh-storage': ^0.1.0-rc.6
       '@deepseek-ai/dsh-storage-domain': ^0.1.0-rc.6
+
+  '@deepseek-ai/node-addon-landlock-run-linux-x64@0.1.1':
+    resolution: {integrity: sha512-OHAzPW2Coe/iYobAJAAA8CeVrBoKV4BnNHsgwvXwOfishxkUVSWSvdyxrZPiwYRXutpIGVrSo9zV3WOQy2euBA==}
+    engines: {node: '>=20'}
+    cpu: [x64]
+    os: [linux]
 
   '@deepseek-ai/schemastery@3.18.1':
     resolution: {integrity: sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==}
@@ -4085,6 +4095,9 @@ snapshots:
       '@deepseek-ai/dsh-storage': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-storage-domain': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
       zod: 4.4.3
+
+  '@deepseek-ai/node-addon-landlock-run-linux-x64@0.1.1':
+    optional: true
 
   '@deepseek-ai/schemastery@3.18.1':
     dependencies:

--- a/scripts/landlock-launcher.d.mts
+++ b/scripts/landlock-launcher.d.mts
@@ -1,0 +1,8 @@
+export const landlockLauncherPackageName: '@deepseek-ai/node-addon-landlock-run-linux-x64'
+
+export interface RestoreLandlockLauncherOptions {
+  readonly runtimeRoot: string
+  readonly sourcePackageRoot: string
+}
+
+export function restoreLandlockLauncher(options: RestoreLandlockLauncherOptions): string

--- a/scripts/landlock-launcher.mjs
+++ b/scripts/landlock-launcher.mjs
@@ -1,0 +1,59 @@
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+} from 'node:fs'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+export const landlockLauncherPackageName = '@deepseek-ai/node-addon-landlock-run-linux-x64'
+const landlockLauncherToolName = 'landlock-run'
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function resolvePackageFile(packageRoot, packagePath) {
+  const resolved = resolve(packageRoot, packagePath)
+  const rel = relative(packageRoot, resolved)
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(`Landlock launcher path escapes its package: ${packagePath}`)
+  }
+  return resolved
+}
+
+export function restoreLandlockLauncher({ runtimeRoot, sourcePackageRoot }) {
+  const targetPackageRoot = join(
+    runtimeRoot,
+    'node_modules',
+    ...landlockLauncherPackageName.split('/'),
+  )
+  const sourceManifest = readJson(join(sourcePackageRoot, 'package.json'))
+  const targetManifest = readJson(join(targetPackageRoot, 'package.json'))
+  if (sourceManifest.name !== landlockLauncherPackageName
+    || targetManifest.name !== landlockLauncherPackageName
+    || sourceManifest.version !== targetManifest.version) {
+    throw new Error(
+      `Landlock launcher package mismatch: staged ${String(targetManifest.name)}@${String(targetManifest.version)}, source ${String(sourceManifest.name)}@${String(sourceManifest.version)}`,
+    )
+  }
+
+  const prebuilds = readJson(join(targetPackageRoot, 'prebuilds.json'))
+  const launcher = prebuilds.binaries?.find(binary => binary.tool === landlockLauncherToolName)
+  if (typeof launcher?.path !== 'string') {
+    throw new Error(`staged ${landlockLauncherPackageName} does not declare ${landlockLauncherToolName}`)
+  }
+
+  const sourceLauncher = resolvePackageFile(sourcePackageRoot, launcher.path)
+  if (!existsSync(sourceLauncher) || !lstatSync(sourceLauncher).isFile()) {
+    throw new Error(`published Landlock launcher is missing: ${sourceLauncher}`)
+  }
+
+  const targetLauncher = resolvePackageFile(targetPackageRoot, launcher.path)
+  mkdirSync(dirname(targetLauncher), { recursive: true })
+  copyFileSync(sourceLauncher, targetLauncher)
+  chmodSync(targetLauncher, 0o755)
+  return targetLauncher
+}

--- a/scripts/stage-dsh.mjs
+++ b/scripts/stage-dsh.mjs
@@ -27,6 +27,10 @@ import {
 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { resolveDshSource, resolvePinnedPnpm } from './dsh-source.mjs'
+import {
+  landlockLauncherPackageName,
+  restoreLandlockLauncher,
+} from './landlock-launcher.mjs'
 import { resolveNodeDistributionPlatform } from '../src/node-platform.ts'
 import { adaptTuiRendererPackage } from './tui-upstream-adapter.mjs'
 
@@ -926,6 +930,30 @@ function ensureLinuxPtyBuild() {
   }
 }
 
+function ensureLinuxLandlockLauncher() {
+  if (nodePlatform !== 'linux') return
+  if (nodeArch !== 'x64') {
+    throw new Error(`unsupported Landlock launcher architecture: linux-${nodeArch}`)
+  }
+
+  const requireFromRoot = createRequire(join(root, 'package.json'))
+  let sourceManifestPath
+  try {
+    sourceManifestPath = requireFromRoot.resolve(`${landlockLauncherPackageName}/package.json`)
+  } catch (cause) {
+    throw new Error(
+      `${landlockLauncherPackageName} is missing; run pnpm install on linux-x64 before staging`,
+      { cause },
+    )
+  }
+
+  const launcher = restoreLandlockLauncher({
+    runtimeRoot: runtime,
+    sourcePackageRoot: dirname(sourceManifestPath),
+  })
+  console.log(`Restored Linux Landlock launcher: ${launcher}`)
+}
+
 if (!existsSync(join(dshSource, 'apps', 'cli', 'package.json'))) {
   throw new Error(`DSH source checkout not found: ${dshSource}`)
 }
@@ -996,6 +1024,7 @@ copyFileSync(join(dshSource, 'THIRD_PARTY_NOTICES.md'), join(runtime, 'THIRD_PAR
 restoreExecutableHelpers()
 console.log('Normalizing runtime links')
 normalizeRuntimeLinks()
+ensureLinuxLandlockLauncher()
 assertSelfContained(runtime, 'DSH runtime')
 ensureNodeRuntime()
 assertSelfContained(nodeRuntime, 'Node runtime')

--- a/tests/landlock-launcher.test.ts
+++ b/tests/landlock-launcher.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import {
+  landlockLauncherPackageName,
+  restoreLandlockLauncher,
+} from '../scripts/landlock-launcher.mjs'
+
+const packageVersion = '0.1.1'
+
+function writePackageManifest(packageRoot: string, version = packageVersion) {
+  mkdirSync(packageRoot, { recursive: true })
+  writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+    name: landlockLauncherPackageName,
+    version,
+  }))
+}
+
+function writePrebuildManifest(packageRoot: string) {
+  writeFileSync(join(packageRoot, 'prebuilds.json'), JSON.stringify({
+    platform: 'linux-x64',
+    binaries: [{
+      tool: 'landlock-run',
+      kind: 'static-musl',
+      path: 'bin/landlock-run',
+    }],
+  }))
+}
+
+function packageRoot(runtimeRoot: string) {
+  return join(runtimeRoot, 'node_modules', ...landlockLauncherPackageName.split('/'))
+}
+
+test('Linux staging restores the published Landlock launcher into the runtime package', () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-landlock-'))
+  const runtimeRoot = join(root, 'runtime')
+  const sourcePackageRoot = join(root, 'published')
+  const targetPackageRoot = packageRoot(runtimeRoot)
+  const sourceLauncher = join(sourcePackageRoot, 'bin', 'landlock-run')
+  try {
+    writePackageManifest(sourcePackageRoot)
+    writePackageManifest(targetPackageRoot)
+    writePrebuildManifest(targetPackageRoot)
+    mkdirSync(dirname(sourceLauncher), { recursive: true })
+    writeFileSync(sourceLauncher, 'published launcher')
+
+    const targetLauncher = restoreLandlockLauncher({ runtimeRoot, sourcePackageRoot })
+
+    assert.equal(targetLauncher, join(targetPackageRoot, 'bin', 'landlock-run'))
+    assert.equal(readFileSync(targetLauncher, 'utf8'), 'published launcher')
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(targetLauncher).mode & 0o777, 0o755)
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('Linux staging fails when the published Landlock launcher is missing', () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-landlock-'))
+  const runtimeRoot = join(root, 'runtime')
+  const sourcePackageRoot = join(root, 'published')
+  const targetPackageRoot = packageRoot(runtimeRoot)
+  try {
+    writePackageManifest(sourcePackageRoot)
+    writePackageManifest(targetPackageRoot)
+    writePrebuildManifest(targetPackageRoot)
+
+    assert.throws(
+      () => restoreLandlockLauncher({ runtimeRoot, sourcePackageRoot }),
+      /published Landlock launcher is missing/,
+    )
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('desktop pins the published Linux x64 Landlock launcher package', () => {
+  const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+  assert.equal(manifest.optionalDependencies?.[landlockLauncherPackageName], packageVersion)
+})


### PR DESCRIPTION
## What changed

- Restore the official `landlock-run` binary while staging Linux x64 releases.
- Check that the launcher package name and version match the current workspace.
- Fail staging when the dependency or binary is missing.
- Set the launcher mode to `0755`.
- Refresh the Nix `pnpmDeps` hash after updating the lockfile.
- Add regression coverage for restoration, failure handling, and version pinning.

## Verification

- `pnpm run typecheck`
- `pnpm test` (171 passed, 2 platform-specific tests skipped)
- `pnpm run build`
- `nix build github:SnowfallC/oh-dsh/3ece3d42bd960922e5436f2100bbd3f23179c1d7#oh-dsh-web`
- `git diff --check`

Closes #98