### PR TITLE
mac: retire stale duplicate app bundles after upgrade

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-17-retire-stale-mac-app-bundles.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-retire-stale-mac-app-bundles.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-17-retire-stale-mac-app-bundles.md
+2026-08-17-retire-stale-mac-app-bundles.md: f00457dc6062ca0dee3c2c39d48d33500f745d69
+2026-08-17-retire-stale-mac-app-bundles.zh.md: f5c62724577b5b3e9dc43ca910e1e3cde222dab9

--- a/.agents/notes/implemented/bug-fix/2026-08-17-retire-stale-mac-app-bundles.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-retire-stale-mac-app-bundles.md
@@ -1,0 +1,70 @@
+# Agent Note: Retire stale duplicate macOS app bundles on first launch
+
+Status: implemented
+
+English | [中文](2026-08-17-retire-stale-mac-app-bundles.zh.md)
+
+## Problem
+
+The packaged macOS bundle changed its file name during the 0.1.x series —
+`Oh-DSH-Desktop.app` (v0.1.0–v0.1.3) became `Oh-DSH Desktop.app` (v0.1.4+)
+while keeping the same bundle identifier (`ai.deepseek.oh-dsh-desktop`).
+Users who install from the release DMG by dragging the app into /Applications
+never run `scripts/install-mac.mjs`, so Finder keeps both bundles side by
+side instead of replacing the old one: two apps end up sharing one bundle
+identifier, and Dock, Spotlight, and auto-update can keep resolving the old
+location. Issue #103 reports the duplicate that shipped with the visible
+rename.
+
+## Decision
+
+On first launch of the packaged macOS app from /Applications, `bootstrap()`
+calls `retireStaleMacBundles`. The migration probes the historical sibling
+bundle names under /Applications, verifies each candidate's
+`CFBundleIdentifier` matches the product bundle identifier and its
+`CFBundleShortVersionString` is strictly older than the running version,
+moves qualifying bundles into ~/.Trash under a timestamped name, unregisters
+the stale path, and re-registers the running bundle with LaunchServices via
+`lsregister`. A sibling whose version cannot be verified is never retired:
+it is left in place and reported, because an unknown version must not count
+as evidence of being older. The running bundle is never moved; a launch
+straight from the mounted DMG (running path outside /Applications) never
+touches /Applications; every failure is logged and never aborts startup.
+This mirrors what `scripts/install-mac.mjs` already does for local installs
+and closes the same gap for DMG installs.
+
+## Alternatives considered
+
+**Revert the bundle file name to `Oh-DSH-Desktop.app`.** electron-builder
+derives the `.app` directory name from `productName` with no per-platform
+override, and `productName` also drives the Linux desktop `Name=` and
+Windows file metadata, so a global revert would regress other platforms'
+display names. It would also move the duplication onto users of the three
+already published `Oh-DSH Desktop.app` releases, and the docs and READMEs
+already document the `/Applications/Oh-DSH Desktop.app` path.
+
+**Rename the bundle during `afterPack`.** The DMG and ZIP targets resolve
+the app path from `productName` (macPackager.js), so a post-pack rename
+breaks artifact creation, and electron-builder has no option that decouples
+the bundle file name from `productName`.
+
+**Scan LaunchServices or Spotlight for every bundle with the identifier.**
+Depends on index freshness and adds a slow scan at launch; probing the two
+historical bundle names is deterministic and fast, and the identifier check
+keeps unrelated applications out of scope.
+
+**Keep the cleanup local to `scripts/install-mac.mjs`.** It never runs for
+DMG drag-install users, which is exactly the gap the issue reports.
+
+## Consequences
+
+Upgrading from any published bundle name converges to a single application
+after the first launch of the newer version; retired bundles stay
+recoverable in the Trash. A user who launches the older of two installed
+bundles is left alone, because siblings newer than the running version are
+never retired. Same-name upgrades still rely on Finder's overwrite as
+before. The retirement is best effort: when /Applications is not writable by
+the current user the move fails, is logged, and startup continues.
+`lsregister` re-registration makes Dock, Spotlight, and auto-update resolve
+the running bundle after a retirement. The behavior is pinned by
+`tests/mac-bundle-migration.test.ts`.

