### PR TITLE
runtime: expose agent-presets in the restored settings boundary

### DIFF
--- a/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.md
-2026-08-18-rc7-settings-namespaces-and-smoke-picker.md: 2952e29d04301cb0e0092258e9ec98c45bb05b09
-2026-08-18-rc7-settings-namespaces-and-smoke-picker.zh.md: 331688f075de5ed2fcbc47b9790e32121b7c1d71
+2026-08-18-rc7-settings-namespaces-and-smoke-picker.md: 31ae1bdf7c9c9aa292d4ee67d5e6ab4c41ff90b1
+2026-08-18-rc7-settings-namespaces-and-smoke-picker.zh.md: 03fcbcb5a945dca709af0ec207b0ca84d11953d7

--- a/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.md
-2026-08-18-rc7-settings-namespaces-and-smoke-picker.md: 31ae1bdf7c9c9aa292d4ee67d5e6ab4c41ff90b1
-2026-08-18-rc7-settings-namespaces-and-smoke-picker.zh.md: 03fcbcb5a945dca709af0ec207b0ca84d11953d7
+2026-08-18-rc7-settings-namespaces-and-smoke-picker.md: 77289dac119b82ee3ea1f12a81aee72adf5d26cb
+2026-08-18-rc7-settings-namespaces-and-smoke-picker.zh.md: a35cadb55e7f8c6f94440788d152bcc91b8a19ab

--- a/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.md
+++ b/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.md
@@ -29,7 +29,14 @@ previously installed pnpm 11.20.0.
   `settings-not-exposed`. The allowlist is WEB_SETTINGS_NAMESPACES
   (agent-loop, shell, locale, permission, ui-conversation, ui-theme,
   web-search-deepseek), PRODUCT_SETTINGS_NAMESPACES (ui-onboarding,
-  settings) and oh-dsh-vision, matching the rc.6 exposedNamespaces() union.
+  agent-presets, settings) and oh-dsh-vision. `agent-presets` was initially
+  omitted because the rc.6 union lacked it; the pinned rc.7 client writes the
+  default agent preset through that namespace (ui-agent-preset
+  writeDefaultPreset), so every default-mode switch was refused with
+  `settings-not-exposed` — a code the rc.7 wire schema does not declare,
+  which crashed the client's response parse into a raw Zod issue dump
+  instead of showing the message. The allowlist now carries it, and
+  tests/settings-boundary.test.ts pins the namespace in the patched output.
   This keeps the configuration-client boundary recorded in
   [2026-07-30-config-plane-boundaries.md](../architecture/2026-07-30-config-plane-boundaries.md),
   [2026-08-10-web-plugin-configuration.md](../feature/2026-08-10-web-plugin-configuration.md),

--- a/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.zh.md
+++ b/.agents/notes/implemented/process/2026-08-18-rc7-settings-namespaces-and-smoke-picker.zh.md
@@ -24,8 +24,13 @@ Status: implemented
   （update/replace/mutate）对其他命名空间一律以 `settings-not-exposed`
   拒绝。白名单为 WEB_SETTINGS_NAMESPACES（agent-loop、shell、locale、
   permission、ui-conversation、ui-theme、web-search-deepseek）、
-  PRODUCT_SETTINGS_NAMESPACES（ui-onboarding、settings）以及
-  oh-dsh-vision，与 rc.6 的 exposedNamespaces() 并集一致。这让
+  PRODUCT_SETTINGS_NAMESPACES（ui-onboarding、agent-presets、settings）
+  以及 oh-dsh-vision。`agent-presets` 最初因 rc.6 并集没有它而被遗漏；
+  固定的 rc.7 client 通过该命名空间写入默认 agent preset（ui-agent-preset
+  的 writeDefaultPreset），导致每次默认模式切换都以 `settings-not-exposed`
+  被拒——该错误码不在 rc.7 wire schema 声明之内，client 的响应解析因此
+  崩溃，界面直接展示原始 Zod issue 转储而非错误消息。白名单现已包含它，
+  tests/settings-boundary.test.ts 也在补丁输出中固定了该命名空间。这让
   [2026-07-30-config-plane-boundaries.md](../architecture/2026-07-30-config-plane-boundaries.md)、
   [2026-08-10-web-plugin-configuration.md](../feature/2026-08-10-web-plugin-configuration.md)
   与

--- a/scripts/settings-boundary.mjs
+++ b/scripts/settings-boundary.mjs
@@ -11,6 +11,7 @@ const ALLOWLIST = [
   'ui-theme',
   'web-search-deepseek',
   'ui-onboarding',
+  'agent-presets',
   'settings',
   'oh-dsh-vision',
 ]

--- a/tests/settings-boundary.test.ts
+++ b/tests/settings-boundary.test.ts
@@ -54,6 +54,7 @@ test('settings boundary patches every assembled runtime idempotently', () => {
     assert.match(once, /WEB_SETTINGS_NAMESPACES/)
     assert.match(once, /ctx\.llm\.listConfigurableProviders\(\)/)
     assert.match(once, /settings-not-exposed/)
+    assert.match(once, /"agent-presets"/)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }


### PR DESCRIPTION
Fixes  #117 

## Summary

Add the `agent-presets` settings namespace to the ALLOWLIST restored by `scripts/settings-boundary.mjs`, and pin it in `tests/settings-boundary.test.ts` so a future allowlist rebuild cannot drop it silently. Amend the rc.7 Agent Note (en/zh) to record the omission.

## Why

The rc.7 settings boundary restore dropped the agent-presets namespace from the allowlist, so every default-mode switch answered settings-not-exposed - a code the rc.7 wire schema does not declare. The client response parse then crashed and surfaced a raw Zod issue dump instead of the message. 

## Verification

- `node --test tests/settings-boundary.test.ts` → 3 pass.
- `pnpm run typecheck` and `pnpm run build` → clean.
- E2E probe against a freshly staged runtime: `settings.describe` lists `agent-presets`; `settings.update` on the namespace returns `ok: true`; an unlisted namespace is still refused with `settings-not-exposed` (the boundary stays fail-closed).
- Manual: reproduced the crash on a main-branch build, then confirmed the default-preset switch succeeds on this branch in the desktop app.