### PR TITLE
desktop: remove the Windows titlebar gap

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
+2026-08-17-windows-native-titlebar-offset.md: d543a7a395f2ce2f9f866b57c260a47ee7d066c0
+2026-08-17-windows-native-titlebar-offset.zh.md: e20fb0cc410e26da504f4b3f467cd823ff1c4470

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
-2026-08-17-windows-native-titlebar-offset.md: d543a7a395f2ce2f9f866b57c260a47ee7d066c0
-2026-08-17-windows-native-titlebar-offset.zh.md: e20fb0cc410e26da504f4b3f467cd823ff1c4470
+2026-08-17-windows-native-titlebar-offset.md: de58b09b138ef9a5725876f98015e7c2cee297ce
+2026-08-17-windows-native-titlebar-offset.zh.md: 1f594278ef0bb01809c6e1bd6fd4e5d7f62d9b51

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
-2026-08-17-windows-native-titlebar-offset.md: de58b09b138ef9a5725876f98015e7c2cee297ce
-2026-08-17-windows-native-titlebar-offset.zh.md: 1f594278ef0bb01809c6e1bd6fd4e5d7f62d9b51
+2026-08-17-windows-native-titlebar-offset.md: 168f6af4563d5b9b13446101b880e44059688ab8
+2026-08-17-windows-native-titlebar-offset.zh.md: d61448b4acc37945a4e752f67c665cfd3553f116

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
@@ -1,0 +1,61 @@
+# Agent Note: Keep native Windows titlebar separate from macOS overlay chrome
+
+Status: implemented
+
+English | [中文](2026-08-17-windows-native-titlebar-offset.zh.md)
+
+## Problem
+
+The Desktop client applies a 40px renderer offset and a fixed draggable chrome
+layer on every platform. Electron hides the native titlebar only on macOS;
+Windows keeps its native titlebar and application menu. The Windows content
+therefore receives an extra top offset, and fixed Desktop surfaces inherit the
+same incorrect titlebar height.
+
+## Decision
+
+The Desktop client reads the platform fact synchronously from the Electron
+preload bridge and sets the shared titlebar offset to 40px on macOS and 0px on
+Windows and Linux. The Desktop client chrome CSS fallback is zero, and fixed
+Desktop surfaces receive the same value before the asynchronous metadata lookup
+starts. That lookup only supplies preview identity; a lookup failure cannot
+remove the installed window chrome. Teardown restores the prior inline value.
+Windows keeps its native Electron titlebar; this change does not introduce a
+second Windows window-controls implementation.
+
+## Alternatives considered
+
+**Hide the Windows native titlebar and enable a window-controls overlay.**
+Rejected for this issue because the current Windows configuration intentionally
+uses native window chrome. That alternative would require owning draggable
+regions, control safe areas, and Windows-specific window behavior.
+
+**Keep the 40px offset on every Desktop platform.** Rejected because it
+duplicates the native Windows titlebar and produces the reported empty region.
+
+**Remove only the body padding on Windows.** Rejected because pinned summary
+and marketplace surfaces also consume the shared titlebar offset and would keep
+their Windows geometry displaced.
+
+## Consequences
+
+macOS retains its custom overlay titlebar. Windows and Linux content begins at
+the top of the renderer viewport below native window chrome, and fixed Desktop
+surfaces use the same zero offset. The platform-dependent style is installed
+synchronously from the preload platform fact and is removed with the Desktop
+client effect.
+
+## Testing
+
+The platform offset and metadata failure-path tests pass. `pnpm run typecheck`
+and `pnpm run build` pass. `pnpm test` reports 180 tests: 177 passed, 1
+failed, and 2 skipped; it exits with failure because the pre-existing Windows
+environment cannot start `python3` in `tests/nix-collect-deps.test.ts` (9009).
+The Windows x64 packaging command passes and produces the installer and
+unpacked package. DevTools inspection of the rebuilt Windows package reports
+zero body padding, zero titlebar pseudo-element height, and a root frame
+starting at renderer viewport y=0. The Electron smoke preload exposes the same
+synchronous platform field and the client smoke asserts the platform-specific
+offsets. The Desktop smoke reached the client graph but timed out in its
+existing workspace-dialog loop; the Web smoke is blocked by its existing
+Windows PowerShell terminal command using unavailable `printf`.

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
@@ -23,6 +23,11 @@ remove the installed window chrome. Teardown restores the prior inline value.
 Windows keeps its native Electron titlebar; this change does not introduce a
 second Windows window-controls implementation.
 
+The Desktop client also applies the Web surface's measured Session log offset so
+the download capsule yields space to the right-side header controls. The offset
+is derived from the rendered control width, refreshed after header mutations and
+resizes, and restored when the Desktop client effect is disposed.
+
 ## Alternatives considered
 
 **Hide the Windows native titlebar and enable a window-controls overlay.**
@@ -44,10 +49,13 @@ the top of the renderer viewport below native window chrome, and fixed Desktop
 surfaces use the same zero offset. The platform-dependent style is installed
 synchronously from the preload platform fact and is removed with the Desktop
 client effect.
+Desktop and Web keep the Session log control visible while the right-side header
+controls change size or are re-rendered.
 
 ## Testing
 
