### PR TITLE
plugins: bundle dsh-auth as the built-in subscription OAuth plugin

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-24-upstream-tui-0.9.0-upgrade.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-24-upstream-tui-0.9.0-upgrade.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-24-upstream-tui-0.9.0-upgrade.md
-2026-08-24-upstream-tui-0.9.0-upgrade.md: 35c9c6e2b6d6259de92ccb054c3b476e9b5ddff4
-2026-08-24-upstream-tui-0.9.0-upgrade.zh.md: 76a3f44ada7768219507c8f836347791d36b390c
+2026-08-24-upstream-tui-0.9.0-upgrade.md: c021cbb1eeb7d5e14957cd42e6420c43c8993e39
+2026-08-24-upstream-tui-0.9.0-upgrade.zh.md: 8d56430c58cdebce7e0872acf63a323298b2a8f4

--- a/.agents/notes/implemented/feature/2026-08-24-upstream-tui-0.9.0-upgrade.md
+++ b/.agents/notes/implemented/feature/2026-08-24-upstream-tui-0.9.0-upgrade.md
@@ -34,8 +34,11 @@ and packaged Nix builds need a reproducible renderer artifact.
 
 ## Consequences
 
-- The staged TUI runs dsh-TUI 0.9.0 and no longer emits the upstream automatic
-  update notice under Oh-DSH.
+- The pin moved on: the staged TUI runs dsh-TUI 0.9.2 under the
+  [0.9.2 upgrade](2026-08-26-upstream-tui-0.9.2-upgrade.md), which supersedes
+  only the version facts here; this record still owns the update-gating
+  decision — no upstream automatic update notice under Oh-DSH, upgrades only
+  through the deliberate pinned flow.
 - Updating dsh-TUI now requires one deliberate pinned upgrade and a fresh
   adapter/staging verification.
 - The manual upstream update implementation remains in the copied renderer

--- a/.agents/notes/implemented/feature/2026-08-24-upstream-tui-0.9.0-upgrade.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-24-upstream-tui-0.9.0-upgrade.zh.md
@@ -33,7 +33,10 @@ renderer 产物。
 
 ## Consequences
 
-- staged TUI 使用 dsh-TUI 0.9.0，并且在 Oh-DSH 环境中不再显示上游后台更新提示。
+- 固定版本已前移：staged TUI 在
+  [0.9.2 升级](2026-08-26-upstream-tui-0.9.2-upgrade.md)下运行 dsh-TUI 0.9.2，
+  该决策仅取代此处的版本事实；本记录继续拥有更新门控决策——Oh-DSH 环境中不
+  显示上游后台更新提示，升级只走刻意的固定版本流程。
 - 后续升级 dsh-TUI 需要一次有意的 pinned upgrade，并重新完成 adapter/staging
   验证。
 - 复制后的 renderer 仍保留上游手动更新实现以维持兼容，但后台检查不再向用户

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
-2026-08-26-bundle-dsh-auth.md: 912d790a3d33e52b95daab9d4e9194db18abf9b5
-2026-08-26-bundle-dsh-auth.zh.md: cdf4da4958c26663333ab49a25e00b9615f509d5
+2026-08-26-bundle-dsh-auth.md: baec6b827ddf0181d706fc81980c340bb69a1fa4
+2026-08-26-bundle-dsh-auth.zh.md: 4c7e935beca90e4bbf8224397475cfd849604ea7

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
-2026-08-26-bundle-dsh-auth.md: ca7869082c7e08725d92f8030f6d2c4283fabf2a
-2026-08-26-bundle-dsh-auth.zh.md: 5f38b0b5eba64bb6954c07ca60098da4ac230006
+2026-08-26-bundle-dsh-auth.md: 912d790a3d33e52b95daab9d4e9194db18abf9b5
+2026-08-26-bundle-dsh-auth.zh.md: cdf4da4958c26663333ab49a25e00b9615f509d5

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
+2026-08-26-bundle-dsh-auth.md: ca7869082c7e08725d92f8030f6d2c4283fabf2a
+2026-08-26-bundle-dsh-auth.zh.md: 5f38b0b5eba64bb6954c07ca60098da4ac230006

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
@@ -40,7 +40,11 @@ patch row. Desktop and Web users had no path to subscription accounts.
   `auth/` dir (npm release layout), and the extra-deps copy loop now merges
   scoped entries package by package instead of skipping a scope directory
   the renderer already created. The full `oh-dsh` package builds clean with
-  both `@deepseek-harness-tui/dsh-auth` and `dsh-context` registered.
+  both `@deepseek-harness-tui/dsh-auth` and `dsh-context` registered. Scoped
+  extra-deps copies also receive the same `node_modules -> ../..`
+  dependency-root link collect-deps.py creates (only when absent), so the
+  renderer's private link to the auth copy resolves peer imports through the
+  runtime graph.
 
 ## Alternatives considered
 

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
@@ -36,6 +36,11 @@ patch row. Desktop and Web users had no path to subscription accounts.
 - Marketplace protection covers the plugin id, package name, and
   `ccch1mneyyy/dsh-auth` repository, with a refusal test mirroring the
   dsh-context one.
+- Nix registers the package for the full and web surfaces from the bundle's
+  `auth/` dir (npm release layout), and the extra-deps copy loop now merges
+  scoped entries package by package instead of skipping a scope directory
+  the renderer already created. The full `oh-dsh` package builds clean with
+  both `@deepseek-harness-tui/dsh-auth` and `dsh-context` registered.
 
 ## Alternatives considered
 

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
@@ -1,0 +1,64 @@
+# Agent Note: Bundle dsh-auth as the built-in subscription OAuth plugin
+
+Status: implemented
+
+English | [中文](2026-08-26-bundle-dsh-auth.zh.md)
+
+## Problem
+
+The 0.9.2 renderer bundles upstream `dsh-auth` (subscription OAuth sign-in
+for ChatGPT/Codex, Claude Pro/Max, and SuperGrok as LLM provider routes),
+but only the TUI surface loaded it — through the renderer's own `oauth`
+patch row. Desktop and Web users had no path to subscription accounts.
+
+## Decision
+
+- Stage the pinned package from `upstream/dsh-TUI/dsh-auth` under its npm
+  name for the Desktop and Web surfaces and mount it with the upstream's own
+  row shape (`- id: dsh-auth`, entry-level `inject: [llm, commands]`) in the
+  root and `web/` patch layers — the same stage-the-upstream-manifest,
+  no-adapter pattern the [dsh-context bundling](2026-08-25-bundle-dsh-context.md)
+  established. The TUI keeps loading it through the renderer's row, so no
+  surface mounts it twice.
+- The plugin is host-only: `/auth` interacts entirely over the DSH
+  `user-questions` seam and the commands registry, so Desktop and Web need
+  no client code — the surfaces' existing question UI carries the login
+  flow, and a non-interactive environment degrades to a clear refusal.
+- All peers resolve from the staged runtime's hoisted tree — including
+  `@deepseek-ai/dsh-llm-pi-ai` and `@earendil-works/pi-ai`, which the
+  0.1.1-rc.2 runtime already ships.
+- `BUNDLED_DESKTOP_HOST_PLUGINS` gains the package; the collection test now
+  asserts host plugins enroll no browser half (`dsh.client` absent) instead
+  of no `dsh` key at all, because upstream bundle manifests declare their
+  patch layer. The desktop smoke host loop resolves `main` from each staged
+  manifest (`lib/index.js` here), and the web smoke asserts the `dsh-auth`
+  row in the composed profile dump.
+- Marketplace protection covers the plugin id, package name, and
+  `ccch1mneyyy/dsh-auth` repository, with a refusal test mirroring the
+  dsh-context one.
+
+## Alternatives considered
+
+**An `@oh-dsh/auth` adapter package.** Rejected: nothing is adapted — the
+upstream package is consumed unmodified, and a wrapper manifest would only
+drift from the upstream version, exactly the trade the dsh-context decision
+already recorded.
+
+**Mount the renderer's oauth row on Desktop/Web.** Rejected: that row is the
+TUI renderer's own export; mounting a foreign package's subpath row would
+couple Desktop/Web staging to the renderer package the TUI surface owns.
+
+**Wait for a DSH-native subscription login.** Rejected: the upstream package
+is designed against DSH core seams (llm registry, commands, user-questions)
+and works unchanged on every surface today.
+
+## Consequences
+
+- `/auth` works on all three surfaces against the same stored credentials
+  in the Oh-DSH data directory.
+- Upgrading the renderer pin moves the dsh-auth source with it; the
+  standalone staging spec follows the nested submodule path, so a future
+  move of the nested package breaks staging loudly.
+- If upstream adds a client half, the package leaves
+  `BUNDLED_DESKTOP_HOST_PLUGINS` for the client list and the smokes gain
+  client-bundle assertions.

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
@@ -33,7 +33,9 @@ renderer 自己的 `oauth` patch 行。Desktop 与 Web 用户没有订阅账号�
 - Nix 为 full 与 web 面从 bundle 的 `auth/` 目录（npm 发布布局）注册该包，
   extra-deps 拷贝循环改为逐包合并 scope 条目，而不是跳过 renderer 已创建的
   scope 目录。完整 `oh-dsh` 包构建通过，`@deepseek-harness-tui/dsh-auth` 与
