### PR TITLE
nix: point renderer auth at the runtime copy

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
-2026-08-26-bundle-dsh-auth.md: baec6b827ddf0181d706fc81980c340bb69a1fa4
-2026-08-26-bundle-dsh-auth.zh.md: 4c7e935beca90e4bbf8224397475cfd849604ea7
+2026-08-26-bundle-dsh-auth.md: 53956fd8a392ab3bb636be0e0733190e7ffb22e5
+2026-08-26-bundle-dsh-auth.zh.md: 502c59219776032fc2f7f3ae91265e5fec287232

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.md
@@ -40,11 +40,11 @@ patch row. Desktop and Web users had no path to subscription accounts.
   `auth/` dir (npm release layout), and the extra-deps copy loop now merges
   scoped entries package by package instead of skipping a scope directory
   the renderer already created. The full `oh-dsh` package builds clean with
-  both `@deepseek-harness-tui/dsh-auth` and `dsh-context` registered. Scoped
-  extra-deps copies also receive the same `node_modules -> ../..`
-  dependency-root link collect-deps.py creates (only when absent), so the
-  renderer's private link to the auth copy resolves peer imports through the
-  runtime graph.
+  both `@deepseek-harness-tui/dsh-auth` and `dsh-context` registered. The
+  renderer always points its private `dsh-auth` dependency at the final runtime
+  copy: full/web reuse the registered package, while TUI materializes it from
+  extra-deps. That copy resolves peers through the final runtime's
+  `node_modules`, never through the immutable bundle-store source path.
 
 ## Alternatives considered
 
@@ -65,6 +65,9 @@ and works unchanged on every surface today.
 
 - `/auth` works on all three surfaces against the same stored credentials
   in the Oh-DSH data directory.
+- `tests/nix-register-plugins.test.ts` imports the renderer through its actual
+  dependency link on full and TUI fixtures and requires `dsh-auth` to resolve a
+  peer from the final runtime graph.
 - Upgrading the renderer pin moves the dsh-auth source with it; the
   standalone staging spec follows the nested submodule path, so a future
   move of the nested package breaks staging loudly.

--- a/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-bundle-dsh-auth.zh.md
@@ -33,9 +33,9 @@ renderer 自己的 `oauth` patch 行。Desktop 与 Web 用户没有订阅账号�
 - Nix 为 full 与 web 面从 bundle 的 `auth/` 目录（npm 发布布局）注册该包，
   extra-deps 拷贝循环改为逐包合并 scope 条目，而不是跳过 renderer 已创建的
   scope 目录。完整 `oh-dsh` 包构建通过，`@deepseek-harness-tui/dsh-auth` 与
-  `dsh-context` 均注册成功。scope 条目的 extra-deps 拷贝还会在缺失时获得与
-  collect-deps.py 相同的 `node_modules -> ../..` 依赖根链接，使 renderer 指向
-  auth 副本的私有链接能经运行时图解析 peer import。
+  `dsh-context` 均注册成功。renderer 的私有 `dsh-auth` 依赖始终指向最终运行时
+  副本：full/web 复用已注册的 package，TUI 则从 extra-deps 物化该副本。该副本经
+  最终运行时的 `node_modules` 解析 peer，不会回到不可变的 bundle store 源路径。
 
 ## Alternatives considered
 
@@ -53,6 +53,8 @@ renderer 包。
 ## Consequences
 
 - `/auth` 在三个面上可用，凭据同样存储于 Oh-DSH 数据目录。