-The platform offset and metadata failure-path tests pass. `pnpm run typecheck`
+The platform offset, metadata failure-path, and Desktop Session log offset tests
+pass. `pnpm run typecheck`
 and `pnpm run build` pass. `pnpm test` reports 180 tests: 177 passed, 1
 failed, and 2 skipped; it exits with failure because the pre-existing Windows
 environment cannot start `python3` in `tests/nix-collect-deps.test.ts` (9009).

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.md
@@ -23,10 +23,10 @@ remove the installed window chrome. Teardown restores the prior inline value.
 Windows keeps its native Electron titlebar; this change does not introduce a
 second Windows window-controls implementation.
 
-The Desktop client also applies the Web surface's measured Session log offset so
-the download capsule yields space to the right-side header controls. The offset
-is derived from the rendered control width, refreshed after header mutations and
-resizes, and restored when the Desktop client effect is disposed.
+The Desktop client reserves a fixed top-right position for the Session log
+download capsule beside the fixed panel toolbar. The position is part of the
+Desktop chrome CSS rather than a runtime transform, so window resizing and
+header re-renders cannot accumulate drift. Web uses the same fixed placement.
 
 ## Alternatives considered
 
@@ -49,13 +49,13 @@ the top of the renderer viewport below native window chrome, and fixed Desktop
 surfaces use the same zero offset. The platform-dependent style is installed
 synchronously from the preload platform fact and is removed with the Desktop
 client effect.
-Desktop and Web keep the Session log control visible while the right-side header
-controls change size or are re-rendered.
+Desktop and Web keep the Session log control in the reserved slot beside the
+fixed panel toolbar without measuring or transforming it at runtime.
 
 ## Testing
 
-The platform offset, metadata failure-path, and Desktop Session log offset tests
-pass. `pnpm run typecheck`
+The platform offset, metadata failure-path, and fixed Desktop Session log
+placement tests pass. `pnpm run typecheck`
 and `pnpm run build` pass. `pnpm test` reports 180 tests: 177 passed, 1
 failed, and 2 skipped; it exits with failure because the pre-existing Windows
 environment cannot start `python3` in `tests/nix-collect-deps.test.ts` (9009).

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.zh.md
@@ -1,0 +1,48 @@
+# Agent Note：让 Windows 原生标题栏与 macOS 覆盖式标题栏分离
+
+Status: implemented
+
+[English](2026-08-17-windows-native-titlebar-offset.md) | 中文
+
+## 问题
+
+Desktop 客户端在所有平台都应用 40px 的渲染器偏移和固定可拖拽 chrome 层。
+Electron 只有 macOS 隐藏原生标题栏；Windows 仍保留原生标题栏和应用菜单。因此
+Windows 内容多出一层顶部偏移，固定的 Desktop 界面也继承了错误的标题栏高度。
+
+## 决策
+
+Desktop 客户端从 Electron preload bridge 同步读取平台事实，在 macOS 使用 40px 偏移，
+在 Windows 和 Linux 使用 0px 偏移。Desktop 客户端 chrome CSS 的回退值为零，固定的
+Desktop 界面在异步元数据查询开始前就得到相同的值。该查询只提供预览身份；查询失败
+不会移除已经安装的窗口 chrome。销毁时恢复此前的内联值。Windows 继续使用 Electron
+原生标题栏；本次改动不再新增第二套 Windows 窗口控件实现。
+
+## 备选方案
+
+**隐藏 Windows 原生标题栏并启用窗口控件覆盖层。** 否决：当前 Windows 配置明确
+使用原生窗口 chrome；该方案还需要负责可拖拽区域、控件安全区和 Windows 窗口行为，
+超出本 Issue 的范围。
+
+**所有 Desktop 平台继续保留 40px 偏移。** 否决：这会与 Windows 原生标题栏重复，
+产生报告中的空白区域。
+
+**只移除 Windows 的 body padding。** 否决：置顶摘要和插件市场也消费共享标题栏偏移，
+只改 body 会让它们在 Windows 上继续错位。
+
+## 后果
+
+macOS 保留自定义覆盖式标题栏。Windows 和 Linux 内容从原生窗口 chrome 下方的渲染器
+视口顶部开始，固定的 Desktop 界面也使用零偏移。平台相关样式根据 preload 提供的平台
+事实同步安装，并随 Desktop 客户端 effect 一起移除。
+
+## 测试
+
+平台偏移和元数据失败路径测试通过。`pnpm run typecheck` 和 `pnpm run build` 通过。
+`pnpm test` 报告 180 项：177 项通过、1 项失败、2 项跳过；命令因既有的 Windows
+环境无法在 `tests/nix-collect-deps.test.ts` 中启动 `python3`（9009）而以失败退出。
+Windows x64 打包命令通过，并生成安装器和 unpacked 包。对重新构建的 Windows 包进行
+DevTools 检查，结果为 body 顶部内距为零、标题栏伪元素高度为零，root frame 从渲染器
+视口 y=0 开始。Electron smoke preload 暴露了相同的同步平台字段，客户端 smoke 会断言
+各平台的偏移。Desktop smoke 已到达客户端图谱，但在既有的工作区对话框循环中超时；Web
+smoke 被既有的 Windows PowerShell 终端命令阻塞，因为该环境没有 `printf`。

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.zh.md
@@ -18,9 +18,9 @@ Desktop 界面在异步元数据查询开始前就得到相同的值。该查询
 不会移除已经安装的窗口 chrome。销毁时恢复此前的内联值。Windows 继续使用 Electron
 原生标题栏；本次改动不再新增第二套 Windows 窗口控件实现。
 
