### PR TITLE
desktop: merge Windows title bar, menu bar, and strip into one row

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-17-desktop-single-row-titlebar.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-17-desktop-single-row-titlebar.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-17-desktop-single-row-titlebar.md
+2026-08-17-desktop-single-row-titlebar.md: fd9700e5590165dcf085f37b58dba7c9eebeaaac
+2026-08-17-desktop-single-row-titlebar.zh.md: bc1062bac0320c33f31ba5ae01346d8a78e69b50

--- a/.agents/notes/implemented/feature/2026-08-17-desktop-single-row-titlebar.md
+++ b/.agents/notes/implemented/feature/2026-08-17-desktop-single-row-titlebar.md
@@ -1,0 +1,47 @@
+# Agent Note: One-row desktop chrome via the Windows Window Controls Overlay
+
+Status: implemented
+
+English | [中文](2026-08-17-desktop-single-row-titlebar.zh.md)
+
+## Problem
+
+On Windows, the Desktop window stacked three horizontal chrome bands above the conversation: the native menu bar row, the native title-bar row, and the in-page 40px titlebar strip that `src/client.ts` paints for dragging (macOS already collapsed to one row with `titleBarStyle: 'hiddenInset'`). Users read the stack as three competing headers. Any fix had to keep the native caption buttons (minimize/maximize/close carry Windows snap layouts), keep the full application menu reachable, and keep the drag strip — without adding a second title-bar implementation or weakening the pinned-Upstream boundary that keeps `upstream/` untouched.
+
+## Decision
+
+Windows windows are created with `titleBarStyle: 'hidden'` plus `titleBarOverlay`, and `autoHideMenuBar: true` so the menu row no longer reserves a band (Alt still reveals the native menu bar; accelerators work because `Menu.setApplicationMenu` stays installed). The overlay's `height` is `Math.ceil(DESKTOP_TITLEBAR_HEIGHT * DEFAULT_UI_ZOOM_FACTOR)`: the overlay is declared in device-independent pixels while the strip measures CSS pixels under the 1.12 zoom factor, so rounding up keeps the caption buttons inside the strip at any zoom. `DESKTOP_TITLEBAR_HEIGHT` lives in `src/contracts.ts` so the main process and the client share one number instead of two constants that can drift.
+
+The application menu is reachable without Alt: the client renders the menu's top-level labels (served over the bridge from the built `Menu`) as buttons inside the strip's left corner, and a click pops the corresponding native submenu anchored at the button. Only the labels cross the process boundary — `buildMenu()` remains the single owner of items, roles, and accelerators. The popup handler converts the button's CSS-pixel position to client-relative DIPs via the webContents zoom factor; on Windows `popup({x, y})` positions are client-relative, so adding window-origin offsets lands the menu mid-window (the bug the first cut shipped with and the live check caught).
+
+The client strip now sizes itself from the overlay geometry instead of assuming its own height: `body` padding and the `::before` drag strip use `env(titlebar-area-height, var(--oh-dsh-titlebar-height))`, and `.oh-dsh-panel-toolbar` — the sidebar plugin's fixed panel buttons, which previously anchored 14px from the window edge and would sit under the caption buttons — shifts with `env(titlebar-area-x)`/`env(titlebar-area-width)` so it keeps its 14px clearance from the overlay's left edge. The menu bar itself is a drag-region sibling of the strip with `no-drag` button islands, filling the corner Windows leaves blank (macOS has traffic lights there). The `nativeTheme` `updated` handler re-calls `setTitleBarOverlay` so the overlay recolors with the window background on theme switches; non-overlay windows (splash/update) are skipped via the existing catch. macOS keeps `hiddenInset`; Linux keeps the plain frame — the merge…
+
+## Alternatives considered
+
+### Why not `frame: false` with fully custom caption buttons?
+
+Drawing our own min/max/close in the strip would remove the Windows snap-layout flyout that hangs off the native maximize button and put OS button behavior (double-click maximize, aero snap, touch targets) in our hands forever. The Window Controls Overlay keeps all of that native; we only reserve the space.
+
+### Why not keep the menu bar and hide only the title bar?
+
+`titleBarStyle: 'hidden'` without `autoHideMenuBar` still leaves the menu bar row occupying its own band on Windows; the three-band stack survives with a hole where the title bar was. The user-visible ask was one row, so the menu must live inside it.
+
+### Why not a full in-page menu (items rendered in the web layer)?
+
+Rendering menu *items* in the web layer would fork the menu into a second UI the main process must drive over the command bridge, duplicating roles (`about`, `services`, `quit`) that `Menu.setApplicationMenu` already owns across surfaces, and it would re-style native menu behavior (checkboxes, accelerators, submenu nesting) forever. Rendering only the top-level *labels* and popping the native submenu keeps one owner; the web layer owns pixels, the main process owns the menu.
+
+### Why not read the overlay height in the client instead of sharing the constant?
+
+The env() variables only exist once the overlay is active; deriving the fallback from a second, client-side height constant is exactly the drift the shared `DESKTOP_TITLEBAR_HEIGHT` exists to prevent. The client still prefers `env()` when present, so the strip follows the real overlay even if Windows reports a different height.
+
+## Consequences
+
+Bought: one chrome row on Windows matching the macOS shape, native caption buttons and snap layouts intact, the menu visible in that row with native submenus, and a single height constant shared across the process boundary. Cost: the strip height now follows the overlay (45px at default zoom rather than a flat 40 CSS px — 5px more content offset), the toolbar sits 137px-plus-clearance from the right edge on default-width windows, and the menu bar's labels are plain text in the web layer — role-provided mnemonics and the native menubar's hover-to-open traversal do not carry over (click-to-open only; Alt reveals the full native bar when needed). The `nativeTheme` listener is win32-guarded and ignores non-overlay windows.
+
+## Testing
+
+`tests/desktop-titlebar.test.ts` pins the win32 window-shape branch, the macOS `hiddenInset` retention, the shared constant, the zoom-aware overlay height derivation, the strip/toolbar `env()` geometry, and the menu-bar contract: labels and popup on the bridge, `buildMenu()` as the single menu owner, zoom-factor coordinate conversion, and the win32-main-window-only mount with drag/no-drag regions. Live verification on Windows (CDP against a staged runtime under an isolated `OH_DSH_HOME`): `outerHeight - innerHeight = 8` (resize border only; the menu+title rows are gone), `titlebar-area-height = 45` equals the strip's 45px `padding-top`, the panel toolbar's right edge keeps 14px clearance from the overlay's left edge, and the menu bar renders all six top-level labels inside the strip (y 0–45, buttons no-drag) with the File submenu popping at the button after the client-relative coordinate fix (user-confirmed on the live window). The full `pnpm test`/`typecheck`/`build` chain passes on this machine except `tests/nix-collect-deps.test.ts`, which needs `python3` (absent here; fails identically on unmodified HEAD), and `scripts/smoke-runtime.mjs`, whose client…
+
+## Related
+
+The drag strip and dialog z-index layering this change builds on are owned by the desktop client chrome in `src/client.ts`; the panel toolbar belongs to the [workspace sidebar tool registry](2026-08-11-workspace-sidebar-order-and-folding.md).

