### PR TITLE
runtime: keep tar operands local on Windows

### DIFF
--- a/.agents/notes/implemented/process/2026-08-23-decoupled-runtime-updates.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-23-decoupled-runtime-updates.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-23-decoupled-runtime-updates.md
-2026-08-23-decoupled-runtime-updates.md: 48a048adb24ba6db36d2fdb1ad8c63be407db933
-2026-08-23-decoupled-runtime-updates.zh.md: 5ad71d9ff620d6e517e36a571efea066a7cb715d
+2026-08-23-decoupled-runtime-updates.md: c2fa11bc073ebcae10594303a206386bc108bc0c
+2026-08-23-decoupled-runtime-updates.zh.md: 75d4e8916d2eb31962bb680f4a49fd49a609a727

--- a/.agents/notes/implemented/process/2026-08-23-decoupled-runtime-updates.md
+++ b/.agents/notes/implemented/process/2026-08-23-decoupled-runtime-updates.md
@@ -18,6 +18,10 @@ model — required a full Oh-DSH Desktop release before users could get it.
   `.stage/dsh-runtime` tree the application packages, so pnpm assembly,
   desktop plugin injection, the settings-boundary patch, and the Linux
   landlock launcher all keep running at build time.
+- `dsh-source.mjs` re-extracts the integrity-checked npm assembly before each
+  stage. Tar receives the archive and extraction directory as basenames under
+  their shared parent directory, so Windows Git Bash cannot interpret a drive
+  letter in the archive operand as a remote host.
 - `src/runtime-update.ts` adds a `RuntimeUpdateManager` in the main
   process: check GitHub Releases for the newest bundle newer than the
   active runtime, download with progress, verify the published SHA-256,
@@ -74,3 +78,7 @@ model — required a full Oh-DSH Desktop release before users could get it.
 - Reuse the marketplace plugin transaction: the marketplace swaps profile
   bundles, not the base runtime the profile runs on; rejected for the
   base-runtime swap, though the verify-then-activate shape mirrors it.
+- Pass absolute Windows paths to tar with `--force-local`: rejected because
+  the release uses the host tar implementation on every platform, while a
+  shared working directory and relative operands need no implementation-
+  specific option.

--- a/.agents/notes/implemented/process/2026-08-23-decoupled-runtime-updates.zh.md
+++ b/.agents/notes/implemented/process/2026-08-23-decoupled-runtime-updates.zh.md
@@ -17,6 +17,9 @@ Desktop 才能到达用户。
   `.sha256`）。该 bundle 就是应用打包用的同一份 `.stage/dsh-runtime`
   树，因此 pnpm 装配、桌面插件注入、settings boundary 补丁和 Linux
   landlock 启动器仍在构建期完成。
+- `dsh-source.mjs` 在每次暂存前重新解压已通过完整性校验的 npm assembly。
+  tar 在 archive 与 extraction directory 的共同父目录下接收两个 basename，
+  因而 Windows Git Bash 不会把 archive 参数中的盘符解释成远程主机。
 - `src/runtime-update.ts` 在主进程新增 `RuntimeUpdateManager`：检查
   GitHub Release 中比当前运行时更新的最新 bundle，带进度下载，校验
   发布的 SHA-256，用系统 tar 解压到 `~/.ohdsh/runtimes/<version>/`，
@@ -62,3 +65,5 @@ Desktop 才能到达用户。
 - 复用 marketplace 插件事务：marketplace 交换的是 profile bundle，
   不是承载该 profile 的基础运行时；基础运行时切换未复用，但"验证后
   激活"的形态与之一致。
+- 向 tar 传绝对 Windows 路径并加 `--force-local`：不采用。release 在各平台
+  使用宿主 tar 实现；切换到共同工作目录并传相对参数，无需依赖实现专属选项。

--- a/scripts/dsh-source.mjs
+++ b/scripts/dsh-source.mjs
@@ -9,7 +9,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -97,6 +97,15 @@ function download(url, target) {
   rmSync(temporary, { force: true })
 }
 
+function extractTarball(archive, extraction) {
+  if (dirname(archive) !== dirname(extraction)) {
+    throw new Error('tar archive and extraction directory must share a parent')
+  }
+  run('tar', ['-xzf', basename(archive), '-C', basename(extraction)], {
+    cwd: dirname(archive),
+  })
+}
+
 /**
  * Resolve a pnpm CLI matching the pinned release. Git checkouts declare
  * their own `packageManager`; npm release assemblies do not, so they fall
@@ -128,7 +137,7 @@ export function resolvePinnedPnpm(source) {
     const extraction = join(cache, `.pnpm-extract-${String(process.pid)}`)
     rmSync(extraction, { recursive: true, force: true })
     mkdirSync(extraction, { recursive: true })
-    run('tar', ['-xzf', archive, '-C', extraction])
+    extractTarball(archive, extraction)
     rmSync(installRoot, { recursive: true, force: true })
     mkdirSync(dirname(cliRoot), { recursive: true })
     renameSync(join(extraction, 'package'), cliRoot)
@@ -233,7 +242,7 @@ function acquireNpmAssembly(target, archive) {
   rmSync(extraction, { recursive: true, force: true })
   mkdirSync(extraction, { recursive: true })
   try {
-    run('tar', ['-xzf', archive, '-C', extraction])
+    extractTarball(archive, extraction)
     const unpacked = join(extraction, 'package')
     if (!existsSync(unpacked)) {
       throw new Error(`DSH npm package did not unpack to ${unpacked}`)

--- a/tests/dsh-source.test.ts
+++ b/tests/dsh-source.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { test } from 'node:test'
@@ -16,6 +16,16 @@ test('desktop release source pins the published DSH npm package', () => {
     'https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.1-rc.2.tgz',
   )
   assert.match(DSH_SOURCE_SPEC.packageManager, /^pnpm@\d+\.\d+\.\d+$/)
+})
+
+test('npm archive extraction keeps tar operands relative on Windows', () => {
+  const source = readFileSync(new URL('../scripts/dsh-source.mjs', import.meta.url), 'utf8')
+
+  assert.match(
+    source,
+    /function extractTarball\(archive, extraction\)[\s\S]*?\['-xzf', basename\(archive\), '-C', basename\(extraction\)\][\s\S]*?cwd: dirname\(archive\)/,
+  )
+  assert.equal([...source.matchAll(/^    extractTarball\(archive, extraction\)$/gm)].length, 2)
 })
 
 test('DSH source override must match the pinned package version', () => {


### PR DESCRIPTION
## Scope

- extract cached npm tarballs from their parent directory using relative archive and destination names
- apply the same helper to the pinned pnpm CLI and DSH npm assembly paths
- pin both extraction call sites in `tests/dsh-source.test.ts`
- update the bilingual decoupled-runtime Agent Note

## Release failure

The second v0.1.10 run confirmed the Windows TUI fix, then failed in the decoupled-runtime step: https://github.com/hust-open-atom-club/oh-dsh/actions/runs/32911628496/job/98006805708

Git Bash tar interpreted the `D:` prefix of the absolute archive path as a remote host. Linux and both macOS jobs passed. Publish was skipped, no GitHub Release existed, and the failed local and remote tag were removed before this PR.

## Verification

- focused dsh-source tests: 3 passed
- Windows-targeted all-surface staging: passed DSH assembly extraction and runtime staging
- `pnpm run typecheck`
- `pnpm run build`
- Agent Notes and bilingual pairing gates
- `git diff --check`

The full suite passed 304 tests and skipped 9. The same 3 unrelated self-update assertions read the installer record created by the requested local Desktop install.