### PR TITLE
web: pass --no-open to the runtime so the launcher owns handoff

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
-2026-08-24-desktop-suppress-auto-browser-open.md: 31b9681248c152335b0454ad8d6dac0661589e70
-2026-08-24-desktop-suppress-auto-browser-open.zh.md: e6ba6080e520b81ca77545762863d6c91a2d16c6
+2026-08-24-desktop-suppress-auto-browser-open.md: 0c689f03c2255cb1d278097399cd3861a6b0b8d4
+2026-08-24-desktop-suppress-auto-browser-open.zh.md: c67e789f2935433b6e42016932fd073dbbb9d4f4

--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
@@ -3,4 +3,4 @@
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
 2026-08-24-desktop-suppress-auto-browser-open.md: 70362bad39a44d84548f88f02c46c8632c2a726b
-2026-08-24-desktop-suppress-auto-browser-open.zh.md: 27d3bf137905493db7ac498c7cba66f23368cee8
+2026-08-24-desktop-suppress-auto-browser-open.zh.md: a276921b107b8ae1a40d1b8db6cd8fc6f50f8b56

--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
-2026-08-24-desktop-suppress-auto-browser-open.md: 0c689f03c2255cb1d278097399cd3861a6b0b8d4
-2026-08-24-desktop-suppress-auto-browser-open.zh.md: c67e789f2935433b6e42016932fd073dbbb9d4f4
+2026-08-24-desktop-suppress-auto-browser-open.md: 70362bad39a44d84548f88f02c46c8632c2a726b
+2026-08-24-desktop-suppress-auto-browser-open.zh.md: 27d3bf137905493db7ac498c7cba66f23368cee8

--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.md
@@ -28,4 +28,4 @@ The standalone web surface is unaffected: `web/cordis.patch.yml` does not restat
 
 The desktop no longer opens a second browser window. The URL line still prints, so desktop runtime supervision and the packaged web launcher remain unchanged. The `openBrowser` config now has a static default on the desktop surface, whose value is owned by the desktop distribution rather than the upstream bundle.
 
-Pinned DSH releases newer than rc.2 keep the auto-open in `web-app`; the desktop patch pins it off regardless. Anyone running `ohdsh web` still gets the upstream default-browser handoff (and `--no-open` still works there).
+Pinned DSH releases newer than rc.2 keep the auto-open in `web-app`; the desktop patch pins it off regardless. The `ohdsh web` launcher no longer receives the upstream handoff: since it started passing `--no-open` to the runtime (see [2026-08-24-web-launcher-owns-browser-handoff](2026-08-24-web-launcher-owns-browser-handoff.md)), the launcher is the sole owner of that surface's browser handoff, and a standalone `dsh --profile web` keeps the upstream interactive default.

--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.zh.md
@@ -28,4 +28,4 @@ Status: implemented
 
 桌面不再打开第二个浏览器窗口。URL 行仍然打印，所以桌面运行时监督与打包的 web 启动器保持不变。`openBrowser` 配置现在在桌面界面上有一个静态默认值，其取值由桌面发行版决定，而非上游 bundle。
 
-比 rc.2 更新的已固定 DSH 版本在 `web-app` 中仍保留自动打开；桌面 patch 无论如何都把它固定为关闭。`ohdsh web` 启动器不再获得上游交棒：自它开始向 runtime 传递 `--no-open` 起（见 [2026-08-24-web-launcher-owns-browser-handoff.zh](2026-08-24-web-launcher-owns-browser-handoff.zh.md)），该界面的浏览器交棒由启动器独占持有，独立的 `dsh --profile web` 保留上游交互式默认。
+比 rc.2 更新的已固定 DSH 版本在 `web-app` 中仍保留自动打开；桌面 patch 无论如何都把它固定为关闭。`ohdsh web` 启动器不再获得上游交棒：自它开始向 runtime 传递 `--no-open` 起（见 [2026-08-24-web-launcher-owns-browser-handoff](2026-08-24-web-launcher-owns-browser-handoff.md)），该界面的浏览器交棒由启动器独占持有，独立的 `dsh --profile web` 保留上游交互式默认。

--- a/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-desktop-suppress-auto-browser-open.zh.md
@@ -28,4 +28,4 @@ Status: implemented
 
 桌面不再打开第二个浏览器窗口。URL 行仍然打印，所以桌面运行时监督与打包的 web 启动器保持不变。`openBrowser` 配置现在在桌面界面上有一个静态默认值，其取值由桌面发行版决定，而非上游 bundle。
 
