### PR TITLE
release: prepare v0.1.9 release

### DIFF
--- a/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.md
+2026-08-24-release-skill-for-stable-publishing.md: 6e63394eb5c50d5f63a58a05fa2043531445edfd
+2026-08-24-release-skill-for-stable-publishing.zh.md: eeee0dcf579e4020a82fe3e23334a6f472ab7fe2

--- a/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.i18n.yaml
@@ -3,4 +3,4 @@
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.md
 2026-08-24-release-skill-for-stable-publishing.md: 6e63394eb5c50d5f63a58a05fa2043531445edfd
-2026-08-24-release-skill-for-stable-publishing.zh.md: eeee0dcf579e4020a82fe3e23334a6f472ab7fe2
+2026-08-24-release-skill-for-stable-publishing.zh.md: 5b1c06d4d39d8c9f2f784cd0178e1df3459554bd

--- a/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.md
+++ b/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.md
@@ -1,0 +1,51 @@
+# Agent Note: Use a release skill for stable application publishing
+
+Status: implemented
+
+English | [中文](2026-08-24-release-skill-for-stable-publishing.zh.md)
+
+## Problem
+
+Stable Oh-DSH releases require the package manifest version, the `v`-prefixed
+tag, the release workflow, and the GitHub Release assets to stay aligned. The
+workflow rejects a tag that does not match `package.json`, but the recovery
+steps for a failed packaging run were not recorded in one reusable place.
+
+## Decision
+
+- Add `.agents/skills/dsh-release/SKILL.md` as the agent-facing procedure for
+  stable application releases.
+- Keep the version and tag forms explicit: `package.json` uses `X.Y.Z`, while
+  the release tag uses `vX.Y.Z`; validate the pair before any tag push.
+- Require a release-preparation PR to merge before tagging `origin/main`, then
+  monitor the `Release` workflow and verify the published asset set.
+- For a deterministic source-related packaging failure, remove only the
+  verified failed tag, submit a fix PR, wait for its merge, and tag the new
+  main commit. Existing Releases or published assets require maintainer
+  recovery rather than blind deletion.
+
+## Alternatives considered
+
+**Document the procedure only in `docs/usage.md`.** Rejected: user-facing
+usage documentation is not the right surface for agent-only tag, CI, and
+rollback guardrails, and it would make operational instructions harder to
+discover at the point of release work.
+
+**Push the tag first and repair the inevitable version mismatch afterward.**
+Rejected: the release workflow has a deterministic version gate, so this would
+create an avoidable failed release run and remote tag mutation.
+
+**Automate all tag deletion and PR recovery in a script.** Rejected: deleting
+remote release history and deciding whether a failure is source-related or
+infrastructure-related require inspection and should remain explicit.
+
+## Consequences
+
+- Release agents have one concise procedure with the repository's actual
+  workflow and asset boundaries as its source of truth.
+- Every stable release needs a merged version-preparation change before its
+  tag can be published.
+- Recovery remains deliberate and credential-free; the skill never embeds or
+  prints API keys.
+- The skill does not replace GitHub Actions or maintainer judgment when a
+  partial Release has already been published.

--- a/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.zh.md
+++ b/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.zh.md
@@ -1,42 +1,43 @@
-# Agent Note: Use a release skill for stable application publishing
+# Agent Note: 使用 release skill（技能）发布稳定应用
 
 Status: implemented
 
 [English](2026-08-24-release-skill-for-stable-publishing.md) | 中文
 
-## Problem
+## 问题
 
-Oh-DSH 的稳定版发布要求 package manifest 版本、带 `v` 前缀的 tag、Release
-workflow 与 GitHub Release 资产保持一致。workflow 会拒绝与 `package.json`
-不匹配的 tag，但此前没有一个可复用的位置记录打包失败后的恢复步骤。
+Oh-DSH 的稳定版发布要求包清单中的版本、带 `v` 前缀的标签、Release 工作流
+与 GitHub Release 资产保持一致。工作流会拒绝与 `package.json` 不匹配的标签，
+但此前没有一个可复用的位置记录打包失败后的恢复步骤。
 
-## Decision
+## 决策
 