-  `dsh-context` 均注册成功。
+  `dsh-context` 均注册成功。scope 条目的 extra-deps 拷贝还会在缺失时获得与
+  collect-deps.py 相同的 `node_modules -> ../..` 依赖根链接，使 renderer 指向
+  auth 副本的私有链接能经运行时图解析 peer import。
 
 ## Alternatives considered
 

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
@@ -1,0 +1,53 @@
+# Agent Note: 内置 dsh-auth 作为订阅账号 OAuth 插件
+
+Status: implemented
+
+[English](2026-08-26-bundle-dsh-auth.md) | 中文
+
+## Problem
+
+0.9.2 renderer 捆绑了上游 `dsh-auth`（为 ChatGPT/Codex、Claude Pro/Max 与
+SuperGrok 提供订阅 OAuth 登录的 LLM 路由），但只有 TUI 面加载它——经由
+renderer 自己的 `oauth` patch 行。Desktop 与 Web 用户没有订阅账号入口。
+
+## Decision
+
+- 把 `upstream/dsh-TUI/dsh-auth` 中的固定包以上游 npm 名暂存到 Desktop 与
+  Web 面，并按上游自己的行形态（`- id: dsh-auth`，条目级
+  `inject: [llm, commands]`）挂载进根目录与 `web/` patch 层——沿用
+  [dsh-context 内置](2026-08-25-bundle-dsh-context.md)确立的"暂存上游
+  manifest、无适配层"模式。TUI 继续经由 renderer 的行加载，因此没有任何面
+  重复挂载。
+- 该插件是纯 host 端：`/auth` 的交互完全走 DSH 的 `user-questions` 接缝与
+  commands 注册表，Desktop 与 Web 无需任何客户端代码——各面既有的问答 UI
+  承载登录流程；无交互面的环境降级为明确的拒绝提示。
+- 所有 peer 经由暂存运行时的 hoisted 树解析——包括 0.1.1-rc.2 运行时已经
+  自带的 `@deepseek-ai/dsh-llm-pi-ai` 与 `@earendil-works/pi-ai`。
+- `BUNDLED_DESKTOP_HOST_PLUGINS` 加入该包；收集测试对 host 插件的断言从
+  "没有 `dsh` 键"放宽为"没有浏览器半区（无 `dsh.client`）"，因为上游 bundle
+  manifest 会声明自己的 patch 层。桌面 smoke 的 host 循环改为从各暂存
+  manifest 解析 `main`（此处为 `lib/index.js`）；web smoke 在组合 profile
+  dump 中断言 `dsh-auth` 行。
+- marketplace 保护覆盖插件 id、包名与 `ccch1mneyyy/dsh-auth` 仓库，并按
+  dsh-context 用例镜像添加拒绝测试。
+
+## Alternatives considered
+
+**做 `@oh-dsh/auth` 适配包。** 不采纳：没有任何被适配的东西——上游包原样
+消费，包装 manifest 只会偏离上游版本，这正是 dsh-context 决策已记录过的
+取舍。
+
+**在 Desktop/Web 挂 renderer 的 oauth 行。** 不采纳：该行是 TUI renderer
+自己的导出；挂载外部包的子路径行会让 Desktop/Web 暂存耦合到 TUI 面拥有的
+renderer 包。
+
+**等待 DSH 原生订阅登录。** 不采纳：上游包本就面向 DSH 核心接缝（llm
+注册表、commands、user-questions）设计，今天就能在所有面上原样工作。
+
+## Consequences
+
+- `/auth` 在三个面上可用，凭据同样存储于 Oh-DSH 数据目录。
+- 升级 renderer pin 会一并移动 dsh-auth 源；独立暂存 spec 指向嵌套子模块
+  路径，将来上游移动该嵌套包时暂存会大声失败。
+- 若上游增加客户端半区，该包将从 `BUNDLED_DESKTOP_HOST_PLUGINS` 移入
+  client 列表，smoke 也会增加 client bundle 断言。

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
@@ -30,6 +30,10 @@ renderer 自己的 `oauth` patch 行。Desktop 与 Web 用户没有订阅账号�
   dump 中断言 `dsh-auth` 行。
 - marketplace 保护覆盖插件 id、包名与 `ccch1mneyyy/dsh-auth` 仓库，并按
   dsh-context 用例镜像添加拒绝测试。
+- Nix 为 full 与 web 面从 bundle 的 `auth/` 目录（npm 发布布局）注册该包，
+  extra-deps 拷贝循环改为逐包合并 scope 条目，而不是跳过 renderer 已创建的
+  scope 目录。完整 `oh-dsh` 包构建通过，`@deepseek-harness-tui/dsh-auth` 与
+  `dsh-context` 均注册成功。
 
 ## Alternatives considered
 

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
-2026-08-26-upstream-tui-0.9.2-upgrade.md: 938192add7e0d5559b10abf69b12a96981def0ab
-2026-08-26-upstream-tui-0.9.2-upgrade.zh.md: 70a4a452ef1c6def666a6d622e76e6c9e4b204ed
+2026-08-26-upstream-tui-0.9.2-upgrade.md: 3d0fcbdba61a73f81060554e543df2d73b902bdd
+2026-08-26-upstream-tui-0.9.2-upgrade.zh.md: 1327f9830c8a5270e8d2510d1602b103c623bc0b

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
+2026-08-26-upstream-tui-0.9.2-upgrade.md: 598d26e02f64f316b6119240cffcecd217e1e6e3
+2026-08-26-upstream-tui-0.9.2-upgrade.zh.md: 323821189f9a27968b6d59b5212f7f73b7c796c6

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
-2026-08-26-upstream-tui-0.9.2-upgrade.md: 598d26e02f64f316b6119240cffcecd217e1e6e3
-2026-08-26-upstream-tui-0.9.2-upgrade.zh.md: 323821189f9a27968b6d59b5212f7f73b7c796c6
+2026-08-26-upstream-tui-0.9.2-upgrade.md: 938192add7e0d5559b10abf69b12a96981def0ab
+2026-08-26-upstream-tui-0.9.2-upgrade.zh.md: 70a4a452ef1c6def666a6d622e76e6c9e4b204ed

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
@@ -1,0 +1,63 @@
+# Agent Note: Upgrade the pinned dsh-TUI renderer to 0.9.2
+
+Status: implemented
+
+English | [中文](2026-08-26-upstream-tui-0.9.2-upgrade.zh.md)
+
+## Problem
+
+The pinned renderer sat at 0.9.0 (decided by the
+[0.9.0 upgrade](2026-08-24-upstream-tui-0.9.0-upgrade.md)); upstream 0.9.2
+adds session identity (`/color`, `/recap`), paste folding, hover
+interactions, a bundled OAuth sign-in package (`dsh-auth`), the `pi-ai`
+subscription LLM route, `/reload` and `/restart`, and fixes a pnpm ≥ 11
+`ERR_PNPM_IGNORED_BUILDS` blocker in the upstream `/update` preset.
+
+## Decision
+
+- Pin the submodule and the published npm renderer to v0.9.2; the nested
+  `dsh-ecosystem-spec` gitlink moves to `2d0236f7`, `vendor/dsh-std` is
+  unchanged, and the new nested `dsh-auth` gitlink (`fba02bcf`) is fetched
+  with the recursive submodule update.
+- `pnpm-workspace.yaml` `allowBuilds` records the two new transitive
+  dependencies as `false`: `@google/genai` and `protobufjs` are pure-JS
+  packages whose postinstall scripts are not needed to stage or run any
+  surface.
+- The staging dependency mirror walks the node_modules chain from the
+  requiring package when a restricted `exports` map hides both
+  `./package.json` and the main entry from `require.resolve`
+  (`@earendil-works/pi-ai` is the first such dependency).
+- The bundled `dsh-auth` is staged as the nested copy the renderer's
+  `link:./dsh-auth` resolution produces; Nix consumes the published
+  `@deepseek-harness-tui/dsh-auth@0.1.0` tarball through extra-deps, the
+  same published-artifact pattern as the renderer.
+- The guarded renderer adapter learns the new `/restart` command's
+  description rewrite; every other 0.9.2 addition needed no adaptation.
+- The upstream fullscreen-default flip (now on by default upstream) is NOT
+  adopted: the Oh-DSH launcher keeps inline as the default and always passes
+  `DSH_OH_TUI_FULLSCREEN` explicitly.
+
+## Alternatives considered
+
+**Adopt the upstream fullscreen default.** Rejected: Oh-DSH's inline
+startup, scrollback-preserving notices, and launcher contract are built
+around the inline default; the upstream flip changes nothing for users who
+pass `--fullscreen`.
+
+**Rewrite the staged `link:./dsh-auth` dependency to the published `"*"`
+form.** Rejected: the nested copy already resolves at runtime and keeps the
+staged manifest byte-identical to the pinned source; only the Nix assembly
+needs the published form.
+
+## Consequences
+
+- The TUI gains 0.9.2 features (session identity, recap, paste folding,
+  hover interactions, OAuth sign-in via `/auth`, `/reload`, `/restart`)
+  under the existing Oh-DSH launcher contract; boot verified with the
+  Liangshen preset in a pty.
+- The Nix `pnpmDeps` hash could not be recomputed without a local nix and
+  still needs a one-line refresh by the next `nix build` runner (the
+  mismatch fails loudly and prints the correct hash).
+- liangshen's preset revision moves to
+  `liangshen-toolcall-full-catalog-subagents-durable-hint-v5` (durable
+  instruction-hint dedupe) with no Oh-DSH-side test changes.

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
@@ -55,9 +55,11 @@ needs the published form.
   hover interactions, OAuth sign-in via `/auth`, `/reload`, `/restart`)
   under the existing Oh-DSH launcher contract; boot verified with the
   Liangshen preset in a pty.