--- a/.agents/notes/implemented/feature/2026-08-17-desktop-single-row-titlebar.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-17-desktop-single-row-titlebar.zh.md
@@ -1,0 +1,47 @@
+# Agent Note: 通过 Windows Window Controls Overlay 实现单行桌面 chrome
+
+Status: implemented
+
+[English](2026-08-17-desktop-single-row-titlebar.md) | 中文
+
+## Problem
+
+在 Windows 上，Desktop 窗口在会话区上方堆了三段横向 chrome：原生菜单栏一行、原生标题栏一行、以及 `src/client.ts` 为拖拽绘制的页内 40px 标题条（macOS 早已用 `titleBarStyle: 'hiddenInset'` 折叠成一行）。用户把这三段读成三个互相竞争的头部。任何修法都必须保留原生最小化/最大化/关闭按钮（Windows 的 snap 布局挂在它们身上）、保留完整可用的应用菜单、保留拖拽条——同时不引入第二套标题栏实现，也不削弱 `upstream/` 不动的固定上游边界。
+
+## Decision
+
+Windows 窗口以 `titleBarStyle: 'hidden'` 加 `titleBarOverlay` 创建，并设 `autoHideMenuBar: true`，让菜单栏不再占一整行（Alt 仍可唤出原生菜单栏；`Menu.setApplicationMenu` 仍安装，快捷键继续生效）。overlay 的 `height` 取 `Math.ceil(DESKTOP_TITLEBAR_HEIGHT * DEFAULT_UI_ZOOM_FACTOR)`：overlay 以设备无关像素声明，而标题条在 1.12 缩放因子下度量 CSS 像素，向上取整保证任何缩放下标题按钮都落在条内。`DESKTOP_TITLEBAR_HEIGHT` 放在 `src/contracts.ts`，主进程与客户端共享一个数，而不是两个会漂移的常量。
+
+应用菜单不依赖 Alt 也可达：客户端把菜单的顶层标签（经 bridge 从已构建的 `Menu` 读取）渲染成标题条左角的按钮，点击时在按钮处弹出对应的原生子菜单。跨进程边界的只有标签——条目、角色与快捷键仍由 `buildMenu()` 唯一持有。弹窗处理器把按钮的 CSS 像素位置经 webContents 缩放因子换算成客户区相对 DIP；Windows 上 `popup({x, y})` 的坐标是客户区相对的，加上窗口原点偏移会把菜单弹到窗口中间（第一版上线时的 bug，实机检查抓到）。
+
+页内标题条不再假设自己的高度，而是跟随 overlay 几何：`body` 的 padding 与 `::before` 拖拽条改用 `env(titlebar-area-height, var(--oh-dsh-titlebar-height))`；`.oh-dsh-panel-toolbar`——sidebar 插件固定的面板按钮，原先锚定在距窗口边缘 14px 处、会压在标题按钮下面——用 `env(titlebar-area-x)`/`env(titlebar-area-width)` 随 overlay 左缘位移，保住 14px 间隙。菜单栏本身是拖拽条的同级元素、按钮为 `no-drag` 孤岛，填上 Windows 留空的左角（macOS 那里是红绿灯按钮）。`nativeTheme` 的 `updated` 处理器重调 `setTitleBarOverlay`，主题切换时 overlay 与窗口背景同步变色；非 overlay 窗口（splash/更新窗口）由现有的 catch 跳过。macOS 保持 `hiddenInset`；Linux 保持普通边框——合并成一行是仅属 win32 的窗口形态决策。
+
+## Alternatives considered
+
+### 为什么不用 `frame: false` 加完全自绘的标题按钮？
+
+在条内自绘最小化/最大化/关闭会失去挂在原生最大化按钮上的 Windows snap 布局弹出层，并把 OS 按钮行为（双击最大化、aero snap、触控目标）永久揽到自己手里。Window Controls Overlay 让这些全部保持原生，我们只保留空间。
+
+### 为什么不保留菜单栏、只隐藏标题栏？
+
+只设 `titleBarStyle: 'hidden'` 而不设 `autoHideMenuBar`，菜单栏在 Windows 上仍占一整行；三段堆叠只是中间破了个洞活下来。用户的诉求是一行，菜单就得住进这一行里。
+
+### 为什么不做完整的页内菜单（条目渲染进网页层）？
+
+把菜单**条目**渲染进网页层会把菜单分叉成第二个 UI，主进程要经命令桥驱动它，跨 surface 复制 `Menu.setApplicationMenu` 已拥有的角色（`about`、`services`、`quit`），并要永远重新实现原生菜单行为（勾选框、快捷键、子菜单嵌套）。只渲染顶层**标签**、弹出原生子菜单保持唯一属主：网页层拥有像素，主进程拥有菜单。
+
+### 为什么不在客户端读 overlay 高度，而要共享常量？
+
+env() 变量只在 overlay 生效时存在；从第二个客户端高度常量推导回退值，正是共享 `DESKTOP_TITLEBAR_HEIGHT` 要防的漂移。客户端在 env() 存在时仍优先用它，因此即便 Windows 报告的高度不同，标题条也跟随真实 overlay。
+
+## Consequences
+
+收获：Windows 上与 macOS 同形的单行 chrome；原生标题按钮与 snap 布局完好；菜单直接显示在这一行里、子菜单为原生；跨进程边界只有一个高度常量。代价：标题条高度改为跟随 overlay（默认缩放下 45px 而非平面 40 CSS px——内容多让出 5px）；默认宽度窗口上工具条距右缘 137px 加间隙；菜单栏标签是网页层的纯文本——角色提供的助记符与原生菜单栏的悬停联动没有带过来（只能点击打开；需要时 Alt 唤出完整原生菜单栏）。`nativeTheme` 监听器有 win32 守卫并忽略非 overlay 窗口。
+
+## Testing
+
+`tests/desktop-titlebar.test.ts` 钉住 win32 窗口形态分支、macOS 保留 `hiddenInset`、共享常量、随缩放的 overlay 高度推导、标题条/工具条的 `env()` 几何，以及菜单栏契约：bridge 上的标签与弹窗、`buildMenu()` 唯一持有菜单、缩放因子坐标换算、仅 win32 主窗口挂载与 drag/no-drag 区域。在 Windows 上的实机验证（CDP 连接隔离 `OH_DSH_HOME` 下的 staged runtime）：`outerHeight - innerHeight = 8`（仅调整边框；菜单+标题两行已消失），`titlebar-area-height = 45` 等于标题条 45px 的 `padding-top`，面板工具条右缘与 overlay 左缘保持 14px 间隙；菜单栏在条内（y 0–45，按钮 no-drag）渲染全部六个顶层标签，修正为客户区相对坐标后 File 子菜单在按钮处弹出（用户在实机窗口确认）。本机 `pnpm test`/`typecheck`/`build` 全链通过，除 `tests/nix-collect-deps.test.ts`（需要 `python3`，本机缺失；未修改的 HEAD 同样失败）与 `scripts/smoke-runtime.mjs`（其 client-graph 轮询在未修改的 HEAD 上同样超时）。
+
+## Related
+
+本决策所依赖的拖拽条与对话框 z-index 分层由 `src/client.ts` 的桌面客户端 chrome 持有；面板工具条属于[工作区侧栏工具注册表](2026-08-11-workspace-sidebar-order-and-folding.md)。

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write docs/usage.md
-usage.md: 736ad655d5c2c4923af2607551055835c8fa6810
-usage.zh.md: 8cf2d04d2dd4c55f95db401e1540ce21863f8c4b
+usage.md: af1bbbf8c5191ce9b91ac82246c7cbc8bc703c74
+usage.zh.md: bf800a64eff5d57927ca96e292207c781349a5c2

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,9 @@ An unsigned installer may trigger Windows SmartScreen. After verifying that it
 came from the project Release, choose **More info**, then **Run anyway**. The
 installer may request administrator approval.
 