-- 新增 `.agents/skills/dsh-release/SKILL.md`，作为稳定版应用发布的 agent
-  操作流程。
-- 明确两种版本形式：`package.json` 使用 `X.Y.Z`，发布 tag 使用
-  `vX.Y.Z`；推送 tag 前先校验两者匹配。
-- 要求版本准备 PR 合并后再对 `origin/main` 打 tag，并观察 `Release`
-  workflow、核对最终发布资产。
-- 对确定且与源码有关的打包失败，只删除已核实的失败 tag，提交修复 PR，
-  等待合并后再对新的 main 提交打 tag。若已有 Release 或资产发布，则交给
-  maintainer 恢复，不能盲目删除。
+- 新增 `.agents/skills/dsh-release/SKILL.md`，作为稳定版应用发布的
+  agent（智能体）操作流程。
+- 明确两种版本形式：`package.json` 使用 `X.Y.Z`，发布标签使用
+  `vX.Y.Z`；推送标签前先校验两者匹配。
+- 要求版本准备 PR（Pull Request）合并后再对 `origin/main` 打标签，并观察
+  `Release` 工作流、核对最终发布资产。
+- 对确定且与源码有关的打包失败，只删除已核实的失败标签，提交修复 PR，
+  等待合并后再对新的 main 提交打标签。若已有 Release 或资产发布，则交给
+  维护者恢复，不能盲目删除。
 
-## Alternatives considered
+## 考虑过的替代方案
 
-**只在 `docs/usage.md` 中记录流程。** 不采纳：面向用户的使用文档不是
-agent 专用 tag、CI 与回滚约束的合适位置，也会让发布时的操作说明更难发现。
+**只在 `docs/usage.md` 中记录流程。** 不采纳：面向用户的使用文档不是供
+agent（智能体）使用的标签、CI 与回滚约束的合适位置，也会让发布时的操作说明
+更难发现。
 
-**先推 tag，再在必然的版本不匹配失败后修复。** 不采纳：Release workflow
-已有确定性的版本门禁，这样做只会制造一次可以预见的失败运行和远端 tag 变更。
+**先推标签，再在必然的版本不匹配失败后修复。** 不采纳：Release 工作流
+已有确定性的版本门禁，这样做只会制造一次可以预见的失败运行和远端标签变更。
 
-**用脚本自动完成所有 tag 删除与 PR 恢复。** 不采纳：删除远端发布历史、
+**用脚本自动完成所有标签删除与 PR 恢复。** 不采纳：删除远端发布历史、
 判断失败属于源码还是基础设施都需要现场检查，应保持显式操作。
 
-## Consequences
+## 后果
 
-- 发布 agent 有一份简洁且对应实际 workflow 与资产边界的操作流程。
-- 每次稳定版发布都必须先合并版本准备变更，再推送 tag。
-- 恢复流程保持谨慎且不接触凭据；skill 不嵌入或打印 API key。
-- 若已有部分 Release 发布，skill 不替代 GitHub Actions 或 maintainer
+- 发布 agent（智能体）有一份简洁且对应实际工作流与资产边界的操作流程。
+- 每次稳定版发布都必须先合并版本准备变更，再推送标签。
+- 恢复流程保持谨慎且不接触凭据；skill（技能）不嵌入或打印 API key。
+- 若已有部分 Release 发布，skill（技能）不替代 GitHub Actions 或维护者
   的恢复判断。