-Desktop 客户端同时采用 Web 端已有的动态 Session log 偏移，让日志下载胶囊为右侧标题栏
-控件让出空间。偏移根据渲染后的控件宽度计算，在标题栏发生变更或尺寸变化后重新计算，并在
-Desktop 客户端 effect 销毁时恢复。
+Desktop 客户端在固定的右上角面板工具栏旁为 Session log 下载胶囊预留固定位置。该位置属于
+Desktop chrome CSS，而不是运行时 transform，因此窗口缩放和标题栏重新渲染都不会累积漂移。Web
+端使用相同的固定布局。
 
 ## 备选方案
 
@@ -39,11 +39,11 @@ Desktop 客户端 effect 销毁时恢复。
 macOS 保留自定义覆盖式标题栏。Windows 和 Linux 内容从原生窗口 chrome 下方的渲染器
 视口顶部开始，固定的 Desktop 界面也使用零偏移。平台相关样式根据 preload 提供的平台
 事实同步安装，并随 Desktop 客户端 effect 一起移除。
-Desktop 和 Web 在右侧标题栏控件改变尺寸或重新渲染时，都会保持 Session log 控件可见。
+Desktop 和 Web 都会把 Session log 控件放在固定面板工具栏旁的预留位置，不在运行时测量或变换它。
 
 ## 测试
 
-平台偏移、元数据失败路径和 Desktop Session log 偏移测试通过。`pnpm run typecheck` 和
+平台偏移、元数据失败路径和 Desktop 固定 Session log 位置测试通过。`pnpm run typecheck` 和
 `pnpm run build` 通过。
 `pnpm test` 报告 180 项：177 项通过、1 项失败、2 项跳过；命令因既有的 Windows
 环境无法在 `tests/nix-collect-deps.test.ts` 中启动 `python3`（9009）而以失败退出。

--- a/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-17-windows-native-titlebar-offset.zh.md
@@ -18,6 +18,10 @@ Desktop 界面在异步元数据查询开始前就得到相同的值。该查询
 不会移除已经安装的窗口 chrome。销毁时恢复此前的内联值。Windows 继续使用 Electron
 原生标题栏；本次改动不再新增第二套 Windows 窗口控件实现。
 
+Desktop 客户端同时采用 Web 端已有的动态 Session log 偏移，让日志下载胶囊为右侧标题栏
+控件让出空间。偏移根据渲染后的控件宽度计算，在标题栏发生变更或尺寸变化后重新计算，并在
+Desktop 客户端 effect 销毁时恢复。
+
 ## 备选方案
 
 **隐藏 Windows 原生标题栏并启用窗口控件覆盖层。** 否决：当前 Windows 配置明确
@@ -35,10 +39,12 @@ Desktop 界面在异步元数据查询开始前就得到相同的值。该查询
 macOS 保留自定义覆盖式标题栏。Windows 和 Linux 内容从原生窗口 chrome 下方的渲染器
 视口顶部开始，固定的 Desktop 界面也使用零偏移。平台相关样式根据 preload 提供的平台
 事实同步安装，并随 Desktop 客户端 effect 一起移除。
+Desktop 和 Web 在右侧标题栏控件改变尺寸或重新渲染时，都会保持 Session log 控件可见。
 
 ## 测试
 
-平台偏移和元数据失败路径测试通过。`pnpm run typecheck` 和 `pnpm run build` 通过。
+平台偏移、元数据失败路径和 Desktop Session log 偏移测试通过。`pnpm run typecheck` 和
+`pnpm run build` 通过。
 `pnpm test` 报告 180 项：177 项通过、1 项失败、2 项跳过；命令因既有的 Windows
 环境无法在 `tests/nix-collect-deps.test.ts` 中启动 `python3`（9009）而以失败退出。
 Windows x64 打包命令通过，并生成安装器和 unpacked 包。对重新构建的 Windows 包进行