-比 rc.2 更新的已固定 DSH 版本在 `web-app` 中仍保留自动打开；桌面 patch 无论如何都把它固定为关闭。任何运行 `ohdsh web` 的人仍然获得上游的默认浏览器交棒（且 `--no-open` 在那里仍然有效）。
+比 rc.2 更新的已固定 DSH 版本在 `web-app` 中仍保留自动打开；桌面 patch 无论如何都把它固定为关闭。`ohdsh web` 启动器不再获得上游交棒：自它开始向 runtime 传递 `--no-open` 起（见 [2026-08-24-web-launcher-owns-browser-handoff.zh](2026-08-24-web-launcher-owns-browser-handoff.zh.md)），该界面的浏览器交棒由启动器独占持有，独立的 `dsh --profile web` 保留上游交互式默认。

--- a/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.md
-2026-08-24-web-launcher-owns-browser-handoff.md: 36d85f92a80fa3e1691161fb237d6913ad4b4c50
-2026-08-24-web-launcher-owns-browser-handoff.zh.md: b69d4c15bdde74c7fbcb98c52df71531c0b8d3d8
+2026-08-24-web-launcher-owns-browser-handoff.md: a656ccd072084bd4550412f29d06cf6bc03adb47
+2026-08-24-web-launcher-owns-browser-handoff.zh.md: b519768d0b587eaa78beb5c711c5bbfc2eabab14

--- a/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.md
+2026-08-24-web-launcher-owns-browser-handoff.md: 66d4e93c9e6d3434db112d304f069ec7496ea954
+2026-08-24-web-launcher-owns-browser-handoff.zh.md: 9cfbace34a9e448cf59f7f750618208f80b306b5

--- a/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.md
-2026-08-24-web-launcher-owns-browser-handoff.md: 66d4e93c9e6d3434db112d304f069ec7496ea954
-2026-08-24-web-launcher-owns-browser-handoff.zh.md: 9cfbace34a9e448cf59f7f750618208f80b306b5
+2026-08-24-web-launcher-owns-browser-handoff.md: 36d85f92a80fa3e1691161fb237d6913ad4b4c50
+2026-08-24-web-launcher-owns-browser-handoff.zh.md: b69d4c15bdde74c7fbcb98c52df71531c0b8d3d8