--- a/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.zh.md
+++ b/.agents/notes/implemented/process/2026-08-24-release-skill-for-stable-publishing.zh.md
@@ -1,0 +1,42 @@
+# Agent Note: Use a release skill for stable application publishing
+
+Status: implemented
+
+[English](2026-08-24-release-skill-for-stable-publishing.md) | 中文
+
+## Problem
+
+Oh-DSH 的稳定版发布要求 package manifest 版本、带 `v` 前缀的 tag、Release
+workflow 与 GitHub Release 资产保持一致。workflow 会拒绝与 `package.json`
+不匹配的 tag，但此前没有一个可复用的位置记录打包失败后的恢复步骤。
+
+## Decision
+
+- 新增 `.agents/skills/dsh-release/SKILL.md`，作为稳定版应用发布的 agent
+  操作流程。
+- 明确两种版本形式：`package.json` 使用 `X.Y.Z`，发布 tag 使用
+  `vX.Y.Z`；推送 tag 前先校验两者匹配。
+- 要求版本准备 PR 合并后再对 `origin/main` 打 tag，并观察 `Release`
+  workflow、核对最终发布资产。
+- 对确定且与源码有关的打包失败，只删除已核实的失败 tag，提交修复 PR，
+  等待合并后再对新的 main 提交打 tag。若已有 Release 或资产发布，则交给
+  maintainer 恢复，不能盲目删除。
+
+## Alternatives considered
+
+**只在 `docs/usage.md` 中记录流程。** 不采纳：面向用户的使用文档不是
+agent 专用 tag、CI 与回滚约束的合适位置，也会让发布时的操作说明更难发现。
+
+**先推 tag，再在必然的版本不匹配失败后修复。** 不采纳：Release workflow
+已有确定性的版本门禁，这样做只会制造一次可以预见的失败运行和远端 tag 变更。
+
+**用脚本自动完成所有 tag 删除与 PR 恢复。** 不采纳：删除远端发布历史、
+判断失败属于源码还是基础设施都需要现场检查，应保持显式操作。
+
+## Consequences
+
+- 发布 agent 有一份简洁且对应实际 workflow 与资产边界的操作流程。
+- 每次稳定版发布都必须先合并版本准备变更，再推送 tag。
+- 恢复流程保持谨慎且不接触凭据；skill 不嵌入或打印 API key。
+- 若已有部分 Release 发布，skill 不替代 GitHub Actions 或 maintainer
+  的恢复判断。

--- a/.agents/skills/dsh-release/SKILL.md
+++ b/.agents/skills/dsh-release/SKILL.md
@@ -6,7 +6,7 @@ description: This skill guides Oh-DSH stable application releases from version p
 # Oh-DSH Stable Release
 
 This skill covers the application release workflow in
-[`.github/workflows/release.yml`](../../.github/workflows/release.yml). The
+[`.github/workflows/release.yml`](../../../.github/workflows/release.yml). The
 runtime-only workflow is separate and must not be used for a stable application
 release.
 
@@ -27,21 +27,28 @@ release.
 4. Run `pnpm run typecheck`, `pnpm test`, `pnpm run build`, the Agent Notes
    checks, the bilingual pairing check, and `git diff --check`.
 5. Commit the version change and any release-process maintenance in English,
-   using `<module>: <subject>` and the repository's required sign-off. Open a
-   PR that lists scope, checks, and the exact version/tag pair.
+   using `<module>: <subject>` with a body that explains why and impact. Open
+   a PR that lists scope, checks, and the exact version/tag pair.
 6. Do not create the tag until this PR is merged and `origin/main` contains the
    validated version.
 
 ## Cut and monitor the release
 
-1. Fetch `origin/main` and tags. Verify the checked-out `main` is the exact
-   commit to release, the manifest/tag validation passes, and the target tag is
-   absent remotely.
+1. Fetch `origin/main` and tags. Derive the release values from the current
+   manifest so this phase does not depend on a previous shell:
+
+   ```sh
+   VERSION="$(node -p "require('./package.json').version")"
+   TAG="v$VERSION"
+   ```
+
+   Verify the checked-out `main` is the exact commit to release, the
+   manifest/tag validation passes, and the target tag is absent remotely.
 2. Create an annotated tag on that commit and push only that tag:
 
    ```sh
-   git tag -a "v$VERSION" origin/main -m "Oh-DSH Desktop v$VERSION"
-   git push origin "v$VERSION"
+   git tag -a "$TAG" origin/main -m "Oh-DSH Desktop $TAG"
+   git push origin "$TAG"
    ```
 
 3. Find the `Release` workflow run for the tag with `gh run list`, then use
@@ -60,14 +67,16 @@ For a source fix, delete only the verified failed tag, create a fix PR from
 the new `origin/main` commit:
 
 ```sh
-git push origin --delete "v$VERSION"
-git tag -d "v$VERSION"
+git push origin --delete "$TAG"
+git tag -d "$TAG"
 ```
 
-Do not force-push, delete an unrelated tag, or retag a different commit under
-the same release name. For an infrastructure-only failure, prefer rerunning
-the failed workflow when possible. If a Release or assets already exist, stop
-and use the repository's maintainer recovery path instead of deleting history.
+Do not force-push or delete an unrelated tag. Reuse the release name only after
+the failed tag is verified deleted, the fix PR is merged, and the new
+`origin/main` commit passes version validation. For an infrastructure-only
+failure, prefer rerunning the failed workflow when possible. If a Release or
+assets already exist, stop and use the repository's maintainer recovery path
+instead of deleting history.
 
 ## Handoff
 

