### PR TITLE
tui: lock nested auth for Windows deployment

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
-2026-08-26-upstream-tui-0.9.2-upgrade.md: 3d0fcbdba61a73f81060554e543df2d73b902bdd
-2026-08-26-upstream-tui-0.9.2-upgrade.zh.md: 1327f9830c8a5270e8d2510d1602b103c623bc0b
+2026-08-26-upstream-tui-0.9.2-upgrade.md: 81a68f8fee2d32c450e7aebc6db5fc054180e754
+2026-08-26-upstream-tui-0.9.2-upgrade.zh.md: d512066620da07dd8a3f7150d936d1abf5eeffda

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.md
@@ -31,6 +31,10 @@ subscription LLM route, `/reload` and `/restart`, and fixes a pnpm ≥ 11
   `link:./dsh-auth` resolution produces; Nix consumes the published
   `@deepseek-harness-tui/dsh-auth@0.1.0` tarball through extra-deps, the
   same published-artifact pattern as the renderer.
+- The root pnpm workspace includes the nested `dsh-auth` package and records
+  its importer in the shared lockfile. pnpm deploy rewrites the renderer's
+  `link:./dsh-auth` as a file dependency; explicit workspace membership gives
+  that dependency a locked owner while preserving the pinned submodule source.
 - The guarded renderer adapter learns the new `/restart` command's
   description rewrite; every other 0.9.2 addition needed no adaptation.
 - The upstream fullscreen-default flip (now on by default upstream) is NOT
@@ -51,6 +55,11 @@ form.** Rejected: the nested copy already resolves at runtime and keeps the
 staged manifest byte-identical to the pinned source; only the Nix assembly
 needs the published form.
 