-- The Nix `pnpmDeps` hash could not be recomputed without a local nix and
-  still needs a one-line refresh by the next `nix build` runner (the
-  mismatch fails loudly and prints the correct hash).
+- The Nix assembly is verified end to end: the fetchFromGitHub tree hashes
+  for the sidebar, renderer, ecosystem-spec, and dsh-auth sources, plus the
+  `fetchPnpmDeps` closure hash, were refreshed from an actual `nix build`
+  and the full `oh-dsh` package builds clean — the first real-build
+  validation of the dsh-context Nix integration as well.
 - liangshen's preset revision moves to
   `liangshen-toolcall-full-catalog-subagents-durable-hint-v5` (durable
   instruction-hint dedupe) with no Oh-DSH-side test changes.

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
@@ -34,8 +34,10 @@ subscription LLM route, `/reload` and `/restart`, and fixes a pnpm ≥ 11
 - The guarded renderer adapter learns the new `/restart` command's
   description rewrite; every other 0.9.2 addition needed no adaptation.
 - The upstream fullscreen-default flip (now on by default upstream) is NOT
-  adopted: the Oh-DSH launcher keeps inline as the default and always passes
-  `DSH_OH_TUI_FULLSCREEN` explicitly.
+  adopted: the Oh-DSH launcher keeps inline as the default and always sets
+  `OH_DSH_TUI_FULLSCREEN` (the variable the Cordis patch and renderer
+  adapter read; `DSH_OH_TUI_FULLSCREEN` is only the launcher's input alias)
+  explicitly.
 
 ## Alternatives considered
 

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
@@ -29,7 +29,8 @@ Status: implemented
 - 带守卫的 renderer 适配器学习新 `/restart` 命令描述的重写；0.9.2 的其他
   新增均无需适配。
 - 不采纳上游的 fullscreen 默认翻转（上游默认改为开启）：Oh-DSH 启动器保持
-  inline 为默认，并始终显式传递 `DSH_OH_TUI_FULLSCREEN`。
+  inline 为默认，并始终显式设置 `OH_DSH_TUI_FULLSCREEN`（Cordis patch 与
+  renderer 适配器读取的变量；`DSH_OH_TUI_FULLSCREEN` 只是启动器的输入别名）。
 
 ## Alternatives considered
 

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
@@ -1,0 +1,53 @@
+# Agent Note: 将 pinned dsh-TUI renderer 升级到 0.9.2
+
+Status: implemented
+
+[English](2026-08-26-upstream-tui-0.9.2-upgrade.md) | 中文
+
+## Problem
+
+固定版本仍停在 0.9.0（由
+[0.9.0 升级](2026-08-24-upstream-tui-0.9.0-upgrade.md)决策）；上游 0.9.2
+新增会话身份（`/color`、`/recap`）、大段粘贴折叠、悬停交互、内置 OAuth 登录包
+（`dsh-auth`）、`pi-ai` 订阅 LLM 路由、`/reload` 与 `/restart`，并修复了上游
+`/update` 预置在 pnpm ≥ 11 下的 `ERR_PNPM_IGNORED_BUILDS` 阻断。
+
+## Decision
+
+- 将子模块与已发布 npm renderer 一起固定到 v0.9.2；嵌套的
+  `dsh-ecosystem-spec` gitlink 移至 `2d0236f7`，`vendor/dsh-std` 不变，新嵌套
+  `dsh-auth` gitlink（`fba02bcf`）随递归子模块更新取得。
+- `pnpm-workspace.yaml` 的 `allowBuilds` 将两个新的传递依赖记为 `false`：
+  `@google/genai` 与 `protobufjs` 均为纯 JS 包，其 postinstall 脚本对任何面的
+  暂存与运行都不需要。
+- 暂存依赖镜像在受限 `exports` 映射把 `./package.json` 与 main 入口都对
+  `require.resolve` 隐藏时（`@earendil-works/pi-ai` 是首个此类依赖），改为从
+  发起解析的包沿 node_modules 链向上查找。
+- 内置 `dsh-auth` 按 renderer `link:./dsh-auth` 解析产生的嵌套副本暂存；Nix
+  通过 extra-deps 消费已发布的 `@deepseek-harness-tui/dsh-auth@0.1.0` 包，
+  与 renderer 使用相同的已发布产物模式。
+- 带守卫的 renderer 适配器学习新 `/restart` 命令描述的重写；0.9.2 的其他
+  新增均无需适配。
+- 不采纳上游的 fullscreen 默认翻转（上游默认改为开启）：Oh-DSH 启动器保持
+  inline 为默认，并始终显式传递 `DSH_OH_TUI_FULLSCREEN`。
+
+## Alternatives considered
+
+**采纳上游 fullscreen 默认。** 不采纳：Oh-DSH 的 inline 启动、保留 scrollback
+的通知以及启动器契约都围绕 inline 默认构建；对传 `--fullscreen` 的用户没有
+任何变化。
+
+**把暂存的 `link:./dsh-auth` 依赖改写成发布态的 `"*"`。** 不采纳：嵌套副本在
+运行时已可解析，且暂存 manifest 与固定源保持逐字节一致；只有 Nix 组装需要
+发布形态。
+
+## Consequences
+
+- TUI 在既有 Oh-DSH 启动器契约下获得 0.9.2 特性（会话身份、recap、粘贴折叠、
+  悬停交互、`/auth` OAuth 登录、`/reload`、`/restart`）；已在 pty 中用 Liangshen
+  预设验证引导。
+- Nix 的 `pnpmDeps` 哈希无法在无本地 nix 的环境重算，仍需下一位执行
+  `nix build` 的人按报错提示一行刷新（不匹配会大声失败并打印正确哈希）。
+- liangshen 预设修订号移至
+  `liangshen-toolcall-full-catalog-subagents-durable-hint-v5`（持久的指令提示
+  去重），Oh-DSH 侧测试无需改动。

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
@@ -46,8 +46,10 @@ Status: implemented
 - TUI 在既有 Oh-DSH 启动器契约下获得 0.9.2 特性（会话身份、recap、粘贴折叠、
   悬停交互、`/auth` OAuth 登录、`/reload`、`/restart`）；已在 pty 中用 Liangshen
   预设验证引导。
-- Nix 的 `pnpmDeps` 哈希无法在无本地 nix 的环境重算，仍需下一位执行
-  `nix build` 的人按报错提示一行刷新（不匹配会大声失败并打印正确哈希）。
+- Nix 组装已端到端验证：sidebar、renderer、ecosystem-spec 与 dsh-auth 源的
+  fetchFromGitHub 树哈希以及 `fetchPnpmDeps` 闭包哈希均由真实 `nix build`
+  刷新，完整 `oh-dsh` 包构建通过——这也是 dsh-context Nix 集成首次经真实
+  构建验证。
 - liangshen 预设修订号移至
   `liangshen-toolcall-full-catalog-subagents-durable-hint-v5`（持久的指令提示
   去重），Oh-DSH 侧测试无需改动。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -95,12 +95,15 @@ and keep the license with the packaged plugin.
 ## dsh-TUI
 
 - Project: <https://github.com/ccch1mneyyy/dsh-TUI>
-- Upstream package: `@deepseek-harness-tui/dsh-tui@0.9.0`
-- Pinned revision: `aca03b83850d4dc52728d068b2b1b05078ecb90b`
+- Upstream package: `@deepseek-harness-tui/dsh-tui@0.9.2`
+- Pinned revision: `b166c2ecc03ab61ec5aee16fe69cdeaf0e2a03a9`
 - Ecosystem specification: <https://github.com/T-Auto/dsh-ecosystem-spec>
-- Pinned ecosystem revision: `e1b902b0f95f4280a8e68d414ec7a4d25d6ce106`
+- Pinned ecosystem revision: `2d0236f7d4579814d9d177a58d03ebd168025960`
 - Protocol packages: <https://github.com/Yan-Zero/dsh-std>
 - Pinned protocol revision: `614dfa1ac168db79fcf4577cf0ebb34e2e3b944b`
+- Bundled OAuth package: <https://github.com/ccch1mneyyy/dsh-auth>
+  (`@deepseek-harness-tui/dsh-auth@0.1.0`, pinned revision
+  `fba02bcf7fb57e3d9885f73882d5835ccdf526c4`, MIT)
 - Declared license: MIT
 - Oh-DSH component: `@oh-dsh/tui`
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -103,7 +103,8 @@ and keep the license with the packaged plugin.
 - Pinned protocol revision: `614dfa1ac168db79fcf4577cf0ebb34e2e3b944b`
 - Bundled OAuth package: <https://github.com/ccch1mneyyy/dsh-auth>
   (`@deepseek-harness-tui/dsh-auth@0.1.0`, pinned revision
-  `fba02bcf7fb57e3d9885f73882d5835ccdf526c4`, MIT)
+  `fba02bcf7fb57e3d9885f73882d5835ccdf526c4`, MIT) — also mounted directly
+  as the built-in Desktop and Web host plugin behind the `/auth` command
 - Declared license: MIT
 - Oh-DSH component: `@oh-dsh/tui`
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -55,3 +55,11 @@
     # dsh.client declaration in its staged manifest loads the browser half.
     - id: dsh-context
       name: 'dsh-context'
