### PR TITLE
fix: prevent update dialog fullscreen crash on macOS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -448,6 +448,9 @@ async function openUpdateWindow(): Promise<void> {
     minHeight: 480,
     ...(mainWindow !== undefined && !mainWindow.isDestroyed() ? { parent: mainWindow } : {}),
     modal: false,
+    // Keep this child window out of macOS fullscreen spaces: closing it while the
+    // parent is fullscreen can trigger an AppKit crash (#119).
+    fullscreenable: false,
     show: false,
     title: 'Software updates',
     webPreferences: {


### PR DESCRIPTION
Fixes #119

## Problem

When the app is in fullscreen mode, opening **Check for Updates** and then closing the dialog can crash on macOS with an uncaught AppKit exception:

```
-[__NSArrayM insertObject:atIndex:]: object cannot be nil
_NSExitFullScreenTransitionController gatherParticipatingWindowNumbers
```

The update window is created as a child `BrowserWindow`. On macOS, a child window opened while the parent is fullscreen can be placed into a fullscreen space. Closing it then races with AppKit's fullscreen-exit transition.

## Change

Mark the update dialog as `fullscreenable: false` when creating the `BrowserWindow`. This prevents the update dialog from participating in fullscreen transitions while keeping the existing non-modal child-window UX.

## Validation

- `pnpm typecheck` passes
- `pnpm test` passes (205 tests, 200 passed / 5 skipped)