+- `tests/nix-register-plugins.test.ts` 在 full 与 TUI fixture 中经实际依赖链接导入
+  renderer，并要求 `dsh-auth` 从最终运行时图解析 peer。
 - 升级 renderer pin 会一并移动 dsh-auth 源；独立暂存 spec 指向嵌套子模块
   路径，将来上游移动该嵌套包时暂存会大声失败。
 - 若上游增加客户端半区，该包将从 `BUNDLED_DESKTOP_HOST_PLUGINS` 移入

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -313,8 +313,7 @@ pkgs.stdenv.mkDerivation {
                 cp -r "$sub" "$out/dsh-runtime/node_modules/$subname"
                 chmod -R u+w "$out/dsh-runtime/node_modules/$subname"
                 # Same dependency-root link collect-deps.py gives collected
-                # packages: without it the renderer's private link resolves
-                # to the store real path and peer imports cannot be found.
+                # packages, so direct runtime consumers can resolve peers.
                 if [ ! -e "$out/dsh-runtime/node_modules/$subname/node_modules" ]; then
                   ln -s ../.. "$out/dsh-runtime/node_modules/$subname/node_modules"
                 fi

--- a/nix/register-plugins.py
+++ b/nix/register-plugins.py
@@ -105,7 +105,16 @@ def main():
             for dependency in sorted(dependency_names):
                 extra = os.path.join(extra_deps, *dependency.split("/"))
                 shared = os.path.join(node_modules, *dependency.split("/"))
-                target = extra if os.path.isdir(extra) else shared
+                if dependency == "@deepseek-harness-tui/dsh-auth":
+                    if not os.path.isdir(shared) and os.path.isdir(extra):
+                        os.makedirs(os.path.dirname(shared), exist_ok=True)
+                        shutil.copytree(extra, shared, symlinks=True)
+                    target = shared
+                    dependency_root = os.path.join(target, "node_modules")
+                    if os.path.isdir(target) and not os.path.lexists(dependency_root):
+                        os.symlink(node_modules, dependency_root)
+                else:
+                    target = extra if os.path.isdir(extra) else shared
                 if not os.path.isdir(target):
                     raise FileNotFoundError(f"missing TUI runtime dependency: {dependency}")
                 link = os.path.join(deps_link, *dependency.split("/"))

--- a/tests/nix-register-plugins.test.ts
+++ b/tests/nix-register-plugins.test.ts
@@ -1,9 +1,17 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { test } from 'node:test'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -49,6 +57,65 @@ function runRegistry(fixture: { bundleRoot: string, distRoot: string, runtime: s
   assert.equal(result.status, 0, result.stderr)
 }
 
+function writeModulePackage(
+  directory: string,
+  manifest: object,
+  entry: string,
+  source: string,
+): void {
+  mkdirSync(dirname(join(directory, entry)), { recursive: true })
+  writeFileSync(join(directory, 'package.json'), JSON.stringify(manifest))
+  writeFileSync(join(directory, entry), source)
+}
+
+function writeAuthRegistryFixture() {
+  const fixture = mkdtempSync(join(tmpdir(), 'oh-dsh-nix-auth-registry-'))
+  const bundleRoot = join(fixture, 'bundle')
+  const manifests = join(bundleRoot, 'manifests')
+  const distRoot = join(fixture, 'dist')
+  const renderer = join(bundleRoot, 'tui-renderer')
+  const bundledAuth = join(bundleRoot, 'auth')
+  const auth = join(bundleRoot, 'extra-deps', '@deepseek-harness-tui', 'dsh-auth')
+  const runtime = join(fixture, 'runtime')
+  const peer = join(runtime, 'node_modules', '@fixture', 'peer')
+  const authManifest = {
+    name: '@deepseek-harness-tui/dsh-auth',
+    version: '0.1.0',
+    type: 'module',
+    exports: './lib/index.js',
+    peerDependencies: { '@fixture/peer': '1.0.0' },
+  }
+  const authSource = "export { value as authValue } from '@fixture/peer'\n"
+
+  mkdirSync(manifests, { recursive: true })
+  mkdirSync(join(renderer, 'lib'), { recursive: true })
+  mkdirSync(join(bundledAuth, 'lib'), { recursive: true })
+
+  writeFileSync(join(manifests, 'tui-renderer.json'), JSON.stringify({
+    name: '@deepseek-harness-tui/dsh-tui',
+    version: '0.9.2',
+    dependencies: { '@deepseek-harness-tui/dsh-auth': 'link:./dsh-auth' },
+  }))
+  writeFileSync(join(manifests, 'dsh-auth.json'), JSON.stringify(authManifest))
+  writeFileSync(
+    join(renderer, 'lib', 'index.js'),
+    "export { authValue } from '@deepseek-harness-tui/dsh-auth'\n",
+  )
+  writeFileSync(join(bundledAuth, 'lib', 'index.js'), authSource)
+  writeModulePackage(auth, authManifest, 'lib/index.js', authSource)
+  writeModulePackage(peer, {
+    name: '@fixture/peer',
+    version: '1.0.0',
+    type: 'module',
+    exports: './index.js',
+  }, 'index.js', "export const value = 'peer-ready'\n")
+  writeFileSync(join(runtime, 'package.json'), JSON.stringify({
+    name: '@deepseek-ai/dsh',
+    dependencies: {},
+  }))
+  return { bundleRoot, distRoot, runtime, fixture }
+}
+
 test('Nix registry carries the Liangshen preset into web and full closures', () => {
   for (const surface of ['web', 'full']) {
     const fixture = writeRegistryFixture(surface)
@@ -78,5 +145,31 @@ test('Nix registry leaves the TUI closure on its upstream Liangshen preset', () 
     assert.equal('@oh-dsh/liangshen' in runtime.dependencies, false)
   } finally {
     rmSync(fixture.fixture, { recursive: true, force: true })
+  }
+})
+
+test('Nix renderers resolve dsh-auth peers through the final runtime graph', async () => {
+  for (const surface of ['full', 'tui']) {
+    const fixture = writeAuthRegistryFixture()
+    try {
+      runRegistry(fixture, surface)
+      const scope = join(fixture.runtime, 'node_modules', '@deepseek-harness-tui')
+      const runtimeAuth = join(scope, 'dsh-auth')
+      const rendererRoot = join(scope, 'dsh-tui')
+      const rendererAuth = join(
+        rendererRoot,
+        'node_modules',
+        '@deepseek-harness-tui',
+        'dsh-auth',
+      )
+      const renderer = await import(pathToFileURL(join(
+        rendererRoot, 'lib', 'index.js',
+      )).href)
+      assert.equal(renderer.authValue, 'peer-ready', surface)
+      assert.equal(existsSync(runtimeAuth), true, surface)
+      assert.equal(realpathSync(rendererAuth), realpathSync(runtimeAuth), surface)
+    } finally {
+      rmSync(fixture.fixture, { recursive: true, force: true })
+    }
   }
 })


### PR DESCRIPTION
## Scope

- link the renderer-private `dsh-auth` package to the final runtime copy
- attach that copy to the final runtime `node_modules` dependency root
- cover full and TUI layouts with a real ESM peer import
- update the existing bilingual Agent Note

This follows up the unresolved P1 review on #148: https://github.com/hust-open-atom-club/oh-dsh/pull/148#discussion_r3857010906

## Verification

- `node --test tests/nix-register-plugins.test.ts tests/nix-collect-deps.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run verify:agent-notes`
- `pnpm run verify-translation-pairing`
- Python compile check for `nix/register-plugins.py`

A local Nix CLI is unavailable, so the real `nix build` remains for CI. The filesystem and Node ESM topology tests pass. The full test run passed 302 tests and skipped 9; 3 unrelated self-update assertions read the installer record created by the requested local Desktop reinstall.