+
+    # Subscription OAuth sign-in (upstream dsh-auth, pinned inside
+    # upstream/dsh-TUI): llm provider routes for ChatGPT/Codex, Claude
+    # Pro/Max and SuperGrok plus the /auth command; login interaction runs
+    # over the user-questions seam. TUI loads it via the renderer instead.
+    - id: dsh-auth
+      name: '@deepseek-harness-tui/dsh-auth'
+      inject: [llm, commands]

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write docs/usage.md
-usage.md: 6ef058ddb8132bba1fd3b4dac01f4d97bff626d6
-usage.zh.md: 59dbc5a155724b407d9d52b82fa1a55d643403b4
+usage.md: c8488a458933bf7b9c4230e0d265e3febcb9f733
+usage.zh.md: 9da92ec414f1005bed0c13b480de2508564fad0f

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -427,6 +427,18 @@ around interactive panels, and the upstream maintainer does not target TUI.
 Oh-DSH upgrades the pin deliberately through the submodule revision with each
 release; it does not follow npm latest automatically.
 
+## Subscription OAuth sign-in
+
+Desktop and Web bundle the upstream
+[dsh-auth](https://github.com/ccch1mneyyy/dsh-auth) host plugin (pinned
+inside the dsh-TUI submodule; the TUI loads the same package through its
+renderer). It registers subscription-account LLM routes — ChatGPT/Codex,
+Claude Pro/Max, and SuperGrok — and contributes the `/auth` command for
+sign-in, status, and sign-out. The interactive login flow runs through the
+same question UI each surface already uses; when no interactive surface is
+present, the command refuses with guidance instead of assuming a browser.
+Credentials stay in the existing Oh-DSH data directory.
+
 ## Desktop operations
 
 ### Conversation input history

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -367,6 +367,15 @@ Desktop 和 Web 内置
 
 Oh-DSH 通过子模块固定版本，随自身发行节奏升级，不会自动跟随 npm latest。
 
