### PR TITLE
release: hash runtime bundles with a Windows-available command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,12 @@ jobs:
             > .stage/oh-dsh-runtime-manifest.json
           tar -czf "${BUNDLE}" -C .stage dsh-runtime oh-dsh-runtime-manifest.json
           rm .stage/oh-dsh-runtime-manifest.json
-          shasum -a 256 "${BUNDLE}" | sed "s#  release/#  #" > "${BUNDLE}.sha256"
+          # Git Bash on Windows ships sha256sum but not shasum.
+          if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "${BUNDLE}" | sed "s#  release/#  #" > "${BUNDLE}.sha256"
+          else
+            sha256sum "${BUNDLE}" | sed "s#  release/#  #" > "${BUNDLE}.sha256"
+          fi
 
       - name: Verify updater metadata
         shell: bash

--- a/.github/workflows/runtime-release.yml
+++ b/.github/workflows/runtime-release.yml
@@ -95,7 +95,12 @@ jobs:
           printf '%s\n' "{\"dshVersion\":\"${DSH_VERSION}\",\"bundledByAppVersion\":\"${APP_VERSION}\",\"runtimeContract\":${CONTRACT}}" \
             > .stage/oh-dsh-runtime-manifest.json
           tar -czf "${BUNDLE}" -C .stage dsh-runtime oh-dsh-runtime-manifest.json
-          shasum -a 256 "${BUNDLE}" > "${BUNDLE}.sha256"
+          # Git Bash on Windows ships sha256sum but not shasum.
+          if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "${BUNDLE}" > "${BUNDLE}.sha256"
+          else
+            sha256sum "${BUNDLE}" > "${BUNDLE}.sha256"
+          fi
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Scope

Fixes the failed **v0.1.8 Release** run (run 32646132255): the Windows x64 lane aborted at `Package decoupled DSH runtime bundle` with `shasum: command not found` — Git Bash on Windows ships `sha256sum` but not `shasum`. Both release.yml and runtime-release.yml now prefer `shasum` when present and fall back to `sha256sum`; the updater parses only the hash prefix, so the two checksum formats are interchangeable.

## Verification

- YAML validated locally; the failing step's command is exercised on every Release/Runtime-release run.
- macOS arm64/x64 and Linux x64 lanes of the failed run all passed and are unaffected.

## After merge

The unpublished `v0.1.8` tag should be moved to the merge commit (publish was skipped, so no release exists yet):

```sh
git tag -f -a v0.1.8 -m 'Oh-DSH Desktop v0.1.8' <merge-sha>
git push origin v0.1.8 --force
```