### PR TITLE
desktop: suppress the default-browser auto-open on the desktop surface

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
+2026-08-24-desktop-suppress-auto-browser-open.md: 31b9681248c152335b0454ad8d6dac0661589e70
+2026-08-24-desktop-suppress-auto-browser-open.zh.md: e6ba6080e520b81ca77545762863d6c91a2d16c6

--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
@@ -1,0 +1,31 @@
+# Agent Note: Suppress the desktop surface's default-browser auto-open
+
+Status: implemented
+
+English | [中文](2026-08-24-desktop-suppress-auto-browser-open.zh.md)
+
+## Problem
+
+Since dsh 0.1.0-rc.8 the `web-app` bundle auto-opens the OS default browser after its webserver settles: `dsh --profile web` now serves and hands the URL to the browser unless `--no-open` is passed. Oh-DSH Desktop embeds that same bundle (`@deepseek-ai/dsh-web-app` is in `DESKTOP_BUNDLES`), so launching the desktop surface also opened a second browser tab at the loopback URL — even though the Electron shell already carves its own window and loads that exact URL itself.
+
+The desktop's profile patch overrides the `web-runtime` row's config (`printUrl: true`, `surfaceContext: false`, `trustedHosts: []`) but did not set `openBrowser`, so the row fell through to the bundle's schema default of `true`.
+
+## Decision
+
+The desktop `cordis.patch.yml` (`web-runtime` row) now sets `openBrowser: false`. This keeps `printUrl: true`, so the runtime still prints `dsh web: <url>` and the supervisor's readiness line still fires. The desktop shell is the sole opener of that URL; the OS default browser is never handed the URL.
+
+The standalone web surface is unaffected: `web/cordis.patch.yml` does not restate `web-runtime`, so the web profile resolves `openBrowser` dynamically from `ctx.webStartup.openBrowser` (the `--open`/`--no-open` flag family the `web-startup` plugin parses). The TUI profile does not bundle `web-app` at all.
+
+## Alternatives considered
+
+**Pass `--no-open` on the desktop runtime's spawned args.** Rejected because it couples the launcher to an upstream flag that may be renamed or removed, and the flag only exists for the `web` command line; the desktop already owns the surface's open behavior through its own patch config. Setting the config in the patch keeps the decision in the surface that makes it.
+
+**Set `openBrowser` only when a `--open`/`--no-open` flag is present.** Rejected because the desktop does not expose those flags and never wants the handoff regardless of argv; a static `false` is unambiguous.
+
+**Reuse the upstream `--no-open` default by removing the desktop's `web-runtime` override.** Rejected because the desktop override exists (it already replaces `printUrl`/`surfaceContext`/`trustedHosts`), and removing it would also drop those deliberate values.
+
+## Consequences
+
+The desktop no longer opens a second browser window. The URL line still prints, so desktop runtime supervision and the packaged web launcher remain unchanged. The `openBrowser` config now has a static default on the desktop surface, whose value is owned by the desktop distribution rather than the upstream bundle.
+
+Pinned DSH releases newer than rc.2 keep the auto-open in `web-app`; the desktop patch pins it off regardless. Anyone running `ohdsh web` still gets the upstream default-browser handoff (and `--no-open` still works there).

--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.zh.md
@@ -1,0 +1,31 @@
+# Agent Note: 抑制桌面界面的默认浏览器自动打开
+
+Status: implemented
+
+[English](2026-08-24-desktop-suppress-auto-browser-open.md) | 中文
+
+## 问题
+
+自 dsh 0.1.0-rc.8 起，`web-app` bundle 在 webserver 启动完成后会自动打开系统默认浏览器：`dsh --profile web` 现在会在服务就绪后把 URL 交给浏览器，除非传入 `--no-open`。Oh-DSH Desktop 内嵌了同一个 bundle（`@deepseek-ai/dsh-web-app` 在 `DESKTOP_BUNDLES` 中），因此启动桌面界面时也会额外打开一个指向 loopback URL 的浏览器标签页——即使 Electron 外壳本身已经绘制了自己的窗口并加载完全相同的 URL。
+
+桌面 profile 的 patch 覆盖了 `web-runtime` 这个 row 的配置（`printUrl: true`、`surfaceContext: false`、`trustedHosts: []`），但未设置 `openBrowser`，于是该行回退到 bundle 的 schema 默认值 `true`。
+
+## 决策
+
+桌面 `cordis.patch.yml`（`web-runtime` 行）现在设置 `openBrowser: false`。这保留了 `printUrl: true`，因此运行时仍会打印 `dsh web: <url>`，supervisor 的就绪行仍会触发。桌面外壳是该 URL 的唯一打开者；系统默认浏览器永远不会被交给该 URL。
+
+独立的 web 界面不受影响：`web/cordis.patch.yml` 没有重新声明 `web-runtime`，所以 web profile 仍然动态地从 `ctx.webStartup.openBrowser` 解析 `openBrowser`（即 `web-startup` 插件解析的 `--open`/`--no-open` 标志族）。TUI profile 完全不打包 `web-app`。
+
+## 备选方案
+
+**在桌面运行时的 spawn 参数上加 `--no-open`。** 被否决，因为这会把启动器与一个上游标志耦合，该标志可能被改名或移除，而且该标志只为 `web` 命令行存在；桌面已经通过自己的 patch 配置拥有界面的打开行为。把决定放在 patch 里，能落在做出该决定的那个界面上。
+
+**仅在出现 `--open`/`--no-open` 标志时设置 `openBrowser`。** 被否决，因为桌面不暴露这些标志，而且无论 argv 是什么它都不想要交棒；一个静态的 `false` 是不含糊的。
+
+**通过移除桌面的 `web-runtime` 覆盖来复用上游的 `--no-open` 默认值。** 被否决，因为桌面覆盖本来就存在（它已经替换了 `printUrl`/`surfaceContext`/`trustedHosts`），移除它也会丢掉这些有意设置的值。
+
+## 影响
+
+桌面不再打开第二个浏览器窗口。URL 行仍然打印，所以桌面运行时监督与打包的 web 启动器保持不变。`openBrowser` 配置现在在桌面界面上有一个静态默认值，其取值由桌面发行版决定，而非上游 bundle。
+
+比 rc.2 更新的已固定 DSH 版本在 `web-app` 中仍保留自动打开；桌面 patch 无论如何都把它固定为关闭。任何运行 `ohdsh web` 的人仍然获得上游的默认浏览器交棒（且 `--no-open` 在那里仍然有效）。

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -9,6 +9,9 @@
 
 - id: web-runtime
   config:
+    # The Electron surface carves its own window; never hand the URL to the
+    # OS default browser (dsh-web-app would otherwise auto-open since rc.8).
+    openBrowser: false
     printUrl: true
     surfaceContext: false
     trustedHosts: []


### PR DESCRIPTION
Since dsh 0.1.0-rc.8 the bundled dsh-web-app auto-opens the OS default browser after its webserver settles, unless --no-open is passed. The desktop surface embeds that bundle, so launching the Electron app also opened a second browser tab at the loopback URL even though the shell carves its own window and loads that URL itself.

Set openBrowser: false on the desktop web-runtime row so the OS browser is never handed the URL; printUrl stays on so the supervisor readiness line still fires. The web surface keeps resolving openBrowser from ctx.webStartup.openBrowser (--open/--no-open), so `dsh web` behaviour is unchanged, and the TUI profile does not bundle dsh-web-app at all.

Verified with a live desktop run (no browser opened) and a config dump for both desktop (openBrowser: false) and web (dynamic webStartup).