--- a/.agents/notes/implemented/bug-fix/2026-08-17-retire-stale-mac-app-bundles.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-retire-stale-mac-app-bundles.zh.md
@@ -1,0 +1,27 @@
+# Agent Note: 首次启动时清理过期的重复 macOS 应用包
+
+Status: implemented
+
+[English](2026-08-17-retire-stale-mac-app-bundles.md) | 中文
+
+## 问题
+
+打包后的 macOS 应用包在 0.1.x 系列中改了文件名——`Oh-DSH-Desktop.app`（v0.1.0–v0.1.3）变成了 `Oh-DSH Desktop.app`（v0.1.4+），但 bundle 标识符（`ai.deepseek.oh-dsh-desktop`）保持不变。从发布页 DMG 拖入 /Applications 安装的用户不会执行 `scripts/install-mac.mjs`，Finder 因而不会覆盖旧应用，而是让两个包并存：最终两个应用共享同一个 bundle 标识符，Dock、Spotlight 和自动更新可能一直解析到旧位置。issue #103 报告了这次可见改名上线后出现的重复应用。
+
+## 决策
+
+打包的 macOS 应用首次从 /Applications 启动时，`bootstrap()` 会调用 `retireStaleMacBundles`。该迁移探测 /Applications 下历史上的兄弟包名，用 `CFBundleIdentifier` 校验每个候选包与产品 bundle 标识符一致、且其 `CFBundleShortVersionString` 严格旧于当前运行版本，然后把符合条件的包以带时间戳的名字移入 ~/.Trash，注销旧路径，并通过 `lsregister` 把当前运行的包重新注册到 LaunchServices。版本无法校验的兄弟包永远不会被清理：保持原位并记录报告，因为未知版本不能作为"更旧"的证据。运行中的包永远不会被移动；直接从挂载的 DMG 启动（运行路径在 /Applications 之外）绝不会改动 /Applications；任何失败都只记日志、绝不中断启动。这与 `scripts/install-mac.mjs` 在本地安装时做的事一致，补齐了 DMG 安装场景下的同一缺口。
+
+## 考虑过的替代方案
+
+**把包文件名改回 `Oh-DSH-Desktop.app`。** electron-builder 用 `productName` 直接决定 `.app` 目录名，且没有按平台覆盖的选项；`productName` 同时驱动 Linux 桌面 `Name=` 和 Windows 文件元数据，全局改回会回归其他平台的显示名。它还会把重复问题转嫁给三个已发布的 `Oh-DSH Desktop.app` 版本的用户，而且文档和 README 已经写明 `/Applications/Oh-DSH Desktop.app` 路径。
+
+**在 `afterPack` 阶段改名。** DMG 和 ZIP 目标按 `productName` 解析应用路径（macPackager.js），打包后改名会破坏产物生成；electron-builder 也没有任何选项能把包文件名与 `productName` 解耦。
+
+**用 LaunchServices 或 Spotlight 扫描所有同标识符的包。** 依赖索引新鲜度，还会在启动时引入慢扫描；探测两个历史包名既确定又快，标识符校验则把无关应用挡在范围之外。
+
+**只把清理留在 `scripts/install-mac.mjs` 里。** 它对 DMG 拖放安装的用户从不生效，而这正是 issue 指出的缺口。
+
+## 后果
+
+从任何一个已发布的包名升级，都会在新版本首次启动后收敛为单个应用；被清理的包仍可在废纸篓中找回。用户启动两个已安装包中较旧的那个时不会被改动，因为比运行版本更新的兄弟包永远不会被清理。同名升级仍然依赖 Finder 的覆盖行为。清理是尽力而为：当前用户对 /Applications 无写权限时移动会失败、只记日志、启动继续。清理后 `lsregister` 的重新注册会让 Dock、Spotlight 和自动更新解析到当前运行的包。该行为由 `tests/mac-bundle-migration.test.ts` 固定。