+## 订阅账号 OAuth 登录
+
+Desktop 和 Web 内置上游 [dsh-auth](https://github.com/ccch1mneyyy/dsh-auth)
+host 插件（固定在 dsh-TUI 子模块内；TUI 通过其 renderer 加载同一包）。它注册
+订阅账号 LLM 路由——ChatGPT/Codex、Claude Pro/Max 与 SuperGrok——并提供
+`/auth` 命令完成登录、查看状态与退出。交互式登录流程走各面已有的问答 UI；
+在没有交互面的环境中，命令会给出指引并拒绝，而不是假定存在浏览器。凭据保存
+在既有的 Oh-DSH 数据目录中。
+
 ## Desktop 操作
 
 ### 对话输入历史

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -65,7 +65,7 @@ let
     owner = "omdsh-dev";
     repo = "DSH-better-sidebar";
     rev = "d9b8f15d9eab018742f97d67e54b2398504894cd";
-    hash = "sha256-TTct9byCf0UobE5E1BGPCSaqxCufvFN9zCgUTXy3wQY=";
+    hash = "sha256-bfpop+QKF8fRAl/vWjcTJgTkBA2bvHK+/KlBkR0NLa4=";
   };
   contextRelease = pkgs.fetchurl {
     url = "https://registry.npmjs.org/dsh-context/-/dsh-context-0.31.1.tgz";
@@ -75,13 +75,13 @@ let
     owner = "ccch1mneyyy";
     repo = "dsh-TUI";
     rev = "b166c2ecc03ab61ec5aee16fe69cdeaf0e2a03a9";
-    hash = "sha256-2akItjIHdFH7cOQa1zgoK8rn0RulUnztpCd3IELFK1Q=";
+    hash = "sha256-AU3SxnjucUA8yvQia+cw/q3cqItRCFb/njaiRoiOS9c=";
   };
   dshAuthSrc = pkgs.fetchFromGitHub {
     owner = "ccch1mneyyy";
     repo = "dsh-auth";
     rev = "fba02bcf7fb57e3d9885f73882d5835ccdf526c4";
-    hash = "sha256-9cJxkcWeWoFf2chJRDZWnKQvcWj5Ur0JzCt8spyw/t8=";
+    hash = "sha256-ip/jdsm/YiPvVdZ0o2m/thImd+4ZmRjzQKzXvJ9dAK8=";
   };
   tuiRelease = pkgs.fetchurl {
     url = "https://registry.npmjs.org/@deepseek-harness-tui/dsh-tui/-/dsh-tui-0.9.2.tgz";
@@ -95,7 +95,7 @@ let
     owner = "T-Auto";
     repo = "dsh-ecosystem-spec";
     rev = "2d0236f7d4579814d9d177a58d03ebd168025960";
-    hash = "sha256-0V5i5OfUGAwZDmnzWBmZoBpDm1SnYMqWdV6aGuJ67Ps=";
+    hash = "sha256-7PK0j8gl3+1esTzjlrKOZkEei6OL13H/4JiIOf5LOR8=";
   };
   tuiStdSrc = pkgs.fetchFromGitHub {
     owner = "Yan-Zero";
@@ -112,14 +112,14 @@ let
     rm -rf $out/upstream/DSH-better-sidebar $out/upstream/dsh-TUI $out/upstream/dsh-context
     cp -r ${betterSidebarSrc} $out/upstream/DSH-better-sidebar
     cp -r ${tuiSrc} $out/upstream/dsh-TUI
+    chmod -R u+w $out/upstream/dsh-TUI
+    rm -rf $out/upstream/dsh-TUI/dsh-ecosystem-spec \
+      $out/upstream/dsh-TUI/vendor/dsh-std
     # The renderer's bundled OAuth package arrives as a gitlink inside
     # tuiSrc; place its source so the pnpm resolution of link:./dsh-auth
     # finds the same tree the submodule build compiles.
     rm -rf $out/upstream/dsh-TUI/dsh-auth
     cp -r ${dshAuthSrc} $out/upstream/dsh-TUI/dsh-auth
-    chmod -R u+w $out/upstream/dsh-TUI
-    rm -rf $out/upstream/dsh-TUI/dsh-ecosystem-spec \
-      $out/upstream/dsh-TUI/vendor/dsh-std
     mkdir -p $out/upstream/dsh-TUI/vendor
     cp -r ${tuiEcosystemSpecSrc} \
       $out/upstream/dsh-TUI/dsh-ecosystem-spec
@@ -147,7 +147,7 @@ let
     pnpmDeps = pkgs.fetchPnpmDeps {
       inherit pname version src;
       fetcherVersion = 4;
-      hash = "sha256-dlysGu1HP7WSjURqeDFttqyeDk0igfu8Qr3b0IVE0Rs=";
+      hash = "sha256-mo7azFsAPB+KuizGuP+8+x0Q0s6W/v+iyLbhbNKYOu8=";
     };
 
     nativeBuildInputs = [

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -188,7 +188,17 @@ let
         $out/lib/oh-dsh/manifests/tui-renderer.json
       cp upstream/dsh-context/package.json \
         $out/lib/oh-dsh/manifests/dsh-context.json
+      cp upstream/dsh-auth-release/package.json \
+        $out/lib/oh-dsh/manifests/dsh-auth.json
 
+      # Carry the prebuilt subscription OAuth plugin for registration into
+      # the runtime (npm release layout, same as the context plugin).
+      mkdir -p $out/lib/oh-dsh/auth
+      cp -r upstream/dsh-auth-release/lib $out/lib/oh-dsh/auth/lib
+      cp upstream/dsh-auth-release/dsh-plugin.json \
+        upstream/dsh-auth-release/cordis.patch.yml \
+        upstream/dsh-auth-release/LICENSE \
+        $out/lib/oh-dsh/auth/ 2>/dev/null || true
       # Carry the prebuilt context plugin (npm release layout: lib/ + patch +
       # license) for registration into the runtime.
       mkdir -p $out/lib/oh-dsh/context
@@ -292,10 +302,26 @@ pkgs.stdenv.mkDerivation {
     if [ -d "${ohDshBundle}/lib/oh-dsh/extra-deps" ]; then
       for dep in ${ohDshBundle}/lib/oh-dsh/extra-deps/*/; do
         name=$(basename "$dep")
-        if [ ! -d "$out/dsh-runtime/node_modules/$name" ]; then
-          cp -r "$dep" "$out/dsh-runtime/node_modules/$name"
-          chmod -R u+w "$out/dsh-runtime/node_modules/$name"
-        fi
+        # Scoped entries (e.g. @deepseek-harness-tui) must merge package by
+        # package; a plain skip would drop dsh-auth beside the renderer.
+        case "$name" in
+          @*)
+            mkdir -p "$out/dsh-runtime/node_modules/$name"
+            for sub in "$dep"*/; do
+              subname="$name/$(basename "$sub")"
+              if [ ! -d "$out/dsh-runtime/node_modules/$subname" ]; then
+                cp -r "$sub" "$out/dsh-runtime/node_modules/$subname"
+                chmod -R u+w "$out/dsh-runtime/node_modules/$subname"
+              fi
+            done
+            ;;
+          *)
+            if [ ! -d "$out/dsh-runtime/node_modules/$name" ]; then
+              cp -r "$dep" "$out/dsh-runtime/node_modules/$name"
+              chmod -R u+w "$out/dsh-runtime/node_modules/$name"
+            fi
+            ;;
+        esac
       done
     fi
 

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -312,6 +312,12 @@ pkgs.stdenv.mkDerivation {
               if [ ! -d "$out/dsh-runtime/node_modules/$subname" ]; then
                 cp -r "$sub" "$out/dsh-runtime/node_modules/$subname"
                 chmod -R u+w "$out/dsh-runtime/node_modules/$subname"
+                # Same dependency-root link collect-deps.py gives collected
+                # packages: without it the renderer's private link resolves
+                # to the store real path and peer imports cannot be found.
+                if [ ! -e "$out/dsh-runtime/node_modules/$subname/node_modules" ]; then
+                  ln -s ../.. "$out/dsh-runtime/node_modules/$subname/node_modules"
+                fi
               fi
             done
             ;;

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -74,18 +74,28 @@ let
   tuiSrc = pkgs.fetchFromGitHub {
     owner = "ccch1mneyyy";
     repo = "dsh-TUI";
-    rev = "aca03b83850d4dc52728d068b2b1b05078ecb90b";
-    hash = "sha256-wMmIu6m5c1+DW5Fl0AK/25Z6wiNVBdOAWXg9GXR3zBU=";
+    rev = "b166c2ecc03ab61ec5aee16fe69cdeaf0e2a03a9";
+    hash = "sha256-2akItjIHdFH7cOQa1zgoK8rn0RulUnztpCd3IELFK1Q=";
+  };
+  dshAuthSrc = pkgs.fetchFromGitHub {
+    owner = "ccch1mneyyy";
+    repo = "dsh-auth";
+    rev = "fba02bcf7fb57e3d9885f73882d5835ccdf526c4";
+    hash = "sha256-9cJxkcWeWoFf2chJRDZWnKQvcWj5Ur0JzCt8spyw/t8=";
   };
   tuiRelease = pkgs.fetchurl {
-    url = "https://registry.npmjs.org/@deepseek-harness-tui/dsh-tui/-/dsh-tui-0.9.0.tgz";
-    hash = "sha512-Z+q2qfPCAoXOfQqpdazMssRl0WxJQ4C3OZITETvZBXzUG63EmPqPhTGsStM0U8AgoKymxgNX0Zkfu6XH37AebQ==";
+    url = "https://registry.npmjs.org/@deepseek-harness-tui/dsh-tui/-/dsh-tui-0.9.2.tgz";
+    hash = "sha512-LsjNnQ790sAGNllrNt3L8B1rdePcwRvwqSlQJ97uTh5skPaUkV9W41oqEYw1g19DZ6CEQ/8T3kKsI9pmQ8AynQ==";
+  };
+  dshAuthRelease = pkgs.fetchurl {
+    url = "https://registry.npmjs.org/@deepseek-harness-tui/dsh-auth/-/dsh-auth-0.1.0.tgz";
+    hash = "sha512-vggwtl0+fuZ9Xuwq9NC5MznT3ZpBfnqGTBgPUfEaqoTPXrxI0S+jcNcO3ou9Akn23cUAZikgmS7zHMVr+ZlXbw==";
   };
   tuiEcosystemSpecSrc = pkgs.fetchFromGitHub {
     owner = "T-Auto";
     repo = "dsh-ecosystem-spec";
-    rev = "e1b902b0f95f4280a8e68d414ec7a4d25d6ce106";
-    hash = "sha256-LVc7bMUJMI4GYW3IyBWYwFzkibayu6BgZxlO67FPtGk=";
+    rev = "2d0236f7d4579814d9d177a58d03ebd168025960";
+    hash = "sha256-0V5i5OfUGAwZDmnzWBmZoBpDm1SnYMqWdV6aGuJ67Ps=";
   };
   tuiStdSrc = pkgs.fetchFromGitHub {
     owner = "Yan-Zero";
@@ -102,6 +112,11 @@ let
     rm -rf $out/upstream/DSH-better-sidebar $out/upstream/dsh-TUI $out/upstream/dsh-context
     cp -r ${betterSidebarSrc} $out/upstream/DSH-better-sidebar
     cp -r ${tuiSrc} $out/upstream/dsh-TUI
+    # The renderer's bundled OAuth package arrives as a gitlink inside
+    # tuiSrc; place its source so the pnpm resolution of link:./dsh-auth
+    # finds the same tree the submodule build compiles.
+    rm -rf $out/upstream/dsh-TUI/dsh-auth
+    cp -r ${dshAuthSrc} $out/upstream/dsh-TUI/dsh-auth
     chmod -R u+w $out/upstream/dsh-TUI
     rm -rf $out/upstream/dsh-TUI/dsh-ecosystem-spec \
       $out/upstream/dsh-TUI/vendor/dsh-std
@@ -112,6 +127,9 @@ let
     mkdir -p $out/upstream/dsh-TUI-release
     tar -xzf ${tuiRelease} --strip-components=1 \
       -C $out/upstream/dsh-TUI-release
+    mkdir -p $out/upstream/dsh-auth-release
+    tar -xzf ${dshAuthRelease} --strip-components=1 \
+      -C $out/upstream/dsh-auth-release
     # The context insight plugin ships prebuilt from npm (same release layout
     # the npm-pinned TUI renderer uses); scripts/build.mjs then sees a lib/
     # already matching the pinned version and skips the sandboxed rebuild.
@@ -208,6 +226,10 @@ let
       rm -rf $out/lib/oh-dsh/extra-deps/@dsh-std
       cp -r upstream/dsh-TUI-release/node_modules/@dsh-std \
         $out/lib/oh-dsh/extra-deps/@dsh-std
+      # The published renderer depends on the released dsh-auth OAuth package.
+      mkdir -p $out/lib/oh-dsh/extra-deps/@deepseek-harness-tui
+      cp -r upstream/dsh-auth-release \
+        $out/lib/oh-dsh/extra-deps/@deepseek-harness-tui/dsh-auth
       for dep in $out/lib/oh-dsh/extra-deps/@dsh-std/*; do
         ln -s ../.. "$dep/node_modules"
       done

--- a/nix/register-plugins.py
+++ b/nix/register-plugins.py
@@ -37,8 +37,8 @@ def main():
         "liangshen": os.path.join("plugins", "liangshen"),
     }
     selected = {
-        "full": set(plugin_dirs) | {"tui-renderer", "dsh-context"},
-        "web": {"web", "skins", "sidebar", "panel-controls", "pinned-summary", "better-sidebar-runtime", "vision", "liangshen", "dsh-context"},
+        "full": set(plugin_dirs) | {"tui-renderer", "dsh-context", "dsh-auth"},
+        "web": {"web", "skins", "sidebar", "panel-controls", "pinned-summary", "better-sidebar-runtime", "vision", "liangshen", "dsh-context", "dsh-auth"},
         "tui": {"tui", "tui-renderer", "skins", "vision"},
     }.get(surface)
     if selected is None:
@@ -64,6 +64,21 @@ def main():
             f.write("\n")
 
         deps_link = os.path.join(package_dir, "node_modules")
+        if plugin_key == "dsh-auth":
+            # Prebuilt npm release mounted directly on full and web; keeps
+            # the upstream lib/ layout its manifest main expects.
+            src_base = os.path.join(bundle_root, "auth")
+            for fname in os.listdir(src_base):
+                src = os.path.join(src_base, fname)
+                dst = os.path.join(package_dir, fname)
+                if os.path.isdir(src):
+                    shutil.copytree(src, dst)
+                else:
+                    shutil.copy2(src, dst)
+            os.symlink(node_modules, deps_link)
+            installed_versions[name] = manifest["version"]
+            print(f"registered {name}")
+            continue
         if plugin_key == "dsh-context":
             # Prebuilt npm release: its files live beside the manifest in the
             # bundle's context/ dir, keeping the upstream lib/ layout its
@@ -78,6 +93,7 @@ def main():
                     shutil.copy2(src, dst)
             os.symlink(node_modules, deps_link)
             installed_versions[name] = manifest["version"]
+            print(f"registered {name}")
             continue
         if plugin_key == "tui-renderer":
             # The renderer requires React 19 while the Web runtime carries

--- a/plugins/plugin-marketplace/src/protocol.ts
+++ b/plugins/plugin-marketplace/src/protocol.ts
@@ -34,6 +34,7 @@ const PROTECTED_PLUGIN_IDS = new Set([
   'desktop-sidebar',
   'dsh-better-sidebar',
   'dsh-context',
+  'dsh-auth',
   'sidebar',
   'oh-dsh-desktop',
   'panel-controls',
@@ -56,12 +57,14 @@ const PROTECTED_PLUGIN_PACKAGES = new Set([
   'dsh-better-sidebar',
   'dsh-cc-tui',
   'dsh-context',
+  '@deepseek-harness-tui/dsh-auth',
 ])
 
 const PROTECTED_PLUGIN_REPOSITORIES = new Set([
   'dsh-external/dsh-better-sidebar',
   'omdsh-dev/dsh-better-sidebar',
   'bowenliang123/dsh-context',
+  'ccch1mneyyy/dsh-auth',
 ])
 
 /** Marketplace code cannot replace a shell or its transaction owner. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       '@alcalzone/ansi-tokenize':
         specifier: ^0.3.0
         version: 0.3.0
+      '@deepseek-harness-tui/dsh-auth':
+        specifier: link:./dsh-auth
+        version: link:dsh-auth
       '@dsh-std/command':
         specifier: workspace:*
         version: link:vendor/dsh-std/packages/command
@@ -250,6 +253,9 @@ importers:
       '@dsh-std/storage':
         specifier: workspace:*
         version: link:vendor/dsh-std/packages/storage
+      '@earendil-works/pi-ai':
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.2)(zod@4.4.3)
       auto-bind:
         specifier: ^4.0.0 || ^5.0.0
         version: 5.0.1
@@ -374,6 +380,9 @@ importers:
       '@deepseek-ai/dsh-llm':
         specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm-pi-ai':
+        specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
+        version: 0.1.1-rc.2(aa3ac838b930116f77e2c84b9f8b896f)
       '@deepseek-ai/dsh-persona':
         specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
         version: 0.1.1-rc.2(c46449525c16bef5ec3490eab6722d56)
@@ -544,6 +553,116 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.34':
+    resolution: {integrity: sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.29':
+    resolution: {integrity: sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.52':
+    resolution: {integrity: sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    resolution: {integrity: sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@deepseek-ai/cordis-plugin-group@1.0.1':
     resolution: {integrity: sha512-E1NThkFB3jn3TCqa6Oc++1zQHqLejF3W2wDwv2BlL3UEmgtBXL1K1j1koc+j676RuiOXtJkUJlPcOntRGKLWBQ==}
     peerDependencies:
@@ -685,6 +804,14 @@ packages:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
       '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+
+  '@deepseek-ai/dsh-authorization@0.1.1-rc.2':
+    resolution: {integrity: sha512-+ye7d4XzenQ4kpfY2nMIlUhoIbcprotL9fmkTBahafIPDhyyph0JzmUVhz1AGnkIqZc8TltjGzX2ssald+f+3A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-credentials': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-brand@0.1.1-rc.2':
     resolution: {integrity: sha512-8vXsAXoUdzKAgvd/E9DgyT6HKmR6ZM4rtJ3fs/XoJ6n2kBk4tWil8Lv+jxCMWJeMOnTJF55gu2+NWQ3ECFPtJw==}
@@ -1341,6 +1468,19 @@ packages:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
 
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.1-rc.2':
+    resolution: {integrity: sha512-/02zlUjTHlJkme5+eM6VFtuiK6TacI5rxwIWMaxItp/s8rz91grzWir+qxRsPrz6XIrmKXagyvi3m/tuRCtk5A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-attachment': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-authorization': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-credentials': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-launch-environment': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-settings': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-timeout': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-llm-retry@0.1.1-rc.2':
     resolution: {integrity: sha512-a13Fpmn8HFy8LCjl6gljaNPxcVjO/R+/uMPDl0QLjwQcHWVyGW38ZA8jP5iRuFgdyNNXpyxLWuZXi/0VOH00tA==}
     peerDependencies:
@@ -1850,6 +1990,11 @@ packages:
   '@deepseek-ai/schemastery@3.18.1':
     resolution: {integrity: sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==}
 
+  '@earendil-works/pi-ai@0.82.1':
+    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
@@ -2202,6 +2347,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -2289,6 +2443,14 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -2296,6 +2458,14 @@ packages:
   '@noble/hashes@2.3.0':
     resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@peculiar/asn1-schema@2.8.0':
     resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
@@ -2311,9 +2481,76 @@ packages:
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2385,6 +2622,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/semver@7.8.0':
     resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
@@ -2492,12 +2732,18 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
@@ -2511,6 +2757,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2649,6 +2898,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2756,6 +3009,9 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -2852,6 +3108,9 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -2875,6 +3134,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -2888,6 +3151,10 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2924,6 +3191,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2955,6 +3230,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3094,8 +3377,15 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -3113,6 +3403,12 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3138,6 +3434,9 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3354,6 +3653,15 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-gyp@12.4.0:
     resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -3389,6 +3697,18 @@ packages:
     resolution: {integrity: sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==}
     engines: {node: '>=20'}
 
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -3396,6 +3716,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -3405,6 +3729,9 @@ packages:
 
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -3476,6 +3803,10 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3536,6 +3867,10 @@ packages:
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
   rimraf@2.6.3:
@@ -3696,6 +4031,9 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3711,6 +4049,9 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -3770,6 +4111,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webcrypto-core@1.9.2:
     resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
@@ -3864,6 +4209,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3891,6 +4241,228 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/util-locate-window': 3.965.10
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.5
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/eventstream-handler-node': 3.972.34
+      '@aws-sdk/middleware-eventstream': 3.972.29
+      '@aws-sdk/middleware-websocket': 3.972.52
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.34':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.29':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@deepseek-ai/cordis-plugin-group@1.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)':
     dependencies:
@@ -4018,6 +4590,13 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-authorization@0.1.1-rc.2(e0350187351f9d964689a3e0122aa410)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-credentials': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
 
   '@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
@@ -4764,6 +5343,27 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.1-rc.2(aa3ac838b930116f77e2c84b9f8b896f)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-authorization': 0.1.1-rc.2(e0350187351f9d964689a3e0122aa410)
+      '@deepseek-ai/dsh-credentials': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-launch-environment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-timeout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+      '@earendil-works/pi-ai': 0.82.1(supports-color@7.2.0)(ws@8.21.2)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@deepseek-ai/dsh-llm-retry@0.1.1-rc.2(a0b14eb40667f7e2f3e22b89a59650a0)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
@@ -5358,6 +5958,27 @@ snapshots:
       '@deepseek-ai/cosmokit': 1.8.2
       '@standard-schema/spec': 1.1.0
 
+  '@earendil-works/pi-ai@0.82.1(supports-color@7.2.0)(ws@8.21.2)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(supports-color@7.2.0)
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      openai: 6.26.0(ws@8.21.2)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
@@ -5606,6 +6227,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@google/genai@1.52.0(supports-color@7.2.0)':
+    dependencies:
+      google-auth-library: 10.9.1(supports-color@7.2.0)
+      p-retry: 4.6.2
+      protobufjs: 7.6.5
+      ws: 8.21.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -5668,9 +6300,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
+      ws: 8.21.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@2.3.0': {}
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@peculiar/asn1-schema@2.8.0':
     dependencies:
@@ -5694,7 +6342,80 @@ snapshots:
       tslib: 2.8.1
       webcrypto-core: 1.9.2
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
   '@sindresorhus/is@4.6.0': {}
+
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5773,6 +6494,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.13.3
+
+  '@types/retry@0.12.0': {}
 
   '@types/semver@7.8.0': {}
 
@@ -5894,10 +6617,14 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
   bluebird@3.7.2: {}
 
   boolean@3.2.0:
     optional: true
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.18:
     dependencies:
@@ -5913,6 +6640,8 @@ snapshots:
       balanced-match: 4.0.4
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -6055,6 +6784,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
@@ -6153,6 +6884,10 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.1.2
 
   ejs@3.1.10:
     dependencies:
@@ -6331,6 +7066,8 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  extend@3.0.2: {}
+
   extract-zip@2.0.1(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -6353,6 +7090,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.8.3: {}
 
   figures@6.1.0:
@@ -6370,6 +7112,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   fs-extra@10.1.0:
     dependencies:
@@ -6414,6 +7160,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.3.1(supports-color@7.2.0):
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2(supports-color@7.2.0):
+    dependencies:
+      gaxios: 7.3.1(supports-color@7.2.0)
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   get-caller-file@2.0.5: {}
 
@@ -6465,6 +7227,19 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
     optional: true
+
+  google-auth-library@10.9.1(supports-color@7.2.0):
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1(supports-color@7.2.0)
+      gcp-metadata: 8.1.2(supports-color@7.2.0)
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -6587,7 +7362,16 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -6605,6 +7389,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.1.2
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.1.2
 
   keyv@4.5.4:
     dependencies:
@@ -6639,6 +7434,8 @@ snapshots:
   lodash.isequal@4.5.0: {}
 
   lodash@4.18.1: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -7014,6 +7811,14 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-gyp@12.4.0:
     dependencies:
       env-paths: 2.2.1
@@ -7057,11 +7862,21 @@ snapshots:
       powershell-utils: 0.2.0
       wsl-utils: 1.0.0
 
+  openai@6.26.0(ws@8.21.2)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.2
+      zod: 4.4.3
+
   p-cancelable@2.1.1: {}
 
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
@@ -7070,6 +7885,8 @@ snapshots:
   parse5@5.1.1: {}
 
   parse5@6.0.1: {}
+
+  partial-json@0.1.7: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -7131,6 +7948,20 @@ snapshots:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 24.13.3
+      long: 5.3.2
 
   pump@3.0.4:
     dependencies:
@@ -7199,6 +8030,8 @@ snapshots:
       lowercase-keys: 2.0.0
 
   retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   rimraf@2.6.3:
     dependencies:
@@ -7365,6 +8198,8 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
+  ts-algebra@2.0.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.23.12:
@@ -7377,6 +8212,8 @@ snapshots:
     optional: true
 
   type-fest@4.41.0: {}
+
+  typebox@1.1.38: {}
 
   typescript@6.0.3: {}
 
@@ -7436,6 +8273,8 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   webcrypto-core@1.9.2:
     dependencies:
@@ -7520,6 +8359,10 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,11 +23,13 @@ peerDependencyRules:
     react: ^19.0.0
 
 allowBuilds:
+  '@google/genai': false
   electron: true
   electron-winstaller: true
   esbuild: true
   koffi: false
   node-pty: true
+  protobufjs: false
 
 onlyBuiltDependencies:
   - electron

--- a/scripts/smoke-runtime.mjs
+++ b/scripts/smoke-runtime.mjs
@@ -183,14 +183,10 @@ try {
   }
 
   for (const pluginId of BUNDLED_DESKTOP_HOST_PLUGINS) {
-    assert.ok(existsSync(join(
-      resources,
-      'dsh-runtime',
-      'node_modules',
-      ...pluginId.split('/'),
-      'dist',
-      'index.js',
-    )), `${pluginId} Host bundle is missing`)
+    const packageDir = join(resources, 'dsh-runtime', 'node_modules', ...pluginId.split('/'))
+    const manifest = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'))
+    assert.ok(existsSync(join(packageDir, manifest.main ?? join('dist', 'index.js'))),
+      `${pluginId} Host bundle is missing`)
   }
 
   const client = spawnSync(electronBinary, [

--- a/scripts/smoke-web.mjs
+++ b/scripts/smoke-web.mjs
@@ -127,6 +127,8 @@ for (const row of [
   'oh-sidebar',
   'oh-panel-controls',
   'oh-plugin-marketplace',
+  'dsh-context',
+  'dsh-auth',
 ]) {
   assert.match(dump.stdout, new RegExp(`\\b${row}\\b`), `composed web profile is missing row ${row}`)
 }
@@ -249,6 +251,15 @@ try {
     'dist',
     'index.js',
   )), '@oh-dsh/vision Host bundle is missing')
+  assert.ok(existsSync(join(
+    resources,
+    'dsh-runtime',
+    'node_modules',
+    '@deepseek-harness-tui',
+    'dsh-auth',
+    'lib',
+    'index.js',
+  )), '@deepseek-harness-tui/dsh-auth Host bundle is missing')
 
   // Only the Electron shell must stay out of the web client graph.
   assert.equal(

--- a/scripts/stage-dsh.mjs
+++ b/scripts/stage-dsh.mjs
@@ -1026,6 +1026,7 @@ const SURFACE_PACKAGE_NAMES = Object.freeze({
     '@oh-dsh/pinned-summary',
     '@oh-dsh/plugin-marketplace',
     'dsh-context',
+    '@deepseek-harness-tui/dsh-auth',
   ]),
   web: new Set([
     '@oh-dsh/web',
@@ -1038,6 +1039,7 @@ const SURFACE_PACKAGE_NAMES = Object.freeze({
     '@oh-dsh/panel-controls',
     '@oh-dsh/plugin-marketplace',
     'dsh-context',
+    '@deepseek-harness-tui/dsh-auth',
   ]),
   tui: new Set([
     '@deepseek-harness-tui/dsh-tui',
@@ -1111,6 +1113,18 @@ function installDesktopPackages(surface = 'all') {
         [join(root, 'dist', 'web', 'client.js'), 'dist/client.js'],
         [join(root, 'dist', 'web', 'client.js.map'), 'dist/client.js.map'],
         [join(root, 'dist', 'web', 'cordis.patch.yml'), 'dist/cordis.patch.yml'],
+      ],
+    },
+    {
+      // The upstream subscription OAuth package is host-only (llm routes +
+      // /auth command over the user-questions seam); Desktop and Web mount
+      // it directly, the TUI loads it through the renderer's oauth row.
+      manifest: join(root, 'upstream', 'dsh-TUI', 'dsh-auth', 'package.json'),
+      files: [
+        [join(root, 'upstream', 'dsh-TUI', 'dsh-auth', 'lib'), 'lib'],
+        [join(root, 'upstream', 'dsh-TUI', 'dsh-auth', 'dsh-plugin.json'), 'dsh-plugin.json'],
+        [join(root, 'upstream', 'dsh-TUI', 'dsh-auth', 'cordis.patch.yml'), 'cordis.patch.yml'],
+        [join(root, 'upstream', 'dsh-TUI', 'dsh-auth', 'LICENSE'), 'LICENSE'],
       ],
     },
     {

--- a/scripts/stage-dsh.mjs
+++ b/scripts/stage-dsh.mjs
@@ -751,16 +751,24 @@ function runtimePackageDirectory(name) {
   return join(runtime, 'node_modules', ...name.split('/'))
 }
 
-function resolveDependencyManifest(requireFromPackage, dependency) {
+function resolveDependencyManifest(requireFromPackage, dependency, fromDirectory) {
   try {
     return requireFromPackage.resolve(`${dependency}/package.json`)
   } catch (packageJsonError) {
-    let directory = dirname(requireFromPackage.resolve(dependency))
+    // A restricted exports map (e.g. @earendil-works/pi-ai) can hide both
+    // ./package.json and the main entry from require.resolve; walk the
+    // node_modules chain from the requiring package instead.
+    let directory = fromDirectory
     for (;;) {
-      const manifestPath = join(directory, 'package.json')
-      if (existsSync(manifestPath)) {
-        const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
-        if (manifest.name === dependency) return manifestPath
+      for (const candidate of [
+        join(directory, 'node_modules', ...dependency.split('/')),
+        directory,
+      ]) {
+        const manifestPath = join(candidate, 'package.json')
+        if (existsSync(manifestPath)) {
+          const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+          if (manifest.name === dependency) return manifestPath
+        }
       }
       const parent = dirname(directory)
       if (parent === directory) throw packageJsonError
@@ -912,7 +920,7 @@ function installCompiledPackageDependencies(sourceManifestPath, packageDir) {
     for (const [dependency, optional] of dependencyNames(manifest)) {
       try {
         const dependencyTarget = installManifest(
-          resolveDependencyManifest(requireFromPackage, dependency),
+          resolveDependencyManifest(requireFromPackage, dependency, source),
         )
         linkDependency(target, dependency, dependencyTarget)
       } catch (error) {
@@ -928,7 +936,11 @@ function installCompiledPackageDependencies(sourceManifestPath, packageDir) {
   for (const [dependency, optional] of dependencyNames(sourceManifest)) {
     try {
       const dependencyTarget = installManifest(
-        resolveDependencyManifest(requireFromSource, dependency),
+        resolveDependencyManifest(
+          requireFromSource,
+          dependency,
+          dirname(sourceManifestPath),
+        ),
       )
       const link = join(installRoot, ...dependency.split('/'))
       mkdirSync(dirname(link), { recursive: true })

--- a/scripts/tui-upstream-adapter.mjs
+++ b/scripts/tui-upstream-adapter.mjs
@@ -236,6 +236,7 @@ export function adaptTuiRendererPackage(packageDir) {
     ['Show the dsh-tui configuration source', 'Show the Oh-DSH TUI configuration source'],
     ['Update dsh-tui and restart', 'Update Oh-DSH TUI and restart'],
     ['Practice programming with dsh-tui', 'Practice programming with Oh-DSH TUI'],
+    ['Restart dsh-tui and resume this session', 'Restart Oh-DSH TUI and resume this session'],
     ['Exit dsh-tui', 'Exit Oh-DSH TUI'],
   ]) {
     replaceEvery(commands, before, after)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -28,6 +28,9 @@ export const BUNDLED_DESKTOP_CLIENT_PLUGINS = [
 export const BUNDLED_DESKTOP_HOST_PLUGINS = [
   '@oh-dsh/better-sidebar-runtime',
   '@oh-dsh/liangshen',
+  // Pinned upstream host plugin (upstream/dsh-TUI/dsh-auth): no browser
+  // half; the /auth command interacts through the user-questions seam.
+  '@deepseek-harness-tui/dsh-auth',
 ] as const
 
 /** Every protected plugin shipped inside the desktop distribution. */

--- a/tests/plugin-collection.test.ts
+++ b/tests/plugin-collection.test.ts
@@ -29,9 +29,13 @@ test('desktop bundle registers every packaged DSH plugin', () => {
     assert.equal(manifest.dshClient, undefined)
   }
   for (const plugin of BUNDLED_DESKTOP_HOST_PLUGINS) {
-    const directory = plugin.slice(plugin.lastIndexOf('/') + 1)
-    const manifest = JSON.parse(readFileSync(join(root, 'plugins', directory, 'package.json'), 'utf8'))
+    const manifestPath = plugin === '@deepseek-harness-tui/dsh-auth'
+      ? join(root, 'upstream', 'dsh-TUI', 'dsh-auth', 'package.json')
+      : join(root, 'plugins', plugin.slice(plugin.lastIndexOf('/') + 1), 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
     assert.equal(manifest.name, plugin)
-    assert.equal(manifest.dsh, undefined)
+    // Host plugins enroll no browser half; upstream bundle manifests may
+    // still declare their patch layer.
+    assert.equal(manifest.dsh?.client, undefined)
   }
 })

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1422,6 +1422,35 @@ test('the marketplace refuses to modify protected desktop plugins', async () => 
   }
 })
 
+test('the marketplace protects the bundled dsh-auth plugin', async () => {
+  const setup = fixture()
+  try {
+    setup.platform.catalog = {
+      schema: 'dsh-external-hub/v0.1',
+      generated: '2026-08-14T00:00:00Z',
+      repos: [{
+        name: 'dsh-auth',
+        repo: 'ccch1mneyyy/dsh-auth',
+        category: 'plugin',
+        description: 'Subscription OAuth sign-in already bundled by Oh-DSH',
+        bundle: true,
+      }],
+    }
+    await setup.manager.dispatch({ type: 'refresh' })
+    const snapshot = await setup.manager.dispatch({
+      type: 'prepare',
+      action: 'install',
+      pluginId: 'dsh-auth',
+    })
+    assert.match(snapshot.error ?? '', /protected by Oh-DSH/)
+    assert.equal(snapshot.preview, null)
+    assert.equal(snapshot.catalog[0]?.protected, true)
+    assert.equal(setup.platform.commands.length, 0)
+  } finally {
+    setup.cleanup()
+  }
+})
+
 test('the marketplace protects the bundled dsh-context plugin', async () => {
   const setup = fixture()
   try {

--- a/web/cordis.patch.yml
+++ b/web/cordis.patch.yml
@@ -47,3 +47,11 @@
     # upstream/dsh-context), shared with the desktop distribution.
     - id: dsh-context
       name: 'dsh-context'
+
+    # Subscription OAuth sign-in (upstream dsh-auth, pinned inside
+    # upstream/dsh-TUI): llm provider routes for ChatGPT/Codex, Claude
+    # Pro/Max and SuperGrok plus the /auth command; login interaction runs
+    # over the user-questions seam. TUI loads it via the renderer instead.
+    - id: dsh-auth
+      name: '@deepseek-harness-tui/dsh-auth'
+      inject: [llm, commands]


### PR DESCRIPTION
## Scope

Bundles upstream
[dsh-auth](https://github.com/ccch1mneyyy/dsh-auth) (pinned inside the
dsh-TUI submodule at `fba02bcf`) as a built-in host plugin on Desktop
and Web, answering the question of making subscription OAuth sign-in a
first-class Oh-DSH capability.

**Stacked on #145** (needs the 0.9.2 pin). This PR targets \`main\`
so CI runs (the workflow only fires on base main); until #145 merges
the diff shows both PRs' commits — merge #145 first, then this one.

- Staged under its npm name from `upstream/dsh-TUI/dsh-auth` for the
  Desktop and Web surfaces and mounted with the upstream row shape
  (`- id: dsh-auth`, entry-level `inject: [llm, commands]`) — the
  same stage-the-upstream-manifest, no-adapter pattern as dsh-context.
  The TUI keeps loading it through the renderer's own oauth row, so no
  surface mounts it twice.
- Host-only by design: `/auth` (ChatGPT/Codex, Claude Pro/Max,
  SuperGrok routes) interacts entirely over the DSH user-questions seam
  and the commands registry — the surfaces' existing question UI
  carries login, and a non-interactive environment degrades to a clear
  refusal. No new client code.
- Every peer resolves from the staged runtime's hoisted tree, including
  `@deepseek-ai/dsh-llm-pi-ai` and `@earendil-works/pi-ai`.
- Test contracts updated: host plugins must enroll no browser half
  (`dsh.client` absent) instead of no `dsh` key; the desktop smoke
  resolves each host plugin's `main` from its staged manifest; the web
  smoke asserts the `dsh-auth` row in the composed profile dump.
- Marketplace protection (plugin id, package, repository) with a
  refusal test; bilingual usage section; Agent Note; notices extended.

## Verification

- Stage web/desktop/tui green; dsh-auth staged on web+desktop only.
- `smoke:web` green incl. composition-dump row assertions;
  `smoke:runtime` green with the generalized host loop.
- `pnpm run typecheck && pnpm test && pnpm run build`: exit 0; 313
  tests, 304 pass, 0 fail.
- `pnpm run verify-translation-pairing`: 585 pairs consistent.

Not covered: a live OAuth login against a real provider (needs external
accounts); coverage relies on the upstream's own tests plus
row/activation/artifact assertions.