--- a/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.md
@@ -10,7 +10,7 @@ DSH runtime 0.1.1-rc.2 (#122) gave `@deepseek-ai/dsh-web-app` a browser handoff 
 
 ## Decision
 
-The launcher passes `--no-open` in the runtime spawn args, next to the existing `--host`/`--port`/`--trusted-host` flags it already routes over the same `webStartup` seam. The launcher remains the single decision point for opening the browser: its `--open`/`--no-open` flags, its `stdout.isTTY` interactive default, and the `DSH_OH_WEB_OPEN` env override all keep working, and the bundle never hand the URL to the OS browser.
+The launcher passes `--no-open` in the runtime spawn args, next to the existing `--host`/`--port`/`--trusted-host` flags it already routes over the same `webStartup` seam. The launcher remains the single decision point for opening the browser: its `--open`/`--no-open` flags, its `stdout.isTTY` interactive default, and the `DSH_OH_WEB_OPEN` env override all keep working, and the bundle never hands the URL to the OS browser.
 
 ## Alternatives considered
 
@@ -18,4 +18,4 @@ The launcher passes `--no-open` in the runtime spawn args, next to the existing 
 
 ## Consequences
 
-`ohdsh web` opens exactly one tab (or zero with `--no-open`, or one forced with `--open`); standalone `dsh --profile web` keeps its upstream interactive default. If a future runtime revision renames or removes `--no-open`, the launcher fails loudly at runtime startup instead of silently double-opening. Verified live in a real PTY for all three flag paths, plus `pnpm run typecheck` and the existing test suite (228 pass; the 3 failures are the pre-existing Nix-only tests that cannot run on Windows).
+`ohdsh web` opens exactly one tab (or zero with `--no-open`, or one forced with `--open`); standalone `dsh --profile web` keeps its upstream interactive default. If a future runtime revision renames or removes `--no-open`, the launcher fails loudly at runtime startup instead of silently double-opening. Verified live in a real PTY for all three flag paths, plus `pnpm run typecheck` and a run of the existing test suite (228 passing; 3 pre-existing Nix-only tests cannot run on Windows).

--- a/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.md
@@ -1,0 +1,21 @@
+# Agent Note: the oh-dsh web launcher owns the browser handoff
+
+Status: implemented
+
+English | [中文](2026-08-24-web-launcher-owns-browser-handoff.zh.md)
+
+## Problem
+
+DSH runtime 0.1.1-rc.2 (#122) gave `@deepseek-ai/dsh-web-app` a browser handoff driven by the `webStartup` service: the row resolves `openBrowser: !!js ctx.webStartup.openBrowser`, and the web-startup plugin defaults that value to `true` when no open flag is passed. PR #132 pinned `openBrowser: false` on the desktop surface's `web-runtime` row, but the Oh-DSH Web launcher (`src/web.ts`) spawns the runtime with only `--profile web --host --port --trusted-host` and never passes an open flag, so `webStartup.openBrowser` resolved to `true`: the bundle opened a second tab on top of the launcher's own handoff, and `ohdsh web --no-open` only silenced the launcher while the bundle still opened one tab.
+
+## Decision
+
+The launcher passes `--no-open` in the runtime spawn args, next to the existing `--host`/`--port`/`--trusted-host` flags it already routes over the same `webStartup` seam. The launcher remains the single decision point for opening the browser: its `--open`/`--no-open` flags, its `stdout.isTTY` interactive default, and the `DSH_OH_WEB_OPEN` env override all keep working, and the bundle never hand the URL to the OS browser.
+
+## Alternatives considered
+
+**Pin `openBrowser: false` in `web/cordis.patch.yml`.** Rejected because the web profile is also reachable standalone via `dsh --profile web`, where the upstream interactive open is the intended UX; a patch pin would suppress it for everyone. The flag keeps the suppression scoped to the launcher path.
+
+## Consequences
+
+`ohdsh web` opens exactly one tab (or zero with `--no-open`, or one forced with `--open`); standalone `dsh --profile web` keeps its upstream interactive default. If a future runtime revision renames or removes `--no-open`, the launcher fails loudly at runtime startup instead of silently double-opening. Verified live in a real PTY for all three flag paths, plus `pnpm run typecheck` and the existing test suite (228 pass; the 3 failures are the pre-existing Nix-only tests that cannot run on Windows).

--- a/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.zh.md
@@ -1,0 +1,21 @@
+# Agent Note: 浏览器移交由 oh-dsh web 启动器独占持有
+
+Status: implemented
+
+[English](2026-08-24-web-launcher-owns-browser-handoff.md) | 中文
+
+## 问题
+
+DSH runtime 0.1.1-rc.2(#122)为 `@deepseek-ai/dsh-web-app` 引入了由 `webStartup` 服务驱动的浏览器移交：行配置解析 `openBrowser: !!js ctx.webStartup.openBrowser`,web-startup 插件在未传 open 旗标时将该值默认为 `true`。PR #132 在 desktop surface 的 `web-runtime` 行上固定了 `openBrowser: false`,但 Oh-DSH Web 启动器(`src/web.ts`)spawn runtime 时只传 `--profile web --host --port --trusted-host`,从不传 open 旗标,于是 `webStartup.openBrowser` 解析为 `true`：bundle 在启动器自己的移交之上又开了一个标签页,且 `ohdsh web --no-open` 只能让启动器闭嘴,bundle 照开一个。
+
+## 决策
+
+启动器在 runtime spawn 参数里加 `--no-open`,与它已经经由同一条 `webStartup` seam 传递的 `--host`/`--port`/`--trusted-host` 并列。启动器保持为打开浏览器的唯一决策点：它的 `--open`/`--no-open` 旗标、`stdout.isTTY` 交互默认、`DSH_OH_WEB_OPEN` 环境变量覆盖全部继续有效,bundle 不再把 URL 交给系统浏览器。
+
+## 考虑过的替代方案
+
+**在 `web/cordis.patch.yml` 固定 `openBrowser: false`。** 否决：web profile 也可被独立 `dsh --profile web` 访问,那里上游的交互式默认打开是预期 UX;patch pin 会对所有人取消它。旗标方案把抑制限定在 launcher 路径。
+
+## 后果
+
+`ohdsh web` 恰好开一个标签页(`--no-open` 时零个,`--open` 强制时一个);独立 `dsh --profile web` 保留上游交互默认。若未来 runtime 版本重命名或移除 `--no-open`,启动器会在 runtime 启动时大声失败,而不是静默双开。已在真实 PTY 下对三条旗标路径活体验证,`pnpm run typecheck` 与既有测试套件通过(228 通过;3 个失败是 Windows 上无法运行的 Nix-only 既有测试)。

--- a/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-24-web-launcher-owns-browser-handoff.zh.md
@@ -6,16 +6,16 @@ Status: implemented
 
 ## 问题
 
-DSH runtime 0.1.1-rc.2(#122)为 `@deepseek-ai/dsh-web-app` 引入了由 `webStartup` 服务驱动的浏览器移交：行配置解析 `openBrowser: !!js ctx.webStartup.openBrowser`,web-startup 插件在未传 open 旗标时将该值默认为 `true`。PR #132 在 desktop surface 的 `web-runtime` 行上固定了 `openBrowser: false`,但 Oh-DSH Web 启动器(`src/web.ts`)spawn runtime 时只传 `--profile web --host --port --trusted-host`,从不传 open 旗标,于是 `webStartup.openBrowser` 解析为 `true`：bundle 在启动器自己的移交之上又开了一个标签页,且 `ohdsh web --no-open` 只能让启动器闭嘴,bundle 照开一个。
+DSH runtime 0.1.1-rc.2（#122）为 `@deepseek-ai/dsh-web-app` 引入了由 `webStartup` 服务驱动的浏览器移交：该行解析 `openBrowser: !!js ctx.webStartup.openBrowser`，而 web-startup 插件在未传入 open 旗标时将该值默认为 `true`。PR #132 在 desktop surface 的 `web-runtime` 行中固定了 `openBrowser: false`，但 Oh-DSH Web 启动器（`src/web.ts`）启动 runtime 时只传入 `--profile web --host --port --trusted-host`，从不传入 open 旗标，因此 `webStartup.openBrowser` 解析为 `true`：捆绑包在启动器自身的移交之外又打开一个标签页，而且 `ohdsh web --no-open` 只会让启动器不打开浏览器，捆绑包仍会打开一个标签页。
 
 ## 决策
 
-启动器在 runtime spawn 参数里加 `--no-open`,与它已经经由同一条 `webStartup` seam 传递的 `--host`/`--port`/`--trusted-host` 并列。启动器保持为打开浏览器的唯一决策点：它的 `--open`/`--no-open` 旗标、`stdout.isTTY` 交互默认、`DSH_OH_WEB_OPEN` 环境变量覆盖全部继续有效,bundle 不再把 URL 交给系统浏览器。
+启动器在 runtime 启动参数中添加 `--no-open`，并将其与已通过同一 `webStartup` 接口传递的 `--host`/`--port`/`--trusted-host` 旗标并列。启动器仍是打开浏览器的唯一决策点：其 `--open`/`--no-open` 旗标、`stdout.isTTY` 交互式默认值和 `DSH_OH_WEB_OPEN` 环境变量覆盖均继续有效，捆绑包不再将 URL 交给操作系统浏览器。
 
 ## 考虑过的替代方案
 
-**在 `web/cordis.patch.yml` 固定 `openBrowser: false`。** 否决：web profile 也可被独立 `dsh --profile web` 访问,那里上游的交互式默认打开是预期 UX;patch pin 会对所有人取消它。旗标方案把抑制限定在 launcher 路径。
+**在 `web/cordis.patch.yml` 中固定 `openBrowser: false`。** 已否决，因为 web profile 也可通过独立的 `dsh --profile web` 访问，此时上游的交互式打开行为是预期 UX；配置固定会为所有人禁用这一行为。旗标方案将抑制范围限制在启动器路径。
 
 ## 后果
 
-`ohdsh web` 恰好开一个标签页(`--no-open` 时零个,`--open` 强制时一个);独立 `dsh --profile web` 保留上游交互默认。若未来 runtime 版本重命名或移除 `--no-open`,启动器会在 runtime 启动时大声失败,而不是静默双开。已在真实 PTY 下对三条旗标路径活体验证,`pnpm run typecheck` 与既有测试套件通过(228 通过;3 个失败是 Windows 上无法运行的 Nix-only 既有测试)。
+`ohdsh web` 恰好打开一个标签页（使用 `--no-open` 时为零个，使用 `--open` 强制时为一个）；独立的 `dsh --profile web` 保留上游交互式默认行为。若未来 runtime 版本重命名或移除 `--no-open`，启动器会在 runtime 启动时明确失败，而不会静默地双开标签页。已在真实 PTY 中对全部三条旗标路径完成活体验证，也已运行 `pnpm run typecheck` 和既有测试套件（228 个通过；3 个既有的 Nix-only 测试无法在 Windows 上运行）。

--- a/src/web.ts
+++ b/src/web.ts
@@ -261,6 +261,10 @@ export async function main(
       '--host', options.host,
       '--port', String(options.port),
       ...options.trustedHosts.flatMap(host => ['--trusted-host', host]),
+      // The launcher owns the browser handoff (--open/--no-open, interactive
+      // default, DSH_OH_WEB_OPEN below); without this flag dsh-web-app's
+      // webStartup default would open a second tab on top of it.
+      '--no-open',
     ],
     cliEntry: paths.cliEntry,
     cwd: dataRoot,

--- a/tests/web-profile.test.ts
+++ b/tests/web-profile.test.ts
@@ -230,6 +230,7 @@ test('web launcher resolves a relative data root before spawning the runtime', a
     )
     assert.equal(code, 1)
     assert.ok(runtime)
+    assert.equal(runtime.plan.args.includes('--no-open'), true)
     assert.equal(runtime.plan.cwd, join(dataRoot, 'state'))
     assert.equal(runtime.plan.env.DSH_HOME, join(dataRoot, 'state'))
     assert.equal(runtime.plan.env.DSH_OH_WEB_DATA, join(dataRoot, 'state'))


### PR DESCRIPTION
## Summary
Pass `--no-open` in the Oh‑DSH Web launcher's runtime spawn args (`src/web.ts`), so the launcher remains the single decision point for opening the browser. This completes the browser‑handoff fix started in #132: that PR pinned `openBrowser: false` on the desktop surface's web‑runtime row, but the web launcher's own path was left double‑opening.

## Why
Since DSH runtime 0.1.1‑rc.2 (#122), `@deepseek‑ai/dsh‑web‑app` resolves its browser handoff from the webStartup service (`openBrowser: !!js ctx.webStartup.openBrowser`), and the web‑startup plugin defaults that value to `true` when no open flag is passed.

PR #132 noted the web surface "keeps resolving openBrowser from ctx.webStartup.openBrowser (--open/--no-open), so dsh web behaviour is unchanged" — true for a standalone `dsh --profile web` invocation, but the oh‑dsh web launcher spawns the runtime with only `--profile web --host --port --trusted-host` and never passes an open flag. As a result `webStartup.openBrowser` resolved to `true`:
- `ohdsh web` opened two tabs (bundle + launcher's own handoff);
- `ohdsh web --no-open` only silenced the launcher — the bundle still opened one tab.

The fix routes `--no-open` over the same webStartup seam the launcher already uses for `--host/--port/--trusted-host`. The launcher's `--open/--no-open` flags, its `stdout.isTTY` interactive default, and the `DSH_OH_WEB_OPEN` env override all keep working; a standalone `dsh --profile web` keeps the upstream interactive default (a `web/cordis.patch.yml` pin was considered and rejected for suppressing that standalone UX).

## Verification
All six cases were run live against real processes, with the tab count measured as established TCP connections to the runtime port (consistently 8 per tab, 14 for two tabs). The bundle's `dsh web: opening the default browser` line is the deterministic discriminator.

**On main (pre‑fix):**
- default terminal launch opened two tabs
- `--open` opened two tabs
- `--no-open` still opened one

The bundle handoff line appeared in all three runs, including the `--no-open` case, proving the flag was ignored by the bundle.

**On this branch:**
- default terminal launch opened exactly one tab
- `--no-open` opened zero
- `--open` opened one

The bundle handoff line was absent in all three runs, so the bundle never handed the URL to the OS browser and the tab count follows the launcher's own flag logic exactly.

- `pnpm run typecheck` passes
- `pnpm test`: 228 pass / 3 fail — the 3 failures are the pre‑existing Nix‑only tests that cannot run on Windows (identical to unmodified main)