### PR TITLE
ci: watch upstream dependencies with a daily bot reporter

### DIFF
--- a/.agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.md
+2026-08-23-upstream-dependency-watch.md: 927b64c7bb8d60f8be98b51ee3c6dc08fe80dbbe
+2026-08-23-upstream-dependency-watch.zh.md: 0ff3c4799b110fefcefe232e637860453e92f0ff

--- a/.agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.md
+++ b/.agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.md
@@ -1,0 +1,63 @@
+# Agent Note: Watch upstream dependencies with a scheduled bot reporter
+
+Status: implemented
+
+English | [中文](2026-08-23-upstream-dependency-watch.zh.md)
+
+## Problem
+
+Oh-DSH pins the DSH runtime through `dsh-source.json` (currently
+`@deepseek-ai/dsh@0.1.1-rc.2`) and pins two plugin sources through the
+`upstream/` submodules. Nothing announces new upstream releases: each
+upgrade — like the 0.1.1-rc.2 bump — is discovered by hand, often days
+after publication, and every DSH bump so far required contract
+adaptation in `plugins/` that benefits from starting early.
+
+## Decision
+
+- A scheduled `Upstream watch` workflow (daily cron at 01:17 UTC, plus
+  `workflow_dispatch`) runs `scripts/watch-upstream.mjs`.
+- The script reads the pins from the repository itself — `dsh-source.json`
+  for the npm runtime, `.gitmodules` plus `git ls-tree` gitlinks for the
+  submodules — so there is no second version list to keep current.
+- The npm check compares the registry's versions and `latest` dist-tag
+  against the pin with semver (pre-release aware). The submodule check
+  reports upstream tags newer than the pin (exact tag match, falling
+  back to the pinned commit's date for pins past a tag) and how far the
+  tracked branch has advanced beyond the pin.
+- Findings become one issue per subject, labeled `upstream-watch` and
+  created by `github-actions[bot]` through `GITHUB_TOKEN` with
+  `issues: write`. An open issue whose title carries the subject's
+  `[upstream-watch] <subject>` prefix suppresses a duplicate; closing an
+  issue without moving the pin lets the next run re-open the subject.
+- A subject whose checks fail fails the job, while finding updates
+  exits 0 — findings are signal, not breakage. Without
+  `GITHUB_TOKEN`/`UPSTREAM_WATCH_REPO` (or with `--dry-run`) the script
+  is report-only, which is what a local run does.
+
+## Alternatives considered
+
+- **Dependabot or Renovate**: the npm pin lives in `dsh-source.json`,
+  not a package manifest, so their npm ecosystem cannot see it; their
+  submodule updates would move pins as PRs without the adaptation step
+  the pinned-source rule requires. Rejected for both gaps.
+- **One rolling digest issue updated daily**: a single thread cannot be
+  closed per subject, and closure is how maintainers mark "handled";
+  per-subject issues match the per-subject bump flow.
+- **A hosted third-party watcher**: adds an external service with repo
+  access for a job a scheduled workflow already does serverlessly.
+
+## Consequences
+
+- Awareness is automated while curation stays manual: the bot never
+  opens PRs or moves pins, because DSH contract drift needs human
+  adaptation before the surfaces can follow.
+- Re-creation is deliberate: as long as a pin is behind upstream, every
+  run after an issue is closed files a fresh one, so "not applicable"
+  closures should come with a comment or a pin move the next day will
+  honor.
+- GitHub disables cron workflows on repositories with 60 days of
+  inactivity; a quiet repository silently stops watching until any push
+  or a `workflow_dispatch` run resumes it.
+- The run costs one npm registry request and about three GitHub API
+  calls per submodule — no token budget worth tracking.

--- a/.agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.zh.md
+++ b/.agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.zh.md
@@ -1,0 +1,54 @@
+# Agent Note: Watch upstream dependencies with a scheduled bot reporter
+
+Status: implemented
+
+[English](2026-08-23-upstream-dependency-watch.md) | 中文
+
+## Problem
+
+Oh-DSH 通过 `dsh-source.json`（当前为 `@deepseek-ai/dsh@0.1.1-rc.2`）
+pin 住 DSH 运行时，并通过 `upstream/` 子模块 pin 住两个插件上游。目前
+没有任何机制播报上游的新版本：每次升级——例如 0.1.1-rc.2 那次——都靠人工
+发现，往往滞后于发布数日，而历次 DSH 升级都需要在 `plugins/` 中做契约
+适配，越早动手越有利。
+
+## Decision
+
+- 新增定时 `Upstream watch` workflow（每日 UTC 01:17 的 cron，外加
+  `workflow_dispatch`），运行 `scripts/watch-upstream.mjs`。
+- 脚本直接从仓库本身读取 pin：npm 运行时来自 `dsh-source.json`，子模块
+  来自 `.gitmodules` 加 `git ls-tree` 的 gitlink——因此不存在需要同步
+  维护的第二份版本清单。
+- npm 检查用 semver（识别预发布版）比较 registry 的版本列表与
+  `latest` dist-tag 和 pin；子模块检查报告比 pin 更新的上游 tag
+  （pin 恰好落在 tag 上时精确比较，落在 tag 之后的提交上时回退到 pin
+  提交时间），以及被跟踪分支领先 pin 的提交数。
+- 检查结果按主题各开一个 issue，打上 `upstream-watch` 标签，由
+  `github-actions[bot]` 使用 `GITHUB_TOKEN`（`issues: write`）创建。
+  已存在标题带该主题 `[upstream-watch] <subject>` 前缀的 open issue
+  即视为在跟踪、不再重复创建；若 issue 被关闭而 pin 未动，下一次运行
+  会重新提请该主题。
+- 任一主题的检查失败都会让 job 失败，而"发现新版本"退出码为 0——发现
+  是信号，不是故障。未设置 `GITHUB_TOKEN`/`UPSTREAM_WATCH_REPO`（或
+  传入 `--dry-run`）时脚本只输出报告，本地运行即处于该模式。
+
+## Alternatives considered
+
+- **Dependabot 或 Renovate**：npm pin 位于 `dsh-source.json` 而非包清单，
+  其 npm 生态看不到；其子模块更新会以 PR 直接移动 pin，绕过 pinned-source
+  规则要求的适配步骤。两个缺口都致命，故弃用。
+- **单个每日滚动汇总 issue**：单一主题串无法按主题关闭，而关闭正是维护者
+  标记"已处理"的方式；按主题开 issue 与按主题升级的流程一致。
+- **托管的第三方监控服务**：为一个定时 workflow 即可无服务器完成的任务
+  引入拥有仓库访问权的外部服务，得不偿失。
+
+## Consequences
+
+- 发现自动化、决策人工化：bot 绝不提 PR 或移动 pin，因为 DSH 的契约漂移
+  需要人工适配后各 surface 才能跟进。
+- 重复提醒是有意为之：只要 pin 落后于上游，issue 被关闭后的每次运行都会
+  重新开一个，因此"不适用"的关闭应当配上说明，或次日移动 pin。
+- GitHub 会在仓库 60 天无活动后停用 cron workflow；安静的仓库会悄悄停止
+  监控，直到任意一次 push 或一次 `workflow_dispatch` 运行将其恢复。
+- 每次运行的开销是一次 npm registry 请求加每个子模块约三次 GitHub API
+  调用——无需关心 token 配额。

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,46 @@
+name: Upstream watch
+
+on:
+  schedule:
+    # Daily at 01:17 UTC, off the half hour to dodge scheduled-workflow peaks.
+    - cron: '17 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: upstream-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: Watch upstream dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.21.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Watch upstream dependencies
+        run: node scripts/watch-upstream.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_WATCH_REPO: ${{ github.repository }}

--- a/scripts/watch-upstream.d.mts
+++ b/scripts/watch-upstream.d.mts
@@ -1,0 +1,39 @@
+export interface SubmoduleEntry {
+  readonly name: string
+  readonly path?: string
+  readonly url?: string
+  readonly branch?: string
+}
+
+export interface UpstreamTag {
+  readonly name: string
+  readonly sha: string
+  readonly date: string | null
+}
+
+export interface NpmVersionEntry {
+  readonly version: string
+  readonly date: string | null
+}
+
+export function parseSubmodules(text: string): SubmoduleEntry[]
+
+export function parseGitlinks(text: string): Map<string, string>
+
+export function npmVersionsNewerThan(pinned: string, versions: readonly string[]): string[]
+
+export function parseTagVersion(tag: string): string | null
+
+export function newerTagsThanPin(input: {
+  readonly tags: readonly UpstreamTag[]
+  readonly pinnedSha: string
+  readonly pinnedTag: string | undefined
+  readonly pinnedDate: string | null
+}): UpstreamTag[]
+
+export function watcherTitlePrefix(subjectKey: string): string
+
+export function findExistingIssue(
+  openTitles: readonly string[],
+  subjectKey: string,
+): string | null

--- a/scripts/watch-upstream.mjs
+++ b/scripts/watch-upstream.mjs
@@ -1,0 +1,341 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import semver from 'semver'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+export const WATCH_LABEL = 'upstream-watch'
+
+/** Parse a `.gitmodules` file into one record per `[submodule "..."]` section. */
+export function parseSubmodules(text) {
+  const entries = []
+  let current = null
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    const section = /^\[submodule\s+"(.+)"\]$/.exec(line)
+    if (section) {
+      current = { name: section[1] }
+      entries.push(current)
+      continue
+    }
+    const field = /^([a-zA-Z]+)\s*=\s*(.*)$/.exec(line)
+    if (field && current) current[field[1]] = field[2]
+  }
+  return entries.filter((entry) => entry.path && entry.url)
+}
+
+/** Parse `git ls-tree HEAD -- <paths>` output into path → pinned commit. */
+export function parseGitlinks(text) {
+  const links = new Map()
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^160000 commit ([0-9a-f]{40})\t(.+)$/.exec(line.trim())
+    if (match) links.set(match[2], match[1])
+  }
+  return links
+}
+
+/**
+ * Versions from an npm registry document strictly newer than `pinned`,
+ * newest first. Pre-release ordering follows semver, matching how the
+ * runtime-update comparator treats DSH releases.
+ */
+export function npmVersionsNewerThan(pinned, versions) {
+  return versions
+    .filter((version) => semver.valid(version) !== null && semver.gt(version, pinned))
+    .sort((a, b) => semver.rcompare(a, b))
+}
+
+/** Strip a leading `v` and return the version if it is valid semver. */
+export function parseTagVersion(tag) {
+  const stripped = tag.startsWith('v') ? tag.slice(1) : tag
+  return semver.valid(stripped)
+}
+
+/**
+ * Upstream tags newer than the pinned submodule revision. When the pin
+ * points exactly at a tag, newer means a greater semver tag; otherwise the
+ * pinned commit's date is the cutoff, because a pin past a tag (e.g.
+ * `v0.8.2-94-gbdff0af`) has no tag of its own to compare against.
+ */
+export function newerTagsThanPin({ tags, pinnedSha, pinnedTag, pinnedDate }) {
+  const pinnedVersion = pinnedTag === undefined ? null : parseTagVersion(pinnedTag)
+  const cutoff = Date.parse(pinnedDate ?? '')
+  return tags
+    .filter((tag) => {
+      const version = parseTagVersion(tag.name)
+      if (version === null) return false
+      if (tag.sha === pinnedSha) return false
+      if (pinnedVersion !== null) return semver.gt(version, pinnedVersion)
+      const tagDate = Date.parse(tag.date ?? '')
+      return !Number.isNaN(cutoff) && !Number.isNaN(tagDate) && tagDate > cutoff
+    })
+    .sort((a, b) => semver.rcompare(parseTagVersion(a.name), parseTagVersion(b.name)))
+}
+
+/** Stable per-subject prefix used both for issue titles and deduplication. */
+export function watcherTitlePrefix(subjectKey) {
+  return `[upstream-watch] ${subjectKey}`
+}
+
+/** The open issue already tracking this subject, if any. */
+export function findExistingIssue(openTitles, subjectKey) {
+  const prefix = watcherTitlePrefix(subjectKey)
+  return openTitles.find((title) => title.startsWith(prefix)) ?? null
+}
+
+function ownerRepoFromUrl(url) {
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/.exec(url)
+  return match === null ? null : `${match[1]}/${match[2]}`
+}
+
+async function fetchJson(url, token, options = {}) {
+  const headers = { accept: 'application/json' }
+  if (token !== undefined) headers.authorization = `Bearer ${token}`
+  if (options.body !== undefined) headers['content-type'] = 'application/json'
+  const response = await fetch(url, { ...options, headers })
+  if (!response.ok) throw new Error(`${url} responded ${response.status}`)
+  return response.json()
+}
+
+async function fetchNpmPackage(name) {
+  return fetchJson(`https://registry.npmjs.org/${encodeURIComponent(name)}`)
+}
+
+function githubApi(path, token) {
+  return fetchJson(`https://api.github.com${path}`, token)
+}
+
+async function checkNpmRuntime(source, token) {
+  if (source.source !== 'npm') {
+    console.log(`dsh-source.json pins a git source; skipping the npm watch`)
+    return null
+  }
+  const doc = await fetchNpmPackage(source.package)
+  const newer = npmVersionsNewerThan(source.version, Object.keys(doc.versions ?? {}))
+  return {
+    kind: 'npm',
+    key: source.package,
+    package: source.package,
+    pinned: source.version,
+    latest: doc['dist-tags']?.latest ?? null,
+    newer: newer.map((version) => ({ version, date: doc.time?.[version] ?? null })),
+  }
+}
+
+async function checkSubmodule(submodule, pinnedSha, token) {
+  const ownerRepo = ownerRepoFromUrl(submodule.url)
+  if (ownerRepo === null) {
+    throw new Error(`cannot derive a GitHub repository from ${submodule.url}`)
+  }
+  const branch = submodule.branch ?? 'main'
+  const tags = await githubApi(`/repos/${ownerRepo}/tags?per_page=100`, token)
+  const tagList = tags.map((tag) => ({ name: tag.name, sha: tag.commit.sha, date: null }))
+  const pinnedTag = tagList.find((tag) => tag.sha === pinnedSha)?.name
+  let pinnedDate = null
+  if (pinnedTag === undefined) {
+    const commit = await githubApi(`/repos/${ownerRepo}/commits/${pinnedSha}`, token)
+    pinnedDate = commit.commit.committer.date
+  }
+  const compare = await githubApi(`/repos/${ownerRepo}/compare/${pinnedSha}...${branch}`, token)
+  return {
+    kind: 'git',
+    key: submodule.path,
+    repo: ownerRepo,
+    branch,
+    pinnedSha,
+    pinnedTag: pinnedTag ?? null,
+    pinnedDate,
+    aheadBy: compare.ahead_by ?? 0,
+    newerTags: newerTagsThanPin({ tags: tagList, pinnedSha, pinnedTag, pinnedDate }),
+  }
+}
+
+function npmNeedsIssue(subject) {
+  return subject.newer.length > 0
+}
+
+function submoduleNeedsIssue(subject) {
+  return subject.newerTags.length > 0 || subject.aheadBy > 0
+}
+
+function formatDate(value) {
+  if (value === null || value === undefined) return 'unknown'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? String(value) : date.toISOString().slice(0, 10)
+}
+
+function npmIssue(subject) {
+  const title = `${watcherTitlePrefix(subject.key)} has newer releases (pinned ${subject.pinned})`
+  const rows = subject.newer
+    .map((entry) => `| ${entry.version} | ${formatDate(entry.date)} |`)
+    .join('\n')
+  const body = [
+    `The pinned DSH runtime \`${subject.package}\` is behind upstream.`,
+    '',
+    `- Pinned version: **${subject.pinned}** (dsh-source.json)`,
+    `- Current \`latest\` dist-tag: **${subject.latest ?? 'unknown'}**`,
+    '',
+    'Versions published after the pin:',
+    '',
+    '| Version | Published |',
+    '| --- | --- |',
+    rows,
+    '',
+    `Registry: https://www.npmjs.com/package/${subject.package}`,
+    '',
+    'Bumping the pin touches `dsh-source.json` and regenerates',
+    '`scripts/dsh-runtime-<version>-lock.yaml`; upstream contract changes',
+    'may need adaptation in `plugins/` before the surfaces can move.',
+    '',
+    'Reported automatically by the daily `Upstream watch` workflow. Close',
+    'this issue after bumping the pin, or as not applicable.',
+  ].join('\n')
+  return { title, body }
+}
+
+function submoduleIssue(subject) {
+  const title = `${watcherTitlePrefix(subject.key)} advanced beyond the pinned revision`
+  const pin = subject.pinnedTag ?? subject.pinnedSha.slice(0, 12)
+  const lines = [
+    `The pinned submodule \`${subject.key}\` is behind \`${subject.repo}\` branch \`${subject.branch}\`.`,
+    '',
+    `- Pinned revision: **${pin}**`,
+    `- Upstream \`${subject.branch}\` is **${subject.aheadBy}** commit(s) ahead`,
+  ]
+  if (subject.newerTags.length > 0) {
+    lines.push('', 'Tags newer than the pin:', '', '| Tag | Pushed |', '| --- | --- |')
+    for (const tag of subject.newerTags.slice(0, 5)) {
+      lines.push(`| ${tag.name} | ${formatDate(tag.date)} |`)
+    }
+  }
+  lines.push(
+    '',
+    `Compare: https://github.com/${subject.repo}/compare/${subject.pinnedSha.slice(0, 12)}...${subject.branch}`,
+    '',
+    'The pin moves via the git submodule pointer; upstream behavior changes',
+    'may need adaptation in `plugins/` per the pinned-source rule.',
+    '',
+    'Reported automatically by the daily `Upstream watch` workflow. Close',
+    'this issue after re-pinning, or as not applicable.',
+  )
+  return { title, body: lines.join('\n') }
+}
+
+async function ensureWatchLabel(token, repo) {
+  try {
+    await fetchJson(`https://api.github.com/repos/${repo}/labels`, token, {
+      method: 'POST',
+      body: JSON.stringify({ name: WATCH_LABEL, color: '5319e7', description: 'Automated upstream dependency watch' }),
+    })
+  } catch (error) {
+    // The label already exists (422); anything else falls through to the
+    // issue creation, which still works without it.
+    if (!String(error.message).includes('422')) console.warn(`label check: ${error.message}`)
+  }
+}
+
+async function listOpenWatcherTitles(token, repo) {
+  const issues = await githubApi(
+    `/repos/${repo}/issues?labels=${encodeURIComponent(WATCH_LABEL)}&state=open&per_page=100`,
+    token,
+  )
+  return issues.map((issue) => issue.title)
+}
+
+async function createIssue(token, repo, issue) {
+  const created = await fetchJson(`https://api.github.com/repos/${repo}/issues`, token, {
+    method: 'POST',
+    body: JSON.stringify({ title: issue.title, body: issue.body, labels: [WATCH_LABEL] }),
+  })
+  return created.html_url
+}
+
+function printSubject(subject) {
+  if (subject.kind === 'npm') {
+    const status = npmNeedsIssue(subject)
+      ? `${subject.newer.length} newer release(s), latest ${subject.latest}`
+      : `up to date (latest ${subject.latest ?? 'unknown'})`
+    console.log(`- npm ${subject.package}: pinned ${subject.pinned} — ${status}`)
+    return
+  }
+  const status = submoduleNeedsIssue(subject)
+    ? `${subject.aheadBy} commit(s) ahead, newer tags: ${subject.newerTags.map((tag) => tag.name).join(', ') || 'none'}`
+    : 'up to date'
+  console.log(`- ${subject.key} (${subject.repo}@${subject.branch}): ${status}`)
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+  const token = process.env.GITHUB_TOKEN
+  const repo = process.env.UPSTREAM_WATCH_REPO
+
+  const source = JSON.parse(readFileSync(join(root, 'dsh-source.json'), 'utf8'))
+  const submodules = parseSubmodules(readFileSync(join(root, '.gitmodules'), 'utf8'))
+  const gitlinks = parseGitlinks(
+    execFileSync('git', ['ls-tree', 'HEAD', '--', ...submodules.map((entry) => entry.path)], {
+      cwd: root,
+      encoding: 'utf8',
+    }),
+  )
+
+  const subjects = []
+  const failures = []
+  const npmSubject = await checkNpmRuntime(source, token).catch((error) => {
+    failures.push(`npm runtime: ${error.message}`)
+    return null
+  })
+  if (npmSubject !== null) subjects.push(npmSubject)
+  for (const submodule of submodules) {
+    const pinnedSha = gitlinks.get(submodule.path)
+    if (pinnedSha === undefined) {
+      failures.push(`${submodule.path}: no pinned gitlink in HEAD`)
+      continue
+    }
+    const subject = await checkSubmodule(submodule, pinnedSha, token).catch((error) => {
+      failures.push(`${submodule.path}: ${error.message}`)
+      return null
+    })
+    if (subject !== null) subjects.push(subject)
+  }
+
+  console.log('Upstream watch report:')
+  for (const subject of subjects) printSubject(subject)
+  for (const failure of failures) console.warn(`! ${failure}`)
+
+  const pending = subjects.filter((subject) =>
+    subject.kind === 'npm' ? npmNeedsIssue(subject) : submoduleNeedsIssue(subject),
+  )
+  if (pending.length === 0) {
+    console.log('No upstream updates to report.')
+    process.exit(failures.length > 0 ? 1 : 0)
+  }
+
+  if (token === undefined || repo === undefined || dryRun) {
+    console.log('Report-only mode; would file issues for:')
+    for (const subject of pending) {
+      const issue = subject.kind === 'npm' ? npmIssue(subject) : submoduleIssue(subject)
+      console.log(`- ${issue.title}`)
+    }
+    process.exit(failures.length > 0 ? 1 : 0)
+  }
+
+  await ensureWatchLabel(token, repo)
+  const openTitles = await listOpenWatcherTitles(token, repo)
+  for (const subject of pending) {
+    const issue = subject.kind === 'npm' ? npmIssue(subject) : submoduleIssue(subject)
+    const existing = findExistingIssue(openTitles, subject.key)
+    if (existing !== null) {
+      console.log(`already tracked: ${existing}`)
+      continue
+    }
+    const url = await createIssue(token, repo, issue)
+    console.log(`created ${url}`)
+  }
+  process.exit(failures.length > 0 ? 1 : 0)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/tests/upstream-watch.test.ts
+++ b/tests/upstream-watch.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  findExistingIssue,
+  newerTagsThanPin,
+  npmVersionsNewerThan,
+  parseGitlinks,
+  parseSubmodules,
+  parseTagVersion,
+  watcherTitlePrefix,
+} from '../scripts/watch-upstream.mjs'
+
+test('parseSubmodules reads every pinned upstream record', () => {
+  const entries = parseSubmodules(
+    [
+      '[submodule "upstream/DSH-better-sidebar"]',
+      '\tpath = upstream/DSH-better-sidebar',
+      '\turl = https://github.com/omdsh-dev/DSH-better-sidebar.git',
+      '\tbranch = main',
+      '[submodule "upstream/dsh-TUI"]',
+      '\tpath = upstream/dsh-TUI',
+      '\turl = https://github.com/ccch1mneyyy/dsh-TUI.git',
+      '\tbranch = main',
+    ].join('\n'),
+  )
+
+  assert.deepEqual(entries, [
+    {
+      name: 'upstream/DSH-better-sidebar',
+      path: 'upstream/DSH-better-sidebar',
+      url: 'https://github.com/omdsh-dev/DSH-better-sidebar.git',
+      branch: 'main',
+    },
+    {
+      name: 'upstream/dsh-TUI',
+      path: 'upstream/dsh-TUI',
+      url: 'https://github.com/ccch1mneyyy/dsh-TUI.git',
+      branch: 'main',
+    },
+  ])
+})
+
+test('parseGitlinks maps submodule paths to pinned commits', () => {
+  const links = parseGitlinks(
+    [
+      '160000 commit f0965e1d6157a3e06ed2f5c7775a64428d5d3c29\tupstream/DSH-better-sidebar',
+      '160000 commit bdff0afb028d50c304e4474fd40f83b0721d50fd\tupstream/dsh-TUI',
+      '100644 blob 0000000000000000000000000000000000000000\tsrc/other.ts',
+    ].join('\n'),
+  )
+
+  assert.equal(links.size, 2)
+  assert.equal(links.get('upstream/dsh-TUI'), 'bdff0afb028d50c304e4474fd40f83b0721d50fd')
+})
+
+test('npmVersionsNewerThan orders DSH pre-releases after their final release', () => {
+  assert.deepEqual(
+    npmVersionsNewerThan('0.1.1-rc.2', ['0.1.0', '0.1.1-rc.1', '0.1.1-rc.2', '0.1.1-rc.3', '0.1.1']),
+    ['0.1.1', '0.1.1-rc.3'],
+  )
+  assert.deepEqual(npmVersionsNewerThan('0.1.1', ['0.1.1', '0.1.0-rc.7']), [])
+})
+
+test('parseTagVersion accepts v-prefixed semver tags only', () => {
+  assert.equal(parseTagVersion('v0.15.0'), '0.15.0')
+  assert.equal(parseTagVersion('0.8.2'), '0.8.2')
+  assert.equal(parseTagVersion('nightly-20260823'), null)
+})
+
+test('newerTagsThanPin compares against the pinned tag when the pin is a tag', () => {
+  const tags = [
+    { name: 'v0.15.0', sha: 'a'.repeat(40), date: null },
+    { name: 'v0.16.0', sha: 'b'.repeat(40), date: null },
+    { name: 'nightly', sha: 'c'.repeat(40), date: null },
+  ]
+
+  const newer = newerTagsThanPin({
+    tags,
+    pinnedSha: 'a'.repeat(40),
+    pinnedTag: 'v0.15.0',
+    pinnedDate: null,
+  })
+
+  assert.deepEqual(newer.map((tag) => tag.name), ['v0.16.0'])
+})
+
+test('newerTagsThanPin falls back to the pinned commit date past a tag pin', () => {
+  const tags = [
+    { name: 'v0.8.2', sha: 'a'.repeat(40), date: '2026-07-01T00:00:00Z' },
+    { name: 'v0.8.8', sha: 'b'.repeat(40), date: '2026-08-20T00:00:00Z' },
+    { name: 'v0.9.0', sha: 'c'.repeat(40), date: '2026-06-01T00:00:00Z' },
+  ]
+
+  const newer = newerTagsThanPin({
+    tags,
+    pinnedSha: 'd'.repeat(40),
+    pinnedTag: undefined,
+    pinnedDate: '2026-08-01T00:00:00Z',
+  })
+
+  assert.deepEqual(newer.map((tag) => tag.name), ['v0.8.8'])
+})
+
+test('watcher issues deduplicate by subject-key title prefix', () => {
+  const openTitles = [
+    '[upstream-watch] @deepseek-ai/dsh has newer releases (pinned 0.1.1-rc.2)',
+    'Unrelated issue title',
+  ]
+
+  assert.equal(
+    findExistingIssue(openTitles, '@deepseek-ai/dsh'),
+    '[upstream-watch] @deepseek-ai/dsh has newer releases (pinned 0.1.1-rc.2)',
+  )
+  assert.equal(findExistingIssue(openTitles, 'upstream/dsh-TUI'), null)
+  assert.equal(watcherTitlePrefix('upstream/dsh-TUI'), '[upstream-watch] upstream/dsh-TUI')
+})


