### PR TITLE
release: prepare v0.1.10 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH Desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",


### PR DESCRIPTION
## Scope

- update the application manifest from `0.1.9` to `0.1.10`
- prepare the exact stable tag pair `package.json = 0.1.10` / `v0.1.10`
- leave tag creation and packaging blocked until this PR is merged

## Verification

- `node scripts/validate-release-tag.mjs --tag v0.1.10 --version 0.1.10`
- `node --test tests/release-workflow.test.ts` (2 passed)
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run verify:agent-notes`
- `pnpm run verify-translation-pairing`
- `git diff --check`

The full test run passed 302 tests and skipped 9. Three unrelated self-update assertions read the installer record created by the requested local Desktop install and therefore included its recorded `--bin-dir /Users/zevorn/.local/bin`; the release version change does not touch that path. CI runs with clean installer state.