+The window title bar, menu bar, and tool strip are merged into a single row;
+open the application menu from the labels in the row's left corner.
+
 ### Desktop online updates
 
 Choose **Oh-DSH Desktop -> Check for Updates...** from the application menu.

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -55,6 +55,8 @@ sudo apt install ./Oh-DSH-Desktop-*.deb
 未签名安装器可能触发 Windows SmartScreen。确认文件来自项目 Release 后，选择
 “更多信息”再选择“仍要运行”；安装过程可能请求管理员授权。
 
+窗口标题栏、菜单栏与工具条合并为一行；点击该行左角的菜单名即可打开应用菜单。
+
 ### Desktop 在线更新
 
 在应用菜单中选择 **Oh-DSH Desktop -> 检查更新…**。更新窗口只检查

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 /** Browser face for the native Oh-DSH Desktop bridge. */
 
-import type { DesktopBridge, DesktopCommand } from './contracts.ts'
+import { DESKTOP_TITLEBAR_HEIGHT, type DesktopBridge, type DesktopCommand } from './contracts.ts'
 import type { DesktopPanels } from '../plugins/panel-controls/src/client.ts'
 import type { PinnedSummary } from '../plugins/pinned-summary/src/client.ts'
 import type { WorkspaceTools } from '../plugins/sidebar/src/client.ts'
