### PR TITLE
docs: fix zh Agent Note language switchers

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-18-windows-hoisted-settings-boundary.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-18-windows-hoisted-settings-boundary.i18n.yaml
@@ -3,4 +3,4 @@
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-18-windows-hoisted-settings-boundary.md
 2026-08-18-windows-hoisted-settings-boundary.md: 3d4f4f9df5b0234ea2144e97d03ddde86e6ad72d
-2026-08-18-windows-hoisted-settings-boundary.zh.md: 8dea49fd4eb503b128297142be27e10a59b5ad25
+2026-08-18-windows-hoisted-settings-boundary.zh.md: 47062c1223061f87965be2fefccc496a8ea3791e

--- a/.agents/notes/implemented/bug-fix/2026-08-18-windows-hoisted-settings-boundary.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-18-windows-hoisted-settings-boundary.zh.md
@@ -2,7 +2,7 @@
 
 Status: implemented
 
-English | 中文
+[English](2026-08-18-windows-hoisted-settings-boundary.md) | 中文
 
 ## Problem
 

--- a/.agents/notes/implemented/testing/2026-08-18-linux-electron-smoke-display.i18n.yaml
+++ b/.agents/notes/implemented/testing/2026-08-18-linux-electron-smoke-display.i18n.yaml
@@ -3,4 +3,4 @@
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/testing/2026-08-18-linux-electron-smoke-display.md
 2026-08-18-linux-electron-smoke-display.md: 5eaabf545e8552c6a1492f43917f6300cfadb4b2
-2026-08-18-linux-electron-smoke-display.zh.md: d99d8d366d2c4d89dcd3b7e5cfa879b011af7d40
+2026-08-18-linux-electron-smoke-display.zh.md: 0b2351e03aae50fd7e425b11b01d523b30041108

--- a/.agents/notes/implemented/testing/2026-08-18-linux-electron-smoke-display.zh.md
+++ b/.agents/notes/implemented/testing/2026-08-18-linux-electron-smoke-display.zh.md
@@ -2,7 +2,7 @@
 
 Status: implemented
 
-English | [English](2026-08-18-linux-electron-smoke-display.md)
+[English](2026-08-18-linux-electron-smoke-display.md) | 中文
 
 ## Problem
 

--- a/.agents/notes/implemented/testing/2026-08-18-linux-web-smoke-timeout.i18n.yaml
+++ b/.agents/notes/implemented/testing/2026-08-18-linux-web-smoke-timeout.i18n.yaml
@@ -3,4 +3,4 @@
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/testing/2026-08-18-linux-web-smoke-timeout.md
 2026-08-18-linux-web-smoke-timeout.md: 0d5e960f451077d9df962c80a3a96983e52060d3
-2026-08-18-linux-web-smoke-timeout.zh.md: 1a71df9a5814c398ffb5ab1a79531788fa021eaa
+2026-08-18-linux-web-smoke-timeout.zh.md: 3877bc83c9adfc76f681e4ee11740ec32473388d

--- a/.agents/notes/implemented/testing/2026-08-18-linux-web-smoke-timeout.zh.md
+++ b/.agents/notes/implemented/testing/2026-08-18-linux-web-smoke-timeout.zh.md
@@ -2,7 +2,7 @@
 
 Status: implemented
 
-English | 中文
+[English](2026-08-18-linux-web-smoke-timeout.md) | 中文
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- Fix the bilingual pairing gate failure from [run 32134822559](https://github.com/hust-open-atom-club/oh-dsh/actions/runs/32134822559).
- Correct the language switcher in the zh Agent Notes to the documented `[English](foo.md) | 中文` form for:
  - `2026-08-18-windows-hoisted-settings-boundary`
  - `2026-08-18-linux-web-smoke-timeout`
  - `2026-08-18-linux-electron-smoke-display` (same defect, not reported because the gate checks link targets only)
- Re-record the three `.i18n.yaml` consistency sidecars.

## Why

Two zh Agent Notes shipped without a link to their English siblings,
which `verify-translation-pairing` rejected. A scan found one more zh
note with a correctly targeted but wrongly labeled switcher and fixed it
in the same change.

## Verification

- `node scripts/verify-translation-pairing.ts` — 555 pairs consistent
- `pnpm run verify:agent-notes` — 550 notes checked
- `git diff --check`

No new Agent Note is required: this is a mechanical documentation fix,
and the affected decisions already have their own notes.