--- a/.agents/skills/dsh-release/SKILL.md
+++ b/.agents/skills/dsh-release/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dsh-release
+description: This skill guides Oh-DSH stable application releases from version preparation through GitHub artifact publication and recovery. Use when preparing a vX.Y.Z release, changing package.json for a release, creating or pushing a release tag, monitoring the Release workflow, or recovering from packaging failure.
+---
+
+# Oh-DSH Stable Release
+
+This skill covers the application release workflow in
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml). The
+runtime-only workflow is separate and must not be used for a stable application
+release.
+
+## Prepare a release PR
+
+1. Start from an up-to-date `main` with a clean worktree. Confirm the target
+   version has no local or remote tag or GitHub Release.
+2. Set `package.json` to the numeric semver `X.Y.Z`; the `v` prefix belongs
+   only to the Git tag `vX.Y.Z`.
+3. Validate the invariant before publishing:
+
+   ```sh
+   VERSION="${VERSION:?set VERSION to the numeric X.Y.Z release}"
+   node scripts/validate-release-tag.mjs \
+     --tag "v$VERSION" --version "$(node -p "require('./package.json').version")"
+   ```
+
+4. Run `pnpm run typecheck`, `pnpm test`, `pnpm run build`, the Agent Notes
+   checks, the bilingual pairing check, and `git diff --check`.
+5. Commit the version change and any release-process maintenance in English,
+   using `<module>: <subject>` and the repository's required sign-off. Open a
+   PR that lists scope, checks, and the exact version/tag pair.
+6. Do not create the tag until this PR is merged and `origin/main` contains the
+   validated version.
+
+## Cut and monitor the release
+
+1. Fetch `origin/main` and tags. Verify the checked-out `main` is the exact
+   commit to release, the manifest/tag validation passes, and the target tag is
+   absent remotely.
+2. Create an annotated tag on that commit and push only that tag:
+
+   ```sh
+   git tag -a "v$VERSION" origin/main -m "Oh-DSH Desktop v$VERSION"
+   git push origin "v$VERSION"
+   ```
+
+3. Find the `Release` workflow run for the tag with `gh run list`, then use
+   `gh run watch <run-id> --exit-status`. Treat each matrix package as pending
+   until the run finishes; inspect failures with `gh run view <run-id> --log-failed`.
+4. On success, verify the GitHub Release and its expected desktop, Web, TUI,
+   runtime, checksum, and updater-metadata assets before reporting completion.
+
+## Recover from a packaging failure
+
+Do not delete a tag while its workflow is still running. First capture the run
+URL and failed job, confirm the failure is deterministic and source-related,
+and confirm no Release or partial published assets require maintainer recovery.
+For a source fix, delete only the verified failed tag, create a fix PR from
+`main`, run the relevant checks, and wait for that PR to merge before retagging
+the new `origin/main` commit:
+
+```sh
+git push origin --delete "v$VERSION"
+git tag -d "v$VERSION"
+```
+
+Do not force-push, delete an unrelated tag, or retag a different commit under
+the same release name. For an infrastructure-only failure, prefer rerunning
+the failed workflow when possible. If a Release or assets already exist, stop
+and use the repository's maintainer recovery path instead of deleting history.
+
+## Handoff
+
+Report the merged version commit, tag object and target commit, workflow URL,
+final matrix result, Release URL, asset verification, and any unresolved gap.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH Desktop",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",


### PR DESCRIPTION
## Scope

- Update `package.json` to `0.1.9` so the `v0.1.9` tag passes release validation.
- Add the `dsh-release` skill for preparation, tagging, CI monitoring,
  asset checks, and safe recovery.
- Record the release decision in a bilingual Agent Note pair.

The `v0.1.9` tag is intentionally not created by this PR. Create it from the
merged `origin/main` commit after this PR lands.

## Verification

- `node scripts/validate-release-tag.mjs --tag v0.1.9 --version 0.1.9`
- `pnpm run verify:agent-notes`
- `pnpm run verify-translation-pairing`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`
- `git diff --check`

## Follow-up

After merge, fetch `main`, create the annotated `v0.1.9` tag, push it, and
monitor the `Release` workflow using the new skill.