--- a/src/mac-bundle-migration.ts
+++ b/src/mac-bundle-migration.ts
@@ -1,0 +1,224 @@
+/**
+ * Retire stale macOS application bundles after an in-place upgrade.
+ *
+ * The packaged .app bundle changed its file name during the 0.1.x series
+ * (Oh-DSH-Desktop.app → Oh-DSH Desktop.app) while keeping the same bundle
+ * identifier. Users who install from the release DMG by dragging the app into
+ * /Applications never run scripts/install-mac.mjs, so Finder keeps both
+ * bundles side by side instead of replacing the old one. The result is two
+ * apps with the same bundle identifier, and Dock, Spotlight, and auto-update
+ * can keep resolving the old location.
+ *
+ * This module implements the same cleanup the local installer performs, for
+ * DMG installs: when the packaged app launches from /Applications it looks
+ * for sibling bundles with the same bundle identifier, moves any that are
+ * strictly older into the Trash, and re-registers the running bundle with
+ * LaunchServices so the system converges on a single app.
+ */
+import { execFile } from 'node:child_process'
+import { existsSync, mkdirSync, renameSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export const MAC_BUNDLE_ID = 'ai.deepseek.oh-dsh-desktop'
+
+/** Every bundle file name the packaged macOS app has shipped under. */
+export const MAC_BUNDLE_NAMES = [
+  'Oh-DSH-Desktop.app',
+  'Oh-DSH Desktop.app',
+] as const
+
+const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister'
+
+/** Compare dotted version strings numerically; returns -1, 0, or 1. */
+export function compareVersions(left: string, right: string): number {
+  const leftParts = left.split('.').map(part => Number.parseInt(part, 10) || 0)
+  const rightParts = right.split('.').map(part => Number.parseInt(part, 10) || 0)
+  const length = Math.max(leftParts.length, rightParts.length)
+  for (let index = 0; index < length; index += 1) {
+    const diff = (leftParts[index] ?? 0) - (rightParts[index] ?? 0)
+    if (diff !== 0) return diff > 0 ? 1 : -1
+  }
+  return 0
+}
+
+/** Read one Info.plist string key from a macOS application bundle. */
+export interface BundleProbe {
+  bundleIdentifier(bundlePath: string): Promise<string | null>
+  shortVersion(bundlePath: string): Promise<string | null>
+}
+
+async function readPlistString(bundlePath: string, key: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('/usr/bin/plutil', [
+      '-extract',
+      key,
+      'raw',
+      '-o',
+      '-',
+      join(bundlePath, 'Contents', 'Info.plist'),
+    ], { timeout: 5000 })
+    const value = stdout.trim()
+    return value === '' ? null : value
+  } catch {
+    return null
+  }
+}
+
+export const plutilBundleProbe: BundleProbe = {
+  bundleIdentifier: bundlePath => readPlistString(bundlePath, 'CFBundleIdentifier'),
+  shortVersion: bundlePath => readPlistString(bundlePath, 'CFBundleShortVersionString'),
+}
+
+export interface StaleMacBundle {
+  path: string
+  version: string
+}
+
+export interface FindStaleMacBundlesOptions {
+  applicationsDir: string
+  runningBundlePath: string
+  runningVersion: string
+  bundleId?: string
+  bundleNames?: readonly string[]
+  probe?: BundleProbe
+}
+
+/**
+ * List sibling bundles under the given Applications directory that share the
+ * running app's bundle identifier but are strictly older. The running bundle
+ * itself and unrelated bundles are never returned.
+ */
+export interface FindStaleMacBundlesResult {
+  /** Same-identifier siblings that are strictly older than the running version. */
+  stale: StaleMacBundle[]
+  /**
+   * Same-identifier siblings whose version could not be read. They are never
+   * retired: an unknown version must not count as evidence of being older.
+   */
+  unverifiable: string[]
+}
+
+/**
+ * Scan the given Applications directory for sibling bundles that share the
+ * running app's bundle identifier but are strictly older. The running bundle
+ * itself and unrelated bundles are never returned, and a bundle whose version
+ * cannot be verified is reported under `unverifiable` instead of being
+ * classified by age.
+ */
+export async function findStaleMacBundles(options: FindStaleMacBundlesOptions): Promise<FindStaleMacBundlesResult> {
+  const bundleId = options.bundleId ?? MAC_BUNDLE_ID
+  const bundleNames = options.bundleNames ?? MAC_BUNDLE_NAMES
+  const probe = options.probe ?? plutilBundleProbe
+  const running = resolve(options.runningBundlePath)
+  const result: FindStaleMacBundlesResult = { stale: [], unverifiable: [] }
+  for (const name of bundleNames) {
+    const candidate = resolve(join(options.applicationsDir, name))
+    if (candidate === running) continue
+    if (!existsSync(candidate)) continue
+    const identifier = await probe.bundleIdentifier(candidate)
+    if (identifier !== bundleId) continue
+    const version = await probe.shortVersion(candidate)
+    if (version === null) {
+      result.unverifiable.push(candidate)
+      continue
+    }
+    if (compareVersions(version, options.runningVersion) >= 0) continue
+    result.stale.push({ path: candidate, version })
+  }
+  return result
+}
+
+function timestamp(date = new Date()): string {
+  const part = (value: number) => String(value).padStart(2, '0')
+  return [
+    String(date.getFullYear()),
+    part(date.getMonth() + 1),
+    part(date.getDate()),
+    '-',
+    part(date.getHours()),
+    part(date.getMinutes()),
+    part(date.getSeconds()),
+  ].join('')
+}
+
+function reserveTrashPath(trashDirectory: string, bundlePath: string): string {
+  const stem = `${basename(bundlePath, '.app')}-before-${timestamp()}`
+  for (let suffix = 0; suffix < 100; suffix += 1) {
+    const name = suffix === 0 ? `${stem}.app` : `${stem}-${String(suffix)}.app`
+    const candidate = join(trashDirectory, name)
+    if (!existsSync(candidate)) return candidate
+  }
+  throw new Error(`unable to reserve a Trash path for ${bundlePath}`)
+}
+
+async function runLsRegister(...args: string[]): Promise<void> {
+  try {
+    await execFileAsync(LSREGISTER, args, { timeout: 5000 })
+  } catch {
+    // LaunchServices rescans on its own; registration is best effort.
+  }
+}
+
+export interface RetireStaleMacBundlesOptions {
+  applicationsDir?: string
+  trashDirectory?: string
+  runningBundlePath: string
+  runningVersion: string
+  bundleId?: string
+  bundleNames?: readonly string[]
+  probe?: BundleProbe
+}
+
+export interface RetiredMacBundle extends StaleMacBundle {
+  trashPath: string
+}
+
+export interface RetireStaleMacBundlesResult {
+  retired: RetiredMacBundle[]
+  failures: string[]
+}
+
+/**
+ * Move strictly older sibling bundles with the same bundle identifier to the
+ * Trash and re-register the running bundle with LaunchServices. Each bundle
+ * is handled independently: a failure to retire one never aborts the others.
+ * A sibling whose version cannot be verified is reported as a failure and
+ * left in place.
+ */
+export async function retireStaleMacBundles(options: RetireStaleMacBundlesOptions): Promise<RetireStaleMacBundlesResult> {
+  const applicationsDir = options.applicationsDir ?? '/Applications'
+  const trashDirectory = options.trashDirectory ?? join(homedir(), '.Trash')
+  const scan = await findStaleMacBundles({
+    applicationsDir,
+    runningBundlePath: options.runningBundlePath,
+    runningVersion: options.runningVersion,
+    ...(options.bundleId === undefined ? {} : { bundleId: options.bundleId }),
+    ...(options.bundleNames === undefined ? {} : { bundleNames: options.bundleNames }),
+    ...(options.probe === undefined ? {} : { probe: options.probe }),
+  })
+  const retired: RetiredMacBundle[] = []
+  const failures: string[] = scan.unverifiable.map(path => (
+    `${path}: bundle version could not be verified; left in place`
+  ))
+  for (const bundle of scan.stale) {
+    try {
+      const trashPath = reserveTrashPath(trashDirectory, bundle.path)
+      // Unregister the stale path first so LaunchServices does not keep
+      // resolving the old location, then move the bundle out of Applications.
+      await runLsRegister('-u', bundle.path)
+      mkdirSync(trashDirectory, { recursive: true })
+      renameSync(bundle.path, trashPath)
+      retired.push({ ...bundle, trashPath })
+    } catch (error) {
+      failures.push(`${bundle.path}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+  if (retired.length > 0) {
+    await runLsRegister('-f', resolve(options.runningBundlePath))
+  }
+  return { retired, failures }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import {
   migrateLegacyDesktopState,
   resolveOhDshHome,
 } from './data-root.ts'
+import { retireStaleMacBundles } from './mac-bundle-migration.ts'
 import { allowsRuntimeClipboardWrite, originOf } from './permissions.ts'
 import { BUNDLED_DESKTOP_PLUGINS, DESKTOP_PROFILE, ensureDesktopProfile } from './profile.ts'
 import { DshRuntimeSupervisor, runDshCommand, type DshRuntimeOptions, type RuntimeExit } from './runtime.ts'
@@ -96,6 +97,37 @@ function resourcesRoot(): string {
     join(currentDir, '..', '.stage'),
     app.isPackaged,
   )
+}
+
+function runningMacBundlePath(): string | undefined {
+  if (process.platform !== 'darwin' || !app.isPackaged) return undefined
+  // process.execPath is <bundle>/Contents/MacOS/<executable>.
+  const bundlePath = resolve(dirname(process.execPath), '..', '..')
+  // Only migrate when launched from the standard install location; a launch
+  // straight from the mounted DMG must never touch /Applications.
+  return bundlePath.startsWith('/Applications/') ? bundlePath : undefined
+}
+
+async function retireDuplicateMacBundles(): Promise<void> {
+  const runningBundlePath = runningMacBundlePath()
+  if (runningBundlePath === undefined) return
+  try {
+    const result = await retireStaleMacBundles({
+      runningBundlePath,
+      runningVersion: PRODUCT_VERSION,
+    })
+    for (const retired of result.retired) {
+      appendLog(
+        'desktop',
+        `retired stale macOS bundle ${retired.path} (v${retired.version}) → ${retired.trashPath}`,
+      )
+    }
+    for (const failure of result.failures) {
+      appendLog('desktop', `could not retire stale macOS bundle: ${failure}`)
+    }
+  } catch (error) {
+    appendLog('desktop', `macOS bundle retirement skipped: ${error instanceof Error ? error.message : String(error)}`)
+  }
 }
 
 function runtimePaths(): BundledRuntimePaths {
@@ -890,6 +922,7 @@ async function bootstrap(): Promise<void> {
   mkdirSync(logsDir, { recursive: true })
   logStream = createWriteStream(join(logsDir, 'desktop.log'), { flags: 'a', mode: 0o600 })
   appendLog('desktop', `${PRODUCT_NAME} ${info.version} starting (${process.arch})`)
+  await retireDuplicateMacBundles()
   await getUpdateManager()
   marketplace = createPluginMarketplace()
   marketplaceAgentGateway = await startMarketplaceAgentGateway(marketplace, {

--- a/tests/mac-bundle-migration.test.ts
+++ b/tests/mac-bundle-migration.test.ts
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { test } from 'node:test'
+import {
+  compareVersions,
+  findStaleMacBundles,
+  retireStaleMacBundles,
+  type BundleProbe,
+} from '../src/mac-bundle-migration.ts'
+
+function makeProbe(metadata: Record<string, { identifier?: string | null; version?: string | null }>): BundleProbe {
+  return {
+    bundleIdentifier: async path => metadata[path]?.identifier ?? null,
+    shortVersion: async path => metadata[path]?.version ?? null,
+  }
+}
+
+test('compareVersions orders dotted versions numerically', () => {
+  assert.equal(compareVersions('0.1.3', '0.1.4'), -1)
+  assert.equal(compareVersions('0.1.9', '0.1.10'), -1)
+  assert.equal(compareVersions('0.2.0', '0.1.99'), 1)
+  assert.equal(compareVersions('1.0.0', '1'), 0)
+  assert.equal(compareVersions('0.1.5', '0.1.5'), 0)
+  assert.equal(compareVersions('0.0.0', '0.1.0'), -1)
+})
+
+test('findStaleMacBundles returns only older siblings with the same bundle identifier', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-stale-'))
+  try {
+    const applications = join(root, 'Applications')
+    const running = join(applications, 'Oh-DSH Desktop.app')
+    const old = join(applications, 'Oh-DSH-Desktop.app')
+    const unrelated = join(applications, 'Unrelated.app')
+    const newer = join(applications, 'Oh-DSH-Newer.app')
+    for (const bundle of [running, old, unrelated, newer]) {
+      mkdirSync(bundle, { recursive: true })
+    }
+    const probe = makeProbe({
+      [old]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: '0.1.3' },
+      [running]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: '0.1.5' },
+      [unrelated]: { identifier: 'com.example.other', version: '0.1.3' },
+      [newer]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: '0.2.0' },
+    })
+
+    const result = await findStaleMacBundles({
+      applicationsDir: applications,
+      runningBundlePath: running,
+      runningVersion: '0.1.5',
+      bundleNames: ['Oh-DSH-Desktop.app', 'Oh-DSH Desktop.app', 'Oh-DSH-Newer.app'],
+      probe,
+    })
+
+    assert.deepEqual(result, {
+      stale: [{ path: old, version: '0.1.3' }],
+      unverifiable: [],
+    })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('findStaleMacBundles ignores bundles that do not exist', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-missing-'))
+  try {
+    const result = await findStaleMacBundles({
+      applicationsDir: join(root, 'Applications'),
+      runningBundlePath: join(root, 'Applications', 'Oh-DSH Desktop.app'),
+      runningVersion: '0.1.5',
+      probe: makeProbe({}),
+    })
+    assert.deepEqual(result, { stale: [], unverifiable: [] })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('findStaleMacBundles never treats an unreadable version as older', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-unverified-'))
+  try {
+    const applications = join(root, 'Applications')
+    const running = join(applications, 'Oh-DSH Desktop.app')
+    const unknown = join(applications, 'Oh-DSH-Desktop.app')
+    mkdirSync(unknown, { recursive: true })
+    const probe = makeProbe({
+      [unknown]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: null },
+    })
+
+    const result = await findStaleMacBundles({
+      applicationsDir: applications,
+      runningBundlePath: running,
+      runningVersion: '0.1.5',
+      probe,
+    })
+
+    assert.deepEqual(result, { stale: [], unverifiable: [unknown] })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('retireStaleMacBundles moves older siblings to the Trash and re-registers the running bundle', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-retire-'))
+  try {
+    const applications = join(root, 'Applications')
+    const trash = join(root, 'Trash')
+    const running = join(applications, 'Oh-DSH Desktop.app')
+    const old = join(applications, 'Oh-DSH-Desktop.app')
+    mkdirSync(join(old, 'Contents'), { recursive: true })
+    writeFileSync(join(old, 'Contents', 'Info.plist'), '<plist/>')
+    const probe = makeProbe({
+      [old]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: '0.1.3' },
+    })
+
+    const result = await retireStaleMacBundles({
+      applicationsDir: applications,
+      trashDirectory: trash,
+      runningBundlePath: running,
+      runningVersion: '0.1.5',
+      probe,
+    })
+
+    assert.equal(result.failures.length, 0)
+    assert.equal(result.retired.length, 1)
+    assert.equal(result.retired[0]!.path, old)
+    assert.equal(result.retired[0]!.version, '0.1.3')
+    assert.equal(existsSync(old), false)
+    assert.equal(existsSync(result.retired[0]!.trashPath), true)
+    assert.match(result.retired[0]!.trashPath, /Oh-DSH-Desktop-before-\d{8}-\d{6}(-\d+)?\.app$/)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('retireStaleMacBundles leaves unverifiable siblings in place and reports them', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-unverifiable-'))
+  try {
+    const applications = join(root, 'Applications')
+    const trash = join(root, 'Trash')
+    const running = join(applications, 'Oh-DSH Desktop.app')
+    const unknown = join(applications, 'Oh-DSH-Desktop.app')
+    mkdirSync(join(unknown, 'Contents'), { recursive: true })
+    writeFileSync(join(unknown, 'Contents', 'Info.plist'), '<plist/>')
+    const probe = makeProbe({
+      [unknown]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: null },
+    })
+
+    const result = await retireStaleMacBundles({
+      applicationsDir: applications,
+      trashDirectory: trash,
+      runningBundlePath: running,
+      runningVersion: '0.1.5',
+      probe,
+    })
+
+    assert.deepEqual(result.retired, [])
+    assert.equal(result.failures.length, 1)
+    assert.match(result.failures[0]!, /could not be verified; left in place/)
+    assert.equal(existsSync(unknown), true)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('retireStaleMacBundles never retires the running bundle or newer siblings', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'oh-dsh-keep-'))
+  try {
+    const applications = join(root, 'Applications')
+    const trash = join(root, 'Trash')
+    const running = join(applications, 'Oh-DSH-Desktop.app')
+    const newer = join(applications, 'Oh-DSH Desktop.app')
+    mkdirSync(join(newer, 'Contents'), { recursive: true })
+    writeFileSync(join(newer, 'Contents', 'Info.plist'), '<plist/>')
+    const probe = makeProbe({
+      [running]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: '0.1.5' },
+      [newer]: { identifier: 'ai.deepseek.oh-dsh-desktop', version: '0.1.6' },
+    })
+
+    const result = await retireStaleMacBundles({
+      applicationsDir: applications,
+      trashDirectory: trash,
+      runningBundlePath: running,
+      runningVersion: '0.1.5',
+      probe,
+    })
+
+    assert.deepEqual(result.retired, [])
+    assert.deepEqual(result.failures, [])
+    assert.equal(existsSync(newer), true)
+    assert.equal(existsSync(running), false)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Fixes #103

## 问题 / Problem

The packaged macOS bundle changed its file name during the 0.1.x series (`Oh-DSH-Desktop.app` → `Oh-DSH Desktop.app`) while keeping the same bundle identifier (`ai.deepseek.oh-dsh-desktop`). Users who install from the release DMG by dragging the app into `/Applications` never run `scripts/install-mac.mjs`, so Finder keeps both bundles side by side instead of replacing the old one — two apps with the same bundle ID, with Dock / Spotlight / auto-update possibly still resolving the old location.

macOS 升级后出现两个应用：`Oh-DSH-Desktop.app`（v0.1.0–v0.1.3）与 `Oh-DSH Desktop.app`（v0.1.4+）具有相同 bundle ID，从 DMG 拖放安装的用户不会执行 `scripts/install-mac.mjs`，因此旧应用不会被替换。

## 修复方案 / Fix

On first launch of the packaged app from `/Applications`, retire stale siblings:

- New module [`src/mac-bundle-migration.ts`](src/mac-bundle-migration.ts): looks for sibling bundles with the same bundle identifier under `/Applications` (only the historical bundle names are probed), verifies the bundle ID via `plutil`, and moves any bundle that is **strictly older** than the running version into `~/.Trash` (timestamped, recoverable), then re-registers the running bundle with LaunchServices (`lsregister`).
- Hooked into `bootstrap()` in [`src/main.ts`](src/main.ts): runs right after startup logging, is best-effort (failures are logged, never fatal), and is skipped unless the app is packaged, on macOS, and launched from `/Applications` — a launch straight from the mounted DMG never touches `/Applications`.
- Unit tests in [`tests/mac-bundle-migration.test.ts`](tests/mac-bundle-migration.test.ts) cover version ordering, bundle-ID filtering, newer-sibling protection, and the Trash move.

Safeguards:
- Only bundles with the same bundle identifier are ever moved; unrelated apps are never touched.
- A sibling that is **newer** than the running app is never retired (prevents the old app from deleting a newer install).
- The running bundle itself is never moved; items go to the Trash (recoverable), mirroring what `scripts/install-mac.mjs` already does for local installs.

## 验证 / Verification

- `pnpm run typecheck` ✅
- `pnpm test` ✅ (182 tests, 0 failures; 5 pre-existing platform skips)
- `pnpm run build` ✅ (migration code confirmed inside `dist/main.js`)