+**Use pnpm legacy deploy for Windows dependency closures.** Rejected: legacy
+deploy does not use the shared workspace lockfile and pnpm 11.21 leaves the
+nested package as a link to its source. The existing copy can dereference that
+link, but dependency resolution would no longer be pinned by the root lockfile.
+
 ## Consequences
 
 - The TUI gains 0.9.2 features (session identity, recap, paste folding,
@@ -65,3 +74,7 @@ needs the published form.
 - liangshen's preset revision moves to
   `liangshen-toolcall-full-catalog-subagents-durable-hint-v5` (durable
   instruction-hint dedupe) with no Oh-DSH-side test changes.
+- Windows TUI release staging preserves the renderer's bundled `dsh-auth`
+  through the deterministic shared-lock deploy path. The staging contract test
+  pins both workspace membership and the lockfile importer, and a
+  Windows-targeted full staging run covers the real deploy path.

--- a/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-upstream-tui-0.9.2-upgrade.zh.md
@@ -26,6 +26,9 @@ Status: implemented
 - 内置 `dsh-auth` 按 renderer `link:./dsh-auth` 解析产生的嵌套副本暂存；Nix
   通过 extra-deps 消费已发布的 `@deepseek-harness-tui/dsh-auth@0.1.0` 包，
   与 renderer 使用相同的已发布产物模式。
+- 根 pnpm workspace 纳入嵌套 `dsh-auth` 包，并在 shared lockfile 中记录其
+  importer。pnpm deploy 会把 renderer 的 `link:./dsh-auth` 改写成 file 依赖；
+  显式 workspace 成员关系在保留固定子模块源码的同时，为该依赖提供锁定归属。
 - 带守卫的 renderer 适配器学习新 `/restart` 命令描述的重写；0.9.2 的其他
   新增均无需适配。
 - 不采纳上游的 fullscreen 默认翻转（上游默认改为开启）：Oh-DSH 启动器保持
@@ -42,6 +45,10 @@ Status: implemented
 运行时已可解析，且暂存 manifest 与固定源保持逐字节一致；只有 Nix 组装需要
 发布形态。
 
+**对 Windows 依赖闭包使用 pnpm legacy deploy。** 不采纳：legacy deploy 不使用
+shared workspace lockfile，且 pnpm 11.21 会把嵌套包保留为指向源码的 link。
+既有复制虽可解引用该 link，但依赖解析将不再受根 lockfile 固定。
+
 ## Consequences
 
 - TUI 在既有 Oh-DSH 启动器契约下获得 0.9.2 特性（会话身份、recap、粘贴折叠、
@@ -54,3 +61,6 @@ Status: implemented
 - liangshen 预设修订号移至
   `liangshen-toolcall-full-catalog-subagents-durable-hint-v5`（持久的指令提示
   去重），Oh-DSH 侧测试无需改动。
+- Windows TUI release 暂存通过确定性的 shared-lock deploy 路径保留 renderer
+  内置的 `dsh-auth`。暂存契约测试同时固定 workspace 成员与 lockfile importer，
+  Windows 目标的完整暂存运行覆盖真实 deploy 路径。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,40 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
 
+  upstream/dsh-TUI/dsh-auth:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.82.1
+        version: 0.82.1(supports-color@7.2.0)(ws@8.21.2)(zod@4.4.3)
+    devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: ^4.0.1
+        version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-attachment':
+        specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-commands':
+        specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
+        version: 0.1.1-rc.2(0ecd3a66a950f0a38490382753aa1d93)
+      '@deepseek-ai/dsh-llm':
+        specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm-pi-ai':
+        specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
+        version: 0.1.1-rc.2(aa3ac838b930116f77e2c84b9f8b896f)
+      '@deepseek-ai/dsh-user-questions':
+        specifier: ^0.1.0-rc.6 || ^0.1.1-rc.1
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(c1537a8836b04097f168b024f1e38d85))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))
+      '@deepseek-ai/schemastery':
+        specifier: ^3.18.1
+        version: 3.18.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   upstream/dsh-TUI/vendor/dsh-std/packages/command:
     dependencies:
       '@dsh-std/connection':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - .
   - plugins/*
   - upstream/dsh-TUI
+  - upstream/dsh-TUI/dsh-auth
   - upstream/dsh-TUI/vendor/dsh-std/packages/command
   - upstream/dsh-TUI/vendor/dsh-std/packages/connection
   - upstream/dsh-TUI/vendor/dsh-std/packages/core

--- a/tests/stage-surface.test.ts
+++ b/tests/stage-surface.test.ts
@@ -41,3 +41,11 @@ test('surface staging keeps Desktop isolated and ships Liangshen as a Web/Deskto
   assert.match(script, /alignBetterSidebarPtyDependency/)
   assert.match(script, /runtimePackageDirectory\('node-pty'\)/)
 })
+
+test('root deploy workspace owns nested TUI link packages', () => {
+  const workspace = readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf8')
+  const lockfile = readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8')
+
+  assert.match(workspace, /^  - upstream\/dsh-TUI\/dsh-auth$/m)
+  assert.match(lockfile, /^  upstream\/dsh-TUI\/dsh-auth:$/m)
+})


### PR DESCRIPTION
## Scope

- add the pinned `upstream/dsh-TUI/dsh-auth` package to the root pnpm workspace
- record its importer in the shared lockfile so pnpm deploy keeps a deterministic owner for `link:./dsh-auth`
- pin the workspace and lockfile contract in `tests/stage-surface.test.ts`
- update the bilingual dsh-TUI 0.9.2 Agent Note

## Release failure

The first v0.1.10 run failed only in Windows TUI staging: https://github.com/hust-open-atom-club/oh-dsh/actions/runs/32909321750/job/98000084194

The new shared-lock deploy rewrote the nested link dependency as a file dependency, then failed because the root lockfile had no dsh-auth importer. Linux and both macOS matrix jobs passed. Publish was skipped, no GitHub Release existed, and the failed local and remote tag were removed before this PR.

## Verification

- focused staging contract: 4 passed
- `pnpm install --frozen-lockfile`
- Windows-targeted `stage:dsh --surface tui`: passed the original deploy path
- staged `dsh-auth` is a materialized directory, not a source symlink
- Windows-targeted `build-tui.mjs`: generated tar and ZIP
- `pnpm run typecheck`
- `pnpm run build`
- Agent Notes and bilingual pairing gates
- `git diff --check`

The full suite passed 303 tests and skipped 9. The same 3 unrelated self-update assertions read the installer record created by the requested local Desktop install.