@@ -35,8 +35,6 @@ declare global {
   }
 }
 
-const DESKTOP_TITLEBAR_HEIGHT = 40
-
 const DESKTOP_CHROME_CSS = `
 html[data-oh-dsh-desktop='true'] {
   --oh-dsh-titlebar-height: ${DESKTOP_TITLEBAR_HEIGHT}px;
@@ -44,7 +42,7 @@ html[data-oh-dsh-desktop='true'] {
 
 html[data-oh-dsh-desktop='true'] body {
   box-sizing: border-box;
-  padding-top: var(--oh-dsh-titlebar-height);
+  padding-top: env(titlebar-area-height, var(--oh-dsh-titlebar-height));
 }
 
 html[data-oh-dsh-desktop='true'] body::before {
@@ -54,10 +52,44 @@ html[data-oh-dsh-desktop='true'] body::before {
   top: 0;
   right: 0;
   left: 0;
-  height: var(--oh-dsh-titlebar-height);
+  height: env(titlebar-area-height, var(--oh-dsh-titlebar-height));
   background: var(--dsw-alias-bg-base);
   -webkit-app-region: drag;
   user-select: none;
+}
+
+/* Keep the panel toolbar clear of the Windows window-controls overlay. */
+html[data-oh-dsh-desktop='true'] .oh-dsh-panel-toolbar {
+  right: calc(100vw - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100vw) + 14px);
+}
+
+/* In-page menu bar: fills the blank strip corner on Windows with the real
+   application menu, popped up natively at the button. */
+html[data-oh-dsh-desktop='true'] .oh-dsh-menubar {
+  position: fixed;
+  z-index: 2147483647;
+  top: 0;
+  left: 6px;
+  display: flex;
+  align-items: stretch;
+  height: env(titlebar-area-height, var(--oh-dsh-titlebar-height));
+  -webkit-app-region: drag;
+}
+
+html[data-oh-dsh-desktop='true'] .oh-dsh-menubar button {
+  -webkit-app-region: no-drag;
+  margin: 5px 0;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dsw-alias-label-primary, #1f2328);
+  font-size: 12px;
+  line-height: calc(env(titlebar-area-height, var(--oh-dsh-titlebar-height)) - 10px);
+}
+
+html[data-oh-dsh-desktop='true'] .oh-dsh-menubar button:hover {
+  background: var(--dsw-alias-interactive-bg-hover, rgb(0 0 0 / 6%));
 }
 
 html[data-oh-dsh-preview='true'] body::after {
@@ -130,13 +162,15 @@ html[data-oh-dsh-desktop='true']:has(
 /** Wait for the DSH services used by native menu commands. */
 export const inject = ['locale', 'workspaces', 'desktopPanels', 'pinnedSummary', 'workspaceTools']
 
-type DesktopShellMessage = 'preview.label'
+type DesktopShellMessage = 'menubar.label' | 'preview.label'
 
 const DESKTOP_SHELL_MESSAGES: LocaleMessages<DesktopShellMessage> = {
   en: {
+    'menubar.label': 'Application menu',
     'preview.label': 'Isolated plugin preview · {plugin}',
   },
   zh: {
+    'menubar.label': '应用菜单',
     'preview.label': '隔离插件预览 · {plugin}',
   },
 }
@@ -154,6 +188,32 @@ function installDesktopChrome(): () => void {
     delete document.documentElement.dataset.ohDshDesktop
     document.title = originalTitle
   }
+}
+
+/**
+ * Windows only: render the application menu's top-level labels inside the
+ * merged titlebar row. Buttons pop up the native submenu, so menu items,
+ * roles, and accelerators keep their single owner in the main process.
+ */
+function installMenuBar(bridge: DesktopBridge, t: Translate<DesktopShellMessage>): () => void {
+  const bar = document.createElement('nav')
+  bar.className = 'oh-dsh-menubar'
+  bar.setAttribute('aria-label', t('menubar.label'))
+  document.body.append(bar)
+  void bridge.menuBarLabels().then(labels => {
+    if (!bar.isConnected) return
+    for (const [index, label] of labels.entries()) {
+      const button = document.createElement('button')
+      button.type = 'button'
+      button.textContent = label
+      button.addEventListener('click', () => {
+        const rect = button.getBoundingClientRect()
+        void bridge.popupMenuBarMenu(index, rect.left, rect.bottom)
+      })
+      bar.append(button)
+    }
+  })
+  return () => { bar.remove() }
 }
 
 function installHeroBranding(): () => void {
@@ -311,13 +371,20 @@ export function apply(ctx: ClientContext): void {
     const removeDesktopChrome = installDesktopChrome()
     const removeHeroBranding = installHeroBranding()
     const unsubscribeLocale = locale.subscribe(renderPreviewLabel)
+    let removeMenuBar: (() => void) | undefined
     void bridge.getInfo().then(info => {
-      if (disposed || info.preview === null) return
+      if (disposed) return
+      if (info.preview === null) {
+        // Windows merges the menu into the titlebar row; the native menu
+        // stays installed, so Alt still reveals it.
+        if (info.platform === 'win32') removeMenuBar = installMenuBar(bridge, t)
+        return
+      }
       previewPluginId = info.preview.pluginId
       document.documentElement.dataset.ohDshPreview = 'true'
       renderPreviewLabel()
     }).catch((error: unknown) => {
-      console.error('oh-dsh-desktop: failed to read preview identity', error)
+      console.error('oh-dsh-desktop: failed to read desktop info', error)
     })
     const unsubscribe = bridge.onCommand((command) => {
       dispatch(command, workspaces, panels, pinnedSummary, workspaceTools)
@@ -325,6 +392,7 @@ export function apply(ctx: ClientContext): void {
     return () => {
       disposed = true
       unsubscribe()
+      removeMenuBar?.()
       unsubscribeLocale()
       removeHeroBranding()
       removeDesktopChrome()

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,5 +1,8 @@
 import type { PluginMarketplaceBridge } from '../plugins/plugin-marketplace/src/protocol.ts'
 
+/** Height of the in-page desktop titlebar strip, in CSS pixels at zoom 1. */
+export const DESKTOP_TITLEBAR_HEIGHT = 40
+
 /** Commands sent from Electron's native chrome to the DSH client plugin. */
 export type DesktopCommand =
   | { type: 'focus-composer' }
@@ -62,16 +65,22 @@ export type DesktopUpdateCommand =
 
 export interface DesktopUpdateBridge {
   getState(): Promise<DesktopUpdateState>
-  command(command: DesktopUpdateCommand): Promise<DesktopUpdateState>
   onState(listener: (state: DesktopUpdateState) => void): () => void
+  command(command: DesktopUpdateCommand): Promise<DesktopUpdateState>
 }
 
-/** Browser-safe desktop bridge made available through contextBridge. */
 export interface DesktopBridge {
   chooseWorkspace(): Promise<string[]>
   getInfo(): Promise<DesktopInfo>
   getRuntimeSnapshot(): Promise<DesktopRuntimeSnapshot>
+  /** Top-level labels of the application menu, in menu order. */
+  menuBarLabels(): Promise<string[]>
   onCommand(listener: (command: DesktopCommand) => void): () => void
   openExternal(url: string): Promise<void>
   pluginMarketplace: PluginMarketplaceBridge
+  /**
+   * Pop up the native submenu of top-level menu `index` with its top-left
+   * corner at the given CSS-pixel position inside the main window.
+   */
+  popupMenuBarMenu(index: number, cssX: number, cssY: number): Promise<void>
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,12 +29,13 @@ import {
   withGitHubCredentials,
 } from '../plugins/plugin-marketplace/src/host/platform.ts'
 import { parseMarketplaceCommand } from '../plugins/plugin-marketplace/src/protocol.ts'
-import type {
-  DesktopCommand,
-  DesktopInfo,
-  DesktopRuntimeSnapshot,
-  DesktopUpdateCommand,
-  DesktopUpdateState,
+import {
+  DESKTOP_TITLEBAR_HEIGHT,
+  type DesktopCommand,
+  type DesktopInfo,
+  type DesktopRuntimeSnapshot,
+  type DesktopUpdateCommand,
+  type DesktopUpdateState,
 } from './contracts.ts'
 import {
   desktopElectronDataRoot,
@@ -275,6 +276,18 @@ function windowIconPath(): string | undefined {
   return existsSync(development) ? development : undefined
 }
 
+function titleBarOverlayOptions(): { color: string; height: number; symbolColor: string } {
+  const dark = nativeTheme.shouldUseDarkColors
+  // The overlay declares its height in device-independent pixels, while the
+  // client strip measures CSS pixels under the default zoom factor; rounding
+  // up keeps the caption buttons inside the strip at any zoom.
+  return {
+    color: dark ? '#202020' : '#f7f7f5',
+    height: Math.ceil(DESKTOP_TITLEBAR_HEIGHT * DEFAULT_UI_ZOOM_FACTOR),
+    symbolColor: dark ? '#f0f0ee' : '#3d3d3b',
+  }
+}
+
 function createWindow(options: { preview?: boolean; title?: string } = {}): BrowserWindow {
   const icon = windowIconPath()
   const window = new BrowserWindow({
@@ -286,7 +299,16 @@ function createWindow(options: { preview?: boolean; title?: string } = {}): Brow
     title: options.title ?? PRODUCT_NAME,
     ...(process.platform === 'darwin'
       ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 16, y: 16 } }
-      : {}),
+      : process.platform === 'win32'
+        ? {
+          // Merge the native menu-bar and title-bar rows into the in-page
+          // titlebar strip: the Window Controls Overlay keeps native caption
+          // buttons and snap layouts while the strip owns the single row.
+          autoHideMenuBar: true,
+          titleBarStyle: 'hidden' as const,
+          titleBarOverlay: titleBarOverlayOptions(),
+        }
+        : {}),
     ...(icon === undefined ? {} : { icon }),
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#202020' : '#f7f7f5',
     webPreferences: {
@@ -836,11 +858,37 @@ function buildMenu(): void {
     },
     { role: 'windowMenu' },
   ]
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+  applicationMenu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(applicationMenu)
 }
+
+/** The native application menu, popped up by the in-page Windows menu bar. */
+let applicationMenu: Menu | undefined
 
 function installIpc(): void {
   ipcMain.handle('desktop:choose-workspace', async () => await selectWorkspacePaths())
+  ipcMain.handle('desktop:menu-bar-labels', event => {
+    if (event.sender !== mainWindow?.webContents) return []
+    return applicationMenu?.items.map(item => item.label) ?? []
+  })
+  ipcMain.handle('desktop:menu-bar-popup', (event, index: unknown, cssX: unknown, cssY: unknown) => {
+    if (event.sender !== mainWindow?.webContents || applicationMenu === undefined) return
+    if (typeof index !== 'number' || typeof cssX !== 'number' || typeof cssY !== 'number') {
+      throw new Error('menu bar popup arguments must be numbers')
+    }
+    const submenu = applicationMenu.items[index]?.submenu
+    const window = mainWindow
+    if (submenu === undefined || window === undefined || window.isDestroyed()) return
+    // The client reports CSS pixels; popup()'s x/y are client-relative DIPs on
+    // Windows, and the webContents zoom factor is exactly how many DIPs one
+    // CSS pixel occupies.
+    const scale = window.webContents.getZoomFactor()
+    submenu.popup({
+      window,
+      x: Math.round(cssX * scale),
+      y: Math.round(cssY * scale),
+    })
+  })
   ipcMain.handle('desktop:update:get-state', async event => {
     assertUpdateWindowSender(event)
     return (await getUpdateManager()).getState()
@@ -937,6 +985,17 @@ async function bootstrap(): Promise<void> {
     if (app.isReady()) flushQueuedPaths()
   })
   await app.whenReady()
+  nativeTheme.on('updated', () => {
+    if (process.platform !== 'win32') return
+    for (const window of [mainWindow, previewWindow]) {
+      if (window === undefined || window.isDestroyed()) continue
+      try {
+        window.setTitleBarOverlay(titleBarOverlayOptions())
+      } catch {
+        // Not a window-controls-overlay window (splash/update); nothing to recolor.
+      }
+    }
+  })
 
   const info = desktopInfo()
   const logsDir = join(info.appDataPath, 'logs')

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -10,6 +10,7 @@ const bridge: DesktopBridge = Object.freeze({
   getRuntimeSnapshot: async (): Promise<DesktopRuntimeSnapshot> => {
     return await ipcRenderer.invoke('desktop:get-runtime-snapshot') as DesktopRuntimeSnapshot
   },
+  menuBarLabels: async (): Promise<string[]> => await ipcRenderer.invoke('desktop:menu-bar-labels') as string[],
   onCommand: (listener: (command: DesktopCommand) => void): (() => void) => {
     const wrapped = (_event: Electron.IpcRendererEvent, command: DesktopCommand): void => { listener(command) }
     ipcRenderer.on('desktop:command', wrapped)
@@ -26,6 +27,9 @@ const bridge: DesktopBridge = Object.freeze({
       return await ipcRenderer.invoke('desktop:plugin-marketplace-snapshot') as MarketplaceSnapshot
     },
   }),
+  popupMenuBarMenu: async (index: number, cssX: number, cssY: number): Promise<void> => {
+    await ipcRenderer.invoke('desktop:menu-bar-popup', index, cssX, cssY)
+  },
 })
 
 contextBridge.exposeInMainWorld('dshDesktop', bridge)

--- a/tests/desktop-titlebar.test.ts
+++ b/tests/desktop-titlebar.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+test('desktop win32 windows collapse title bar, menu bar, and strip into one row', () => {
+  const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
+  const client = readFileSync(new URL('../src/client.ts', import.meta.url), 'utf8')
+  const contracts = readFileSync(new URL('../src/contracts.ts', import.meta.url), 'utf8')
+
+  // The native title-bar and menu-bar rows are traded for the window-controls
+  // overlay; the in-page strip owns the single merged row.
+  assert.match(
+    main,
+    /: process\.platform === 'win32'[\s\S]*?autoHideMenuBar: true,[\s\S]*?titleBarStyle: 'hidden' as const,[\s\S]*?titleBarOverlay: titleBarOverlayOptions\(\),[\s\S]*?: \{\}\)/,
+  )
+  // macOS keeps the hiddenInset row and every other platform keeps the frame.
+  assert.match(main, /process\.platform === 'darwin'[\s\S]*?titleBarStyle: 'hiddenInset'/)
+
+  // Overlay geometry derives from the strip height shared across processes.
+  assert.match(contracts, /export const DESKTOP_TITLEBAR_HEIGHT = 40/)
+  assert.match(main, /Math\.ceil\(DESKTOP_TITLEBAR_HEIGHT \* DEFAULT_UI_ZOOM_FACTOR\)/)
+
+  // The strip follows the overlay height and keeps its drag region.
+  assert.match(client, /padding-top: env\(titlebar-area-height, var\(--oh-dsh-titlebar-height\)\)/)
+  assert.match(client, /height: env\(titlebar-area-height, var\(--oh-dsh-titlebar-height\)\)/)
+  assert.match(client, /-webkit-app-region: drag/)
+
+  // The panel toolbar shifts clear of the overlay caption buttons.
+  assert.match(
+    client,
+    /right: calc\(100vw - env\(titlebar-area-x, 0px\) - env\(titlebar-area-width, 100vw\) \+ 14px\)/,
+  )
+})
+
+test('desktop win32 menu bar renders in the merged row but pops the native menu', () => {
+  const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
+  const client = readFileSync(new URL('../src/client.ts', import.meta.url), 'utf8')
+  const contracts = readFileSync(new URL('../src/contracts.ts', import.meta.url), 'utf8')
+  const preload = readFileSync(new URL('../src/preload.ts', import.meta.url), 'utf8')
+
+  // The bridge exposes the application menu's labels and a native popup.
+  assert.match(contracts, /menuBarLabels\(\): Promise<string\[\]\>/)
+  assert.match(contracts, /popupMenuBarMenu\(index: number, cssX: number, cssY: number\): Promise<void>/)
+  assert.match(preload, /desktop:menu-bar-labels/)
+  assert.match(preload, /desktop:menu-bar-popup/)
+
+  // The main process serves labels and pops the built application menu's own
+  // submenus — no second menu definition beside buildMenu().
+  assert.match(main, /applicationMenu = Menu\.buildFromTemplate\(template\)/)
+  assert.match(main, /Menu\.setApplicationMenu\(applicationMenu\)/)
+  assert.match(main, /'desktop:menu-bar-labels'/)
+  assert.match(main, /submenu\.popup\(\{/)
+  // CSS pixels convert to screen DIPs through the webContents zoom factor.
+  assert.match(main, /cssX \* scale/)
+  assert.match(main, /getZoomFactor\(\)/)
+
+  // The client mounts the bar only for the win32 main window; buttons are
+  // no-drag islands inside the draggable strip.
+  assert.match(client, /info\.preview === null[\s\S]*?info\.platform === 'win32'[\s\S]*?installMenuBar\(bridge, t\)/)
+  assert.match(client, /\.oh-dsh-menubar \{[\s\S]*?-webkit-app-region: drag;/)
+  assert.match(client, /\.oh-dsh-menubar button \{[\s\S]*?-webkit-app-region: no-drag;/)
+  assert.match(client, /popupMenuBarMenu\(index, rect\.left, rect\.bottom\)/)
+})


### PR DESCRIPTION
Fixes #91

## Changes

On Windows the window stacked three chrome bands above the conversation: the native menu bar, the native title bar, and the in-page 40px drag strip — the blank band reported in #91 — while macOS already rendered one row. This merges all three into a single row on win32:

- Create Windows windows with `titleBarStyle: 'hidden'` plus `titleBarOverlay`, so the native caption buttons and their snap layouts live inside the strip instead of above it; `autoHideMenuBar: true` drops the menu row.
- The strip sizes itself from the overlay geometry via `env(titlebar-area-*)` instead of a hardcoded 40px, and the sidebar panel toolbar shifts clear of the caption buttons.
- The application menu stays reachable without Alt: the client renders the menu's top-level labels (served from the built `Menu` over the bridge) as buttons in the row's left corner; a click pops the native submenu at the button. `buildMenu()` remains the single owner of items, roles, and accelerators — only the labels cross the process boundary.
- `DESKTOP_TITLEBAR_HEIGHT` moves to `src/contracts.ts` so the main process and the client share one constant.

macOS (`hiddenInset`) and Linux (plain frame) are unchanged: the new CSS falls back to value-identical results, the in-row menu mounts only when the bridge reports win32, and the overlay/theme handlers are platform-guarded.

This takes the further step #105 defers (it removes the gap but keeps the native title/menu bars), so the two PRs are alternative fixes for #91.

## Verification

- Live on Windows 11 x64 (staged runtime, isolated `OH_DSH_HOME`): page-level native chrome is 8px (resize border only — the menu and title rows are gone); strip height equals `titlebar-area-height` (45px at default zoom); the panel toolbar keeps 14px clearance from the caption overlay; all six menu labels render inside the row and submenus pop at their buttons.
- `pnpm run typecheck`, `pnpm run build`: pass.
- `pnpm test`: 196 passed, 1 pre-existing Windows python3/9009 failure (fails identically on unmodified HEAD, verified via stash baseline), 2 skipped.
- macOS/Linux: not run locally (no such environment).

## Reference Screenshots

After fix: <img width="962" height="630" alt="Snipaste_2026-08-18_08-30-33" src="https://github.com/user-attachments/assets/9f957afc-8915-484d-be28-170ad3ea1815" />