### PR DESCRIPTION
## Scope

Adds a daily automated upstream watch that files issues from
`github-actions[bot]` when our pinned upstream dependencies fall
behind:

- **`@deepseek-ai/dsh` npm runtime** — compared against the npm
  registry versions and `latest` dist-tag, using the pin already
  recorded in `dsh-source.json`.
- **`upstream/` plugin submodules** (`DSH-better-sidebar`, `dsh-TUI`)
  — compared against upstream tags and branch movement, using the
  gitlinks already recorded in HEAD.

Mechanics:

- `.github/workflows/upstream-watch.yml`: daily cron (01:17 UTC) plus
  `workflow_dispatch`; permissions are `contents: read` and
  `issues: write` only.
- `scripts/watch-upstream.mjs` (+ `.d.mts` declarations): reads pins
  from the repository itself, so there is no second version inventory
  to maintain. Report-only without `GITHUB_TOKEN` /
  `UPSTREAM_WATCH_REPO`, and with `--dry-run`.
- One labeled (`upstream-watch`) issue per behind-pin subject; an open
  issue carrying the subject's `[upstream-watch] <subject>` title
  prefix suppresses duplicates. Finding updates exits 0; a failed
  subject check fails the job so breakage is visible.
- New `tests/upstream-watch.test.ts` covers the pure helpers (module
  parsing, semver ordering incl. DSH pre-releases, tag-vs-pin
  comparison, issue dedup).
- Agent Note triplet under
  `.agents/notes/implemented/process/2026-08-23-upstream-dependency-watch.*`
  records why bot-filed issues (not Dependabot/Renovate auto-PRs) fit
  the hand-adaptation bump flow.

## Verification

- `node scripts/watch-upstream.mjs` (live, report-only): npm pin up to
  date at `0.1.1-rc.2`; `DSH-better-sidebar` 28 commits ahead with
  newer tags `v0.15.1`/`v0.15.2`; `dsh-TUI` 137 commits ahead with
  newer tag `v0.9.0` — the first post-merge run will file those two
  issues.
- `pnpm run typecheck`, `pnpm test` (226 tests, 0 failures),
  `pnpm run build`, `pnpm run verify:agent-notes`, and
  `pnpm run verify-translation-pairing` all pass.
- Workflow YAML validated with the repository `yaml` dependency.

## Notes

- The bot never opens PRs or moves pins; DSH bumps need contract
  adaptation in `plugins/`, so notification issues match the existing
  `upstream/dependencies-*` bump flow.
- GitHub disables cron workflows after 60 days of repository
  inactivity; `workflow_dispatch` keeps the watch runnable regardless.