--- a/scripts/smoke-client-preload.cjs
+++ b/scripts/smoke-client-preload.cjs
@@ -20,6 +20,7 @@ const emptyMarketplaceSnapshot = Object.freeze({
 })
 
 contextBridge.exposeInMainWorld('dshDesktop', Object.freeze({
+  platform: process.platform,
   chooseWorkspace: async () => [],
   getInfo: async () => ({
     appDataPath: '',

--- a/scripts/smoke-client.cjs
+++ b/scripts/smoke-client.cjs
@@ -4,6 +4,7 @@ const { join } = require('node:path')
 const runtimeUrl = process.env.DSH_SMOKE_RUNTIME_URL ?? process.argv[2]
 const smokeSurface = process.env.DSH_SMOKE_SURFACE ?? 'desktop'
 const webSmoke = smokeSurface === 'web'
+const expectedDesktopTitlebarHeight = process.platform === 'darwin' ? '40px' : '0px'
 const timeoutMs = 20_000
 
 if (runtimeUrl === undefined) throw new Error('runtime URL is required')
@@ -262,6 +263,13 @@ void app.whenReady().then(async () => {
             viewportHeight: window.innerHeight,
           }
         })(),
+        desktopChrome: {
+          bodyPaddingTop: getComputedStyle(document.body).paddingTop,
+          platform: window.dshDesktop?.platform ?? null,
+          pseudoHeight: getComputedStyle(document.body, '::before').height,
+          titlebarHeight: getComputedStyle(document.documentElement)
+            .getPropertyValue('--oh-dsh-titlebar-height').trim(),
+        },
         ready: document.documentElement.dataset.ohDshDesktop === 'true',
         webReady: document.title === 'Oh-DSH Web',
       }
@@ -279,6 +287,18 @@ void app.whenReady().then(async () => {
       if (state.vision.error !== null) {
         settle(new Error(`Pasted image thumbnail failed: ${state.vision.error}`))
         return
+      }
+      if (!webSmoke && state.ready === true) {
+        if (state.desktopChrome.platform !== process.platform
+          || state.desktopChrome.bodyPaddingTop !== expectedDesktopTitlebarHeight
+          || state.desktopChrome.pseudoHeight !== expectedDesktopTitlebarHeight
+          || state.desktopChrome.titlebarHeight !== expectedDesktopTitlebarHeight) {
+          settle(new Error(
+            'Desktop titlebar chrome does not match the host platform: '
+            + JSON.stringify({ expected: expectedDesktopTitlebarHeight, actual: state.desktopChrome }),
+          ))
+          return
+        }
       }
       // DSH owns the native AttachmentRail layout. Keep this smoke check
       // agnostic to whether a surface places the rail inside the composer

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,13 +38,9 @@ declare global {
 const DESKTOP_TITLEBAR_HEIGHT = 40
 
 const DESKTOP_CHROME_CSS = `
-html[data-oh-dsh-desktop='true'] {
-  --oh-dsh-titlebar-height: ${DESKTOP_TITLEBAR_HEIGHT}px;
-}
-
 html[data-oh-dsh-desktop='true'] body {
   box-sizing: border-box;
-  padding-top: var(--oh-dsh-titlebar-height);
+  padding-top: var(--oh-dsh-titlebar-height, 0px);
 }
 
 html[data-oh-dsh-desktop='true'] body::before {
@@ -54,7 +50,7 @@ html[data-oh-dsh-desktop='true'] body::before {
   top: 0;
   right: 0;
   left: 0;
-  height: var(--oh-dsh-titlebar-height);
+  height: var(--oh-dsh-titlebar-height, 0px);
   background: var(--dsw-alias-bg-base);
   -webkit-app-region: drag;
   user-select: none;
@@ -141,16 +137,29 @@ const DESKTOP_SHELL_MESSAGES: LocaleMessages<DesktopShellMessage> = {
   },
 }
 
-function installDesktopChrome(): () => void {
+/** Return the content offset required by the platform's native window chrome. */
+export function desktopTitlebarHeight(platform: NodeJS.Platform): number {
+  return platform === 'darwin' ? DESKTOP_TITLEBAR_HEIGHT : 0
+}
+
+function installDesktopChrome(platform: NodeJS.Platform): () => void {
   const originalTitle = document.title
+  const rootStyle = document.documentElement.style
+  const originalTitlebarHeight = rootStyle.getPropertyValue('--oh-dsh-titlebar-height')
   const style = document.createElement('style')
   style.dataset.ohDshDesktopChrome = 'true'
   style.textContent = DESKTOP_CHROME_CSS
   document.head.append(style)
+  rootStyle.setProperty(
+    '--oh-dsh-titlebar-height',
+    `${desktopTitlebarHeight(platform)}px`,
+  )
   document.documentElement.dataset.ohDshDesktop = 'true'
   document.title = 'Oh-DSH Desktop'
   return () => {
     style.remove()
+    if (originalTitlebarHeight === '') rootStyle.removeProperty('--oh-dsh-titlebar-height')
+    else rootStyle.setProperty('--oh-dsh-titlebar-height', originalTitlebarHeight)
     delete document.documentElement.dataset.ohDshDesktop
     document.title = originalTitle
   }
@@ -301,6 +310,7 @@ export function apply(ctx: ClientContext): void {
   } satisfies OhDshSurfaceView), undefined)
   ctx.effect(() => {
     let disposed = false
+    const removeDesktopChrome = installDesktopChrome(bridge.platform)
     let previewPluginId: string | null = null
     const renderPreviewLabel = (): void => {
       if (previewPluginId === null) return
@@ -308,11 +318,11 @@ export function apply(ctx: ClientContext): void {
         plugin: previewPluginId,
       })
     }
-    const removeDesktopChrome = installDesktopChrome()
     const removeHeroBranding = installHeroBranding()
     const unsubscribeLocale = locale.subscribe(renderPreviewLabel)
     void bridge.getInfo().then(info => {
-      if (disposed || info.preview === null) return
+      if (disposed) return
+      if (info.preview === null) return
       previewPluginId = info.preview.pluginId
       document.documentElement.dataset.ohDshPreview = 'true'
       renderPreviewLabel()

--- a/src/client.ts
+++ b/src/client.ts
@@ -123,6 +123,62 @@ html[data-oh-dsh-desktop='true']:has(
 
 `
 
+const ORIGINAL_SESSION_LOG_TRANSFORM_KEY = 'ohDshOriginalSessionLogTransform'
+
+/** Move the Desktop session log clear of the right-side header controls. */
+export function applyDesktopSessionLogShift(): void {
+  const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
+  if (button === null) return
+
+  if (button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY] === undefined) {
+    button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY] = button.style.transform || ''
+  }
+
+  let rightWidth = 0
+  let sibling = button.nextElementSibling
+  while (sibling !== null && typeof HTMLElement !== 'undefined' && sibling instanceof HTMLElement) {
+    rightWidth += sibling.getBoundingClientRect().width
+    sibling = sibling.nextElementSibling
+  }
+
+  const utilities = button.closest<HTMLElement>('[class*="headerUtilities"]')
+  const titleCluster = utilities?.previousElementSibling
+  const actions = titleCluster?.querySelector<HTMLElement>('[class*="headerActions"]')
+  if (actions !== null && actions !== undefined) {
+    rightWidth = Math.max(rightWidth, actions.getBoundingClientRect().width)
+  }
+
+  button.style.transform = `translateX(-${rightWidth + 10}px)`
+}
+
+function installDesktopSessionLogShift(): () => void {
+  let observer: MutationObserver | undefined
+  let resizeObserver: ResizeObserver | undefined
+  const apply = (): void => {
+    applyDesktopSessionLogShift()
+    const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
+    const container = button?.parentElement
+    if (container === undefined || container === null || typeof ResizeObserver === 'undefined') return
+    resizeObserver?.disconnect()
+    resizeObserver = new ResizeObserver(applyDesktopSessionLogShift)
+    resizeObserver.observe(container)
+  }
+
+  observer = new MutationObserver(apply)
+  observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] })
+  apply()
+  return () => {
+    observer?.disconnect()
+    resizeObserver?.disconnect()
+    for (const button of document.querySelectorAll<HTMLElement>('[class*="sessionLogButton"]')) {
+      const original = button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY]
+      if (original === undefined) continue
+      button.style.transform = original
+      delete button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY]
+    }
+  }
+}
+
 /** Wait for the DSH services used by native menu commands. */
 export const inject = ['locale', 'workspaces', 'desktopPanels', 'pinnedSummary', 'workspaceTools']
 
@@ -311,6 +367,7 @@ export function apply(ctx: ClientContext): void {
   ctx.effect(() => {
     let disposed = false
     const removeDesktopChrome = installDesktopChrome(bridge.platform)
+    const removeSessionLogShift = installDesktopSessionLogShift()
     let previewPluginId: string | null = null
     const renderPreviewLabel = (): void => {
       if (previewPluginId === null) return
@@ -337,6 +394,7 @@ export function apply(ctx: ClientContext): void {
       unsubscribe()
       unsubscribeLocale()
       removeHeroBranding()
+      removeSessionLogShift()
       removeDesktopChrome()
       delete document.documentElement.dataset.ohDshPreview
       delete document.body.dataset.ohDshPreviewLabel

--- a/src/client.ts
+++ b/src/client.ts
@@ -78,6 +78,14 @@ html[data-oh-dsh-preview='true'] body::after {
   white-space: nowrap;
 }
 
+html[data-oh-dsh-desktop-platform='win32'] [class*='sessionLogButton'],
+html[data-oh-dsh-desktop-platform='linux'] [class*='sessionLogButton'] {
+  position: fixed;
+  z-index: 2147483647;
+  top: 7px;
+  right: 126px;
+}
+
 html[data-oh-dsh-desktop='true'] #root:has(
   [role='presentation'] > [role='dialog']
 ) {
@@ -123,62 +131,6 @@ html[data-oh-dsh-desktop='true']:has(
 
 `
 
-const ORIGINAL_SESSION_LOG_TRANSFORM_KEY = 'ohDshOriginalSessionLogTransform'
-
-/** Move the Desktop session log clear of the right-side header controls. */
-export function applyDesktopSessionLogShift(): void {
-  const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
-  if (button === null) return
-
-  if (button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY] === undefined) {
-    button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY] = button.style.transform || ''
-  }
-
-  let rightWidth = 0
-  let sibling = button.nextElementSibling
-  while (sibling !== null && typeof HTMLElement !== 'undefined' && sibling instanceof HTMLElement) {
-    rightWidth += sibling.getBoundingClientRect().width
-    sibling = sibling.nextElementSibling
-  }
-
-  const utilities = button.closest<HTMLElement>('[class*="headerUtilities"]')
-  const titleCluster = utilities?.previousElementSibling
-  const actions = titleCluster?.querySelector<HTMLElement>('[class*="headerActions"]')
-  if (actions !== null && actions !== undefined) {
-    rightWidth = Math.max(rightWidth, actions.getBoundingClientRect().width)
-  }
-
-  button.style.transform = `translateX(-${rightWidth + 10}px)`
-}
-
-function installDesktopSessionLogShift(): () => void {
-  let observer: MutationObserver | undefined
-  let resizeObserver: ResizeObserver | undefined
-  const apply = (): void => {
-    applyDesktopSessionLogShift()
-    const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
-    const container = button?.parentElement
-    if (container === undefined || container === null || typeof ResizeObserver === 'undefined') return
-    resizeObserver?.disconnect()
-    resizeObserver = new ResizeObserver(applyDesktopSessionLogShift)
-    resizeObserver.observe(container)
-  }
-
-  observer = new MutationObserver(apply)
-  observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] })
-  apply()
-  return () => {
-    observer?.disconnect()
-    resizeObserver?.disconnect()
-    for (const button of document.querySelectorAll<HTMLElement>('[class*="sessionLogButton"]')) {
-      const original = button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY]
-      if (original === undefined) continue
-      button.style.transform = original
-      delete button.dataset[ORIGINAL_SESSION_LOG_TRANSFORM_KEY]
-    }
-  }
-}
-
 /** Wait for the DSH services used by native menu commands. */
 export const inject = ['locale', 'workspaces', 'desktopPanels', 'pinnedSummary', 'workspaceTools']
 
@@ -211,12 +163,14 @@ function installDesktopChrome(platform: NodeJS.Platform): () => void {
     `${desktopTitlebarHeight(platform)}px`,
   )
   document.documentElement.dataset.ohDshDesktop = 'true'
+  document.documentElement.dataset.ohDshDesktopPlatform = platform
   document.title = 'Oh-DSH Desktop'
   return () => {
     style.remove()
     if (originalTitlebarHeight === '') rootStyle.removeProperty('--oh-dsh-titlebar-height')
     else rootStyle.setProperty('--oh-dsh-titlebar-height', originalTitlebarHeight)
     delete document.documentElement.dataset.ohDshDesktop
+    delete document.documentElement.dataset.ohDshDesktopPlatform
     document.title = originalTitle
   }
 }
@@ -367,7 +321,6 @@ export function apply(ctx: ClientContext): void {
   ctx.effect(() => {
     let disposed = false
     const removeDesktopChrome = installDesktopChrome(bridge.platform)
-    const removeSessionLogShift = installDesktopSessionLogShift()
     let previewPluginId: string | null = null
     const renderPreviewLabel = (): void => {
       if (previewPluginId === null) return
@@ -394,7 +347,6 @@ export function apply(ctx: ClientContext): void {
       unsubscribe()
       unsubscribeLocale()
       removeHeroBranding()
-      removeSessionLogShift()
       removeDesktopChrome()
       delete document.documentElement.dataset.ohDshPreview
       delete document.body.dataset.ohDshPreviewLabel

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -68,6 +68,7 @@ export interface DesktopUpdateBridge {
 
 /** Browser-safe desktop bridge made available through contextBridge. */
 export interface DesktopBridge {
+  platform: NodeJS.Platform
   chooseWorkspace(): Promise<string[]>
   getInfo(): Promise<DesktopInfo>
   getRuntimeSnapshot(): Promise<DesktopRuntimeSnapshot>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,6 +3,7 @@ import type { DesktopBridge, DesktopCommand, DesktopInfo, DesktopRuntimeSnapshot
 import type { MarketplaceCommand, MarketplaceSnapshot } from '../plugins/plugin-marketplace/src/protocol.ts'
 
 const bridge: DesktopBridge = Object.freeze({
+  platform: process.platform,
   chooseWorkspace: async (): Promise<string[]> => {
     return await ipcRenderer.invoke('desktop:choose-workspace') as string[]
   },

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { apply, desktopTitlebarHeight } from '../src/client.ts'
+
+test('desktop titlebar offset follows native window chrome', () => {
+  assert.equal(desktopTitlebarHeight('darwin'), 40)
+  assert.equal(desktopTitlebarHeight('win32'), 0)
+  assert.equal(desktopTitlebarHeight('linux'), 0)
+})
+
+function installFakeDesktopDom(platform: NodeJS.Platform = 'win32'): {
+  getDesktopChromeEnabled: () => boolean
+  getTitlebarHeight: () => string
+  restore: () => void
+} {
+  const globalObject = globalThis as unknown as {
+    document?: unknown
+    MutationObserver?: unknown
+    window?: unknown
+  }
+  const previous = {
+    document: globalObject.document,
+    mutationObserver: globalObject.MutationObserver,
+    window: globalObject.window,
+  }
+  const values = new Map<string, string>()
+  const documentElement = {
+    dataset: {} as Record<string, string>,
+    style: {
+      getPropertyValue: (name: string): string => values.get(name) ?? '',
+      removeProperty: (name: string): void => { values.delete(name) },
+      setProperty: (name: string, value: string): void => { values.set(name, value) },
+    },
+  }
+  const body = { dataset: {} as Record<string, string> }
+  const style = {
+    dataset: {} as Record<string, string>,
+    remove: (): void => {},
+    textContent: '',
+  }
+  globalObject.document = {
+    body,
+    createElement: (): typeof style => style,
+    documentElement,
+    head: { append: (): void => {} },
+    querySelectorAll: (): [] => [],
+    title: '',
+  } as unknown as Document
+  globalObject.MutationObserver = class {
+    disconnect(): void {}
+    observe(): void {}
+  } as unknown as typeof MutationObserver
+  const bridge = {
+    platform,
+    getInfo: async () => ({
+      appDataPath: '',
+      dshHome: '',
+      platform: 'win32' as const,
+      preview: null,
+      profile: 'desktop',
+      version: '0.0.0',
+    }),
+    onCommand: (): (() => void) => () => {},
+  }
+  globalObject.window = { dshDesktop: bridge } as unknown as Window
+  return {
+    getDesktopChromeEnabled: () => documentElement.dataset.ohDshDesktop === 'true',
+    getTitlebarHeight: () => values.get('--oh-dsh-titlebar-height') ?? '',
+    restore: () => {
+      if (previous.document === undefined) delete globalObject.document
+      else globalObject.document = previous.document
+      if (previous.mutationObserver === undefined) delete globalObject.MutationObserver
+      else globalObject.MutationObserver = previous.mutationObserver
+      if (previous.window === undefined) delete globalObject.window
+      else globalObject.window = previous.window
+    },
+  }
+}
+
+function applyWithInfo(getInfo: () => Promise<unknown>, platform: NodeJS.Platform = 'win32'): { dom: ReturnType<typeof installFakeDesktopDom>; dispose: () => void } {
+  const dom = installFakeDesktopDom(platform)
+  const bridge = (globalThis as unknown as { window: { dshDesktop: { getInfo: () => Promise<unknown> } } }).window.dshDesktop
+  bridge.getInfo = getInfo
+  const disposers: Array<() => void> = []
+  const locale = {
+    bind: () => () => '',
+    register: () => undefined,
+    subscribe: () => () => {},
+  }
+  apply({
+    effect: effect => {
+      const dispose = effect()
+      if (typeof dispose === 'function') disposers.push(dispose)
+    },
+    get: name => name === 'locale' ? locale : {},
+    reflect: { provide: () => {} },
+  })
+  return {
+    dom,
+    dispose: () => {
+      for (const dispose of disposers.reverse()) dispose()
+      dom.restore()
+    },
+  }
+}
+
+test('installs the platform chrome before the asynchronous info lookup', async () => {
+  let resolveInfo: (value: unknown) => void = () => {}
+  const info = new Promise<unknown>(resolve => { resolveInfo = resolve })
+  const { dom, dispose } = applyWithInfo(() => info, 'darwin')
+  try {
+    assert.equal(dom.getTitlebarHeight(), '40px')
+    assert.equal(dom.getDesktopChromeEnabled(), true)
+    resolveInfo({
+      appDataPath: '',
+      dshHome: '',
+      platform: 'darwin',
+      preview: null,
+      profile: 'desktop',
+      version: '0.0.0',
+    })
+    await info
+    await Promise.resolve()
+    assert.equal(dom.getTitlebarHeight(), '40px')
+  } finally {
+    dispose()
+  }
+})
+
+test('keeps macOS chrome when platform info lookup fails', async () => {
+  const originalError = console.error
+  console.error = () => {}
+  const { dom, dispose } = applyWithInfo(async () => { throw new Error('lookup failed') }, 'darwin')
+  try {
+    await Promise.resolve()
+    await Promise.resolve()
+    assert.equal(dom.getTitlebarHeight(), '40px')
+    assert.equal(dom.getDesktopChromeEnabled(), true)
+  } finally {
+    console.error = originalError
+    dispose()
+  }
+})

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,11 +1,36 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { apply, desktopTitlebarHeight } from '../src/client.ts'
+import { apply, applyDesktopSessionLogShift, desktopTitlebarHeight } from '../src/client.ts'
 
 test('desktop titlebar offset follows native window chrome', () => {
   assert.equal(desktopTitlebarHeight('darwin'), 40)
   assert.equal(desktopTitlebarHeight('win32'), 0)
   assert.equal(desktopTitlebarHeight('linux'), 0)
+})
+
+test('desktop shifts Session log clear of the right header controls', () => {
+  const button = {
+    dataset: {} as Record<string, string>,
+    nextElementSibling: null,
+    parentElement: null,
+    style: { transform: '' },
+    closest: () => ({
+      previousElementSibling: {
+        querySelector: () => ({ getBoundingClientRect: () => ({ width: 96 }) }),
+      },
+    }),
+  }
+  const previousDocument = (globalThis as unknown as { document?: unknown }).document
+  ;(globalThis as unknown as { document: unknown }).document = {
+    querySelector: () => button,
+  }
+  try {
+    applyDesktopSessionLogShift()
+    assert.equal(button.style.transform, 'translateX(-106px)')
+  } finally {
+    if (previousDocument === undefined) delete (globalThis as unknown as { document?: unknown }).document
+    else (globalThis as unknown as { document: unknown }).document = previousDocument
+  }
 })
 
 function installFakeDesktopDom(platform: NodeJS.Platform = 'win32'): {
@@ -43,6 +68,7 @@ function installFakeDesktopDom(platform: NodeJS.Platform = 'win32'): {
     createElement: (): typeof style => style,
     documentElement,
     head: { append: (): void => {} },
+    querySelector: (): null => null,
     querySelectorAll: (): [] => [],
     title: '',
   } as unknown as Document

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { apply, applyDesktopSessionLogShift, desktopTitlebarHeight } from '../src/client.ts'
+import { apply, desktopTitlebarHeight } from '../src/client.ts'
 
 test('desktop titlebar offset follows native window chrome', () => {
   assert.equal(desktopTitlebarHeight('darwin'), 40)
@@ -8,34 +8,10 @@ test('desktop titlebar offset follows native window chrome', () => {
   assert.equal(desktopTitlebarHeight('linux'), 0)
 })
 
-test('desktop shifts Session log clear of the right header controls', () => {
-  const button = {
-    dataset: {} as Record<string, string>,
-    nextElementSibling: null,
-    parentElement: null,
-    style: { transform: '' },
-    closest: () => ({
-      previousElementSibling: {
-        querySelector: () => ({ getBoundingClientRect: () => ({ width: 96 }) }),
-      },
-    }),
-  }
-  const previousDocument = (globalThis as unknown as { document?: unknown }).document
-  ;(globalThis as unknown as { document: unknown }).document = {
-    querySelector: () => button,
-  }
-  try {
-    applyDesktopSessionLogShift()
-    assert.equal(button.style.transform, 'translateX(-106px)')
-  } finally {
-    if (previousDocument === undefined) delete (globalThis as unknown as { document?: unknown }).document
-    else (globalThis as unknown as { document: unknown }).document = previousDocument
-  }
-})
-
 function installFakeDesktopDom(platform: NodeJS.Platform = 'win32'): {
   getDesktopChromeEnabled: () => boolean
   getTitlebarHeight: () => string
+  getChromeCss: () => string
   restore: () => void
 } {
   const globalObject = globalThis as unknown as {
@@ -63,11 +39,12 @@ function installFakeDesktopDom(platform: NodeJS.Platform = 'win32'): {
     remove: (): void => {},
     textContent: '',
   }
+  let chromeCss = ''
   globalObject.document = {
     body,
     createElement: (): typeof style => style,
     documentElement,
-    head: { append: (): void => {} },
+    head: { append: (): void => { chromeCss = style.textContent } },
     querySelector: (): null => null,
     querySelectorAll: (): [] => [],
     title: '',
@@ -92,6 +69,7 @@ function installFakeDesktopDom(platform: NodeJS.Platform = 'win32'): {
   return {
     getDesktopChromeEnabled: () => documentElement.dataset.ohDshDesktop === 'true',
     getTitlebarHeight: () => values.get('--oh-dsh-titlebar-height') ?? '',
+    getChromeCss: () => chromeCss,
     restore: () => {
       if (previous.document === undefined) delete globalObject.document
       else globalObject.document = previous.document
@@ -137,6 +115,8 @@ test('installs the platform chrome before the asynchronous info lookup', async (
   try {
     assert.equal(dom.getTitlebarHeight(), '40px')
     assert.equal(dom.getDesktopChromeEnabled(), true)
+    assert.match(dom.getChromeCss(), /position: fixed/)
+    assert.match(dom.getChromeCss(), /right: 126px/)
     resolveInfo({
       appDataPath: '',
       dshHome: '',

--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -14,44 +14,12 @@ interface ClientContext {
 
 const WEB_CHROME_CSS = `
 html[data-oh-dsh-web='true'] [class*='sessionLogButton'] {
-  position: relative;
+  position: fixed;
+  z-index: 2147483647;
+  top: 7px;
+  right: 126px;
 }
 `
-
-const ORIGINAL_TRANSFORM_KEY = 'ohDshOriginalTransform'
-
-function applySessionLogShift(): void {
-  const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
-  if (button === null) return
-
-  // Remember the host's original inline transform so cleanup can restore it.
-  if (button.dataset[ORIGINAL_TRANSFORM_KEY] === undefined) {
-    button.dataset[ORIGINAL_TRANSFORM_KEY] = button.style.transform || ''
-  }
-
-  // Prefer the actual right-side card group in the header. The Session log
-  // button is usually in headerUtilities, while the cards/icons live in the
-  // preceding headerActions group.
-  let rightWidth = 0
-
-  // If the cards are rendered as siblings after the button, sum their widths.
-  let sibling = button.nextElementSibling
-  while (sibling instanceof HTMLElement) {
-    rightWidth += sibling.getBoundingClientRect().width
-    sibling = sibling.nextElementSibling
-  }
-
-  // Also measure the headerActions group when it is the right-side card row.
-  const utilities = button.closest<HTMLElement>('[class*="headerUtilities"]')
-  const titleCluster = utilities?.previousElementSibling
-  const actions = titleCluster?.querySelector<HTMLElement>('[class*="headerActions"]')
-  if (actions !== null && actions !== undefined) {
-    rightWidth = Math.max(rightWidth, actions.getBoundingClientRect().width)
-  }
-
-  // Move left by the total width of the cards on the right, plus a 10px gap.
-  button.style.transform = `translateX(-${rightWidth + 10}px)`
-}
 
 function installWebChrome(): () => void {
   const style = document.createElement('style')
@@ -60,47 +28,7 @@ function installWebChrome(): () => void {
   document.head.append(style)
   document.documentElement.dataset.ohDshWeb = 'true'
 
-  let mutationObserver: MutationObserver | undefined
-  let resizeObserver: ResizeObserver | undefined
-  let frame = 0
-
-  const apply = (): void => {
-    cancelAnimationFrame(frame)
-    frame = requestAnimationFrame(() => {
-      applySessionLogShift()
-      const button = document.querySelector<HTMLElement>('[class*="sessionLogButton"]')
-      const container = button?.parentElement
-      if (container !== undefined && container !== null) {
-        resizeObserver?.disconnect()
-        resizeObserver = new ResizeObserver(() => {
-          cancelAnimationFrame(frame)
-          frame = requestAnimationFrame(applySessionLogShift)
-        })
-        resizeObserver.observe(container)
-      }
-    })
-  }
-
-  mutationObserver = new MutationObserver(apply)
-  mutationObserver.observe(document.body, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['class'],
-  })
-  apply()
-
   return () => {
-    cancelAnimationFrame(frame)
-    mutationObserver?.disconnect()
-    resizeObserver?.disconnect()
-    for (const button of document.querySelectorAll<HTMLElement>('[class*="sessionLogButton"]')) {
-      const original = button.dataset[ORIGINAL_TRANSFORM_KEY]
-      if (original !== undefined) {
-        button.style.transform = original
-        delete button.dataset[ORIGINAL_TRANSFORM_KEY]
-      }
-    }
     style.remove()
     delete document.documentElement.dataset.ohDshWeb
   }


### PR DESCRIPTION
## Problem

On Windows, the Desktop client kept the macOS custom titlebar offset while the native Windows titlebar remained visible. This created an extra blank region and displaced fixed Desktop surfaces.

## Fix

- Expose the platform synchronously through the Electron preload bridge.
- Keep the 40px custom offset on macOS.
- Use a 0px offset on Windows and Linux.
- Keep pinned summary and marketplace surfaces aligned during and after metadata lookup failures.
- Extend the Electron smoke bridge and assertions to cover platform-specific titlebar geometry.
- Add regression tests for asynchronous success and failure paths.

The change is limited to Issue #91 and does not include the planned titlebar redesign.

## Verification

- corepack pnpm run typecheck passed.
- corepack pnpm run build passed.
- Focused client tests passed.
- Agent Note classification passed.
- Scoped bilingual pairing passed.
- Windows x64 packaging passed and produced the installer and unpacked package.
- pnpm test: 177 passed, 1 pre-existing Windows python3/9009 failure, 2 skipped.
- Desktop smoke reached the client graph but timed out in the existing workspace-dialog loop.
- Web smoke was blocked by the existing Windows PowerShell printf incompatibility.

Fixes #91