### PR TITLE
presets: localize Liangshen mode metadata

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.md
-2026-08-24-cross-surface-liangshen-preset.md: 5a7930a513481c6e957fcbf27aef490370e8829e
-2026-08-24-cross-surface-liangshen-preset.zh.md: 6b3f4485281143443cddcfc5571041b0f1beebf0
+2026-08-24-cross-surface-liangshen-preset.md: 986028c0a64d3ca510bed544de1c0fe309781369
+2026-08-24-cross-surface-liangshen-preset.zh.md: af7211af4ff79bfb1fcc04c29a299db708d858bf

--- a/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.md
-2026-08-24-cross-surface-liangshen-preset.md: 986028c0a64d3ca510bed544de1c0fe309781369
-2026-08-24-cross-surface-liangshen-preset.zh.md: af7211af4ff79bfb1fcc04c29a299db708d858bf
+2026-08-24-cross-surface-liangshen-preset.md: bb38bd35fcf34dafbd02cad6c1368f0dafd347b0
+2026-08-24-cross-surface-liangshen-preset.zh.md: 0159f8be3073c56f9d065bcb2caf9d085e9143c0

--- a/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.md
+++ b/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.md
@@ -11,11 +11,24 @@ discoverable after the TUI package installed its user-root copy. Web and
 Desktop use the same DSH agent-preset service, but their staged deployments did
 not contain that composition.
 
+The preset publishes one Chinese `name` and `description`. Both the DSH Web
+client and dsh-TUI treated user-root preset metadata as literal copy, so the
+English locale still rendered the Chinese Liangshen name and description.
+
 ## Decision
 
 - Add an Oh-DSH `@oh-dsh/liangshen` Host plugin to the Web and Desktop bundle
   patches. The plugin installs the pinned `presets/liangshen` composition into
   the shared user preset root before sessions are created.
+- Localize only a roster row whose id, name, and description exactly match the
+  pinned Liangshen metadata. A user-authored row, including another row using
+  the `liangshen` id, keeps the text it published.
+- Adapt the pinned DSH Agent-preset client for Web/Desktop and the compiled
+  dsh-TUI roster projection for TUI. Both resolve the Liangshen name and
+  description from the active locale without rewriting preset files.
+- Apply the presentation adapters only to copied runtime packages in regular
+  staging and Nix assembly. Exact, idempotent anchors make a DSH or dsh-TUI
+  layout change fail packaging for review.
 - Skip the install when the surface starts as a read-only viewer
   (`OH_DSH_READ_ONLY=1`): the viewer shares the data root with an active
   surface, and installing would replace preset state that surface owns.
@@ -33,7 +46,18 @@ not contain that composition.
 
 **Copy the preset into the staged DSH config root.** Rejected because it would
 make the preset a deployment asset rather than the explicitly scoped built-in
-Web/Desktop plugin requested by the product boundary.
+Web/Desktop plugin requested by the product boundary. Giving that root
+precedence would also shadow an unmanaged user preset that already owns the
+`liangshen` id, replacing the existing conflict-preservation behavior.
+
+**Translate every row named `liangshen`.** Rejected because an unmanaged user
+preset may legitimately use that id; replacing its published name and
+description would misrepresent user-owned code as the managed composition.
+
+**Add locale maps to `preset.yml`.** Rejected because the pinned
+`dsh-agent-presets` metadata and API accept plain strings. Expanding that wire
+format would require coordinated changes in DSH, dsh-TUI, and every roster
+consumer for one downstream preset.
 
 **Duplicate the preset under a new Oh-DSH plugin package.** Rejected because it
 would create a second copy of a composition whose lifecycle and upstream
@@ -46,11 +70,16 @@ backward compatible.
 ## Consequences
 
 - Web/Desktop Agent preset settings resolve the preset through the built-in
-  plugin, while TUI continues to use dsh-TUI's native implementation.
+  plugin, while TUI continues to use dsh-TUI's native implementation. Both
+  render `Liangshen mode` in English and `梁神模式` in Chinese.
+- Custom preset metadata remains literal, including a conflicting user-owned
+  `liangshen` row that the Host plugin refuses to replace.
 - Surface-local staging includes the plugin only for Web and Desktop; TUI does
   not receive a duplicate Liangshen runtime package.
 - Nix Desktop/Web resolve the plugin package and its preset exactly like the
   staged (non-Nix) deployment, guarded by
   `tests/nix-register-plugins.test.ts`.
-- A dsh-TUI upgrade must revalidate the preset composition and its cross-surface
-  staged copy.
+- `tests/liangshen.test.ts`, `tests/tui.test.ts`, and the Desktop/Web smoke
+  checks pin the canonical-metadata guard and the served client bundles.
+- A DSH or dsh-TUI upgrade must revalidate the presentation anchors, preset
+  composition, and cross-surface staged copy.

--- a/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.md
+++ b/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.md
@@ -20,12 +20,14 @@ English locale still rendered the Chinese Liangshen name and description.
 - Add an Oh-DSH `@oh-dsh/liangshen` Host plugin to the Web and Desktop bundle
   patches. The plugin installs the pinned `presets/liangshen` composition into
   the shared user preset root before sessions are created.
-- Localize only a roster row whose id, name, and description exactly match the
-  pinned Liangshen metadata. A user-authored row, including another row using
-  the `liangshen` id, keeps the text it published.
-- Adapt the pinned DSH Agent-preset client for Web/Desktop and the compiled
-  dsh-TUI roster projection for TUI. Both resolve the Liangshen name and
-  description from the active locale without rewriting preset files.
+- Project the package-owned `.dsh-tui-managed.json` owner through the DSH
+  roster and `agentPreset.list` as `managedBy`. Localize only a row whose
+  owner, id, name, and description match the pinned Liangshen preset. A
+  user-authored row, including one that copies the canonical display text but
+  carries no management marker, keeps the text it published.
+- Adapt the pinned DSH Agent-preset roster, API, and client for Web/Desktop and
+  the compiled dsh-TUI roster projection for TUI. Both resolve the Liangshen
+  name and description from the active locale without rewriting preset files.
 - Apply the presentation adapters only to copied runtime packages in regular
   staging and Nix assembly. Exact, idempotent anchors make a DSH or dsh-TUI
   layout change fail packaging for review.
@@ -50,9 +52,10 @@ Web/Desktop plugin requested by the product boundary. Giving that root
 precedence would also shadow an unmanaged user preset that already owns the
 `liangshen` id, replacing the existing conflict-preservation behavior.
 
-**Translate every row named `liangshen`.** Rejected because an unmanaged user
-preset may legitimately use that id; replacing its published name and
-description would misrepresent user-owned code as the managed composition.
+**Infer ownership from the `liangshen` id or canonical display text.** Rejected
+because an unmanaged user preset may legitimately retain either; replacing its
+published name and description would misrepresent user-owned code as the
+managed composition.
 
 **Add locale maps to `preset.yml`.** Rejected because the pinned
 `dsh-agent-presets` metadata and API accept plain strings. Expanding that wire
@@ -73,13 +76,15 @@ backward compatible.
   plugin, while TUI continues to use dsh-TUI's native implementation. Both
   render `Liangshen mode` in English and `梁神模式` in Chinese.
 - Custom preset metadata remains literal, including a conflicting user-owned
-  `liangshen` row that the Host plugin refuses to replace.
+  `liangshen` row that retains the canonical Chinese display text but does not
+  carry the package-owned marker.
 - Surface-local staging includes the plugin only for Web and Desktop; TUI does
   not receive a duplicate Liangshen runtime package.
 - Nix Desktop/Web resolve the plugin package and its preset exactly like the
   staged (non-Nix) deployment, guarded by
   `tests/nix-register-plugins.test.ts`.
 - `tests/liangshen.test.ts`, `tests/tui.test.ts`, and the Desktop/Web smoke
-  checks pin the canonical-metadata guard and the served client bundles.
+  checks pin the marker-derived ownership field, canonical-metadata guard, and
+  served client bundles.
 - A DSH or dsh-TUI upgrade must revalidate the presentation anchors, preset
   composition, and cross-surface staged copy.

--- a/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.zh.md
@@ -10,11 +10,21 @@ Status: implemented
 才可发现。Web 和 Desktop 使用同一个 DSH agent-preset service，但各自的 staged
 deployment 没有这份 composition。
 
+该 preset 只发布一套中文 `name` 和 `description`。DSH Web client 与 dsh-TUI 都把
+用户根目录中的 preset 元数据按原文显示，因此英文 locale 仍显示中文的梁神模式名称
+与说明。
+
 ## Decision
 
 - 增加 Oh-DSH 内置 `@oh-dsh/liangshen` Host plugin，并在 Web/Desktop bundle
   patch 中挂载；plugin 在会话创建前把 pinned `presets/liangshen` composition
   安装到共享用户 preset 根目录。
+- 仅本地化 id、名称、说明与 pinned 梁神元数据完全一致的 roster 行。用户创作的行
+  即使也使用 `liangshen` id，仍显示自己发布的文本。
+- Web/Desktop 适配 pinned DSH Agent preset client，TUI 适配编译后的 dsh-TUI
+  roster 投影。两者都按当前 locale 解析梁神模式的名称与说明，不改写 preset 文件。
+- 普通 staging 与 Nix 装配只适配复制后的运行时 package。适配使用精确且幂等的
+  anchor；DSH 或 dsh-TUI 布局变化会让打包失败并要求复核。
 - 以只读 viewer 启动（`OH_DSH_READ_ONLY=1`）时跳过安装：viewer 与活跃
   surface 共享 data root，此时安装会覆盖那个 surface 拥有的 preset 状态。
 - 在 Nix 的 `full` 与 `web` 装配中通过 `nix/register-plugins.py` 注册该
@@ -29,6 +39,15 @@ deployment 没有这份 composition。
 
 **复制到 staged DSH config root。** 不采纳，因为这会把 preset 变成 deployment
 asset，而不是产品要求的、明确限定在 Web/Desktop 的内置 plugin。
+让该根目录优先还会遮蔽已经占用 `liangshen` id 的非托管用户 preset，改变现有的
+冲突保护行为。
+
+**翻译所有名为 `liangshen` 的行。** 不采纳，因为非托管用户 preset 可以合法使用
+该 id；替换它发布的名称与说明，会把用户自有代码误写成托管 composition。
+
+**给 `preset.yml` 增加 locale map。** 不采纳，因为 pinned
+`dsh-agent-presets` 的元数据与 API 只接受普通字符串。为一个下游 preset 扩展该协议
+格式，需要同时修改 DSH、dsh-TUI 以及所有 roster 消费方。
 
 **复制成新的 Oh-DSH plugin package。** 不采纳，因为这会产生一份由两个项目共同
 维护的 composition 副本，而它的生命周期和上游归属已经由 dsh-TUI 负责。
@@ -39,9 +58,14 @@ asset，而不是产品要求的、明确限定在 Web/Desktop 的内置 plugin�
 ## Consequences
 
 - Web/Desktop Agent preset 设置通过内置 plugin 解析梁神模式，TUI 继续使用 dsh-TUI
-  原生实现。
+  原生实现。英文界面显示 `Liangshen mode`，中文界面显示 `梁神模式`。
+- 自定义 preset 元数据仍按原文显示；Host plugin 拒绝替换的同名用户
+  `liangshen` 行也不例外。
 - 按交互端的本地 staging 只在 Web/Desktop 包含该 plugin；TUI 不会收到重复的
   Liangshen runtime package。
 - Nix 的 Desktop/Web 与 staged（非 Nix）部署以相同方式解析 plugin package 及
   其 preset，由 `tests/nix-register-plugins.test.ts` 守护。
-- 每次 dsh-TUI 升级都需要重新验证 preset composition 以及三端 staged copy。
+- `tests/liangshen.test.ts`、`tests/tui.test.ts` 以及 Desktop/Web 冒烟测试固定了
+  canonical 元数据保护与实际提供的 client bundle。
+- 每次升级 DSH 或 dsh-TUI 都需要重新验证 presentation anchor、preset
+  composition 以及三端 staged copy。

--- a/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-24-cross-surface-liangshen-preset.zh.md
@@ -19,10 +19,13 @@ deployment 没有这份 composition。
 - 增加 Oh-DSH 内置 `@oh-dsh/liangshen` Host plugin，并在 Web/Desktop bundle
   patch 中挂载；plugin 在会话创建前把 pinned `presets/liangshen` composition
   安装到共享用户 preset 根目录。
-- 仅本地化 id、名称、说明与 pinned 梁神元数据完全一致的 roster 行。用户创作的行
-  即使也使用 `liangshen` id，仍显示自己发布的文本。
-- Web/Desktop 适配 pinned DSH Agent preset client，TUI 适配编译后的 dsh-TUI
-  roster 投影。两者都按当前 locale 解析梁神模式的名称与说明，不改写 preset 文件。
+- 将 package 自有 `.dsh-tui-managed.json` 的 owner 通过 DSH roster 和
+  `agentPreset.list` 投影为 `managedBy`。仅本地化 owner、id、名称、说明均与 pinned
+  梁神 preset 一致的行。用户创作的行即使复制了 canonical 展示文本，只要没有管理
+  标记，仍显示自己发布的文本。
+- Web/Desktop 适配 pinned DSH Agent preset roster、API 与 client，TUI 适配编译后的
+  dsh-TUI roster 投影。两者都按当前 locale 解析梁神模式的名称与说明，不改写 preset
+  文件。
 - 普通 staging 与 Nix 装配只适配复制后的运行时 package。适配使用精确且幂等的
   anchor；DSH 或 dsh-TUI 布局变化会让打包失败并要求复核。
 - 以只读 viewer 启动（`OH_DSH_READ_ONLY=1`）时跳过安装：viewer 与活跃
@@ -42,8 +45,9 @@ asset，而不是产品要求的、明确限定在 Web/Desktop 的内置 plugin�
 让该根目录优先还会遮蔽已经占用 `liangshen` id 的非托管用户 preset，改变现有的
 冲突保护行为。
 
-**翻译所有名为 `liangshen` 的行。** 不采纳，因为非托管用户 preset 可以合法使用
-该 id；替换它发布的名称与说明，会把用户自有代码误写成托管 composition。
+**根据 `liangshen` id 或 canonical 展示文本推断所有权。** 不采纳，因为非托管用户
+preset 可以合法保留任一项；替换它发布的名称与说明，会把用户自有代码误写成托管
+composition。
 
 **给 `preset.yml` 增加 locale map。** 不采纳，因为 pinned
 `dsh-agent-presets` 的元数据与 API 只接受普通字符串。为一个下游 preset 扩展该协议
@@ -59,13 +63,13 @@ asset，而不是产品要求的、明确限定在 Web/Desktop 的内置 plugin�
 
 - Web/Desktop Agent preset 设置通过内置 plugin 解析梁神模式，TUI 继续使用 dsh-TUI
   原生实现。英文界面显示 `Liangshen mode`，中文界面显示 `梁神模式`。
-- 自定义 preset 元数据仍按原文显示；Host plugin 拒绝替换的同名用户
-  `liangshen` 行也不例外。
+- 自定义 preset 元数据仍按原文显示；Host plugin 拒绝替换、保留 canonical 中文展示
+  文本但不携带 package 管理标记的 `liangshen` 行也不例外。
 - 按交互端的本地 staging 只在 Web/Desktop 包含该 plugin；TUI 不会收到重复的
   Liangshen runtime package。
 - Nix 的 Desktop/Web 与 staged（非 Nix）部署以相同方式解析 plugin package 及
   其 preset，由 `tests/nix-register-plugins.test.ts` 守护。
 - `tests/liangshen.test.ts`、`tests/tui.test.ts` 以及 Desktop/Web 冒烟测试固定了
-  canonical 元数据保护与实际提供的 client bundle。
+  marker 派生的所有权字段、canonical 元数据保护与实际提供的 client bundle。
 - 每次升级 DSH 或 dsh-TUI 都需要重新验证 presentation anchor、preset
   composition 以及三端 staged copy。

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -218,6 +218,8 @@ let
         upstream/dsh-TUI-release/LICENSE \
         $out/lib/oh-dsh/tui-renderer/
       node -e "import('./scripts/tui-upstream-adapter.mjs').then(({ adaptTuiRendererPackage }) => adaptTuiRendererPackage('$out/lib/oh-dsh/tui-renderer'))"
+      node ${../plugins/liangshen/src/upstream-adapter.mjs} tui \
+        $out/lib/oh-dsh/tui-renderer
 
       # Collect runtime dependency closures that the DSH runtime may not ship.
       mkdir -p $out/lib/oh-dsh/extra-deps
@@ -280,6 +282,11 @@ pkgs.stdenv.mkDerivation {
     # anchors change.
     ${pkgs.nodejs_24}/bin/node ${../scripts/settings-boundary.mjs} \
       $out/dsh-runtime
+    ${lib.optionalString includesWeb ''
+      ${pkgs.nodejs_24}/bin/node \
+        ${../plugins/liangshen/src/upstream-adapter.mjs} \
+        dsh $out/dsh-runtime
+    ''}
 
     # Node runtime: reuse the same nodejs that built the bundle. The DSH
     # runtime's HMR service requires --expose-internals (upstream releases

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -282,6 +282,9 @@ pkgs.stdenv.mkDerivation {
     # anchors change.
     ${pkgs.nodejs_24}/bin/node ${../scripts/settings-boundary.mjs} \
       $out/dsh-runtime
+    ${pkgs.nodejs_24}/bin/node \
+      ${../plugins/liangshen/src/upstream-adapter.mjs} \
+      ownership $out/dsh-runtime
     ${lib.optionalString includesWeb ''
       ${pkgs.nodejs_24}/bin/node \
         ${../plugins/liangshen/src/upstream-adapter.mjs} \

--- a/plugins/liangshen/src/upstream-adapter.d.mts
+++ b/plugins/liangshen/src/upstream-adapter.d.mts
@@ -1,2 +1,3 @@
+export function adaptDshLiangshenOwnership(runtimeRoot: string): void
 export function adaptDshLiangshenPresentation(runtimeRoot: string): void
 export function adaptTuiLiangshenPresentation(packageDir: string): void

--- a/plugins/liangshen/src/upstream-adapter.d.mts
+++ b/plugins/liangshen/src/upstream-adapter.d.mts
@@ -1,0 +1,2 @@
+export function adaptDshLiangshenPresentation(runtimeRoot: string): void
+export function adaptTuiLiangshenPresentation(packageDir: string): void

--- a/plugins/liangshen/src/upstream-adapter.mjs
+++ b/plugins/liangshen/src/upstream-adapter.mjs
@@ -148,9 +148,29 @@ export function adaptDshLiangshenPresentation(runtimeRoot) {
     'lib',
     'client.js',
   )
-  if (!existsSync(path)) {
-    throw new Error('dsh-client-ui-agent-preset is missing from the staged runtime')
+  const connectionPath = dshPackageFilePath(
+    runtimeRoot,
+    'dsh-client-connection',
+    'lib',
+    'client.js',
+  )
+  for (const required of [path, connectionPath]) {
+    if (!existsSync(required)) {
+      throw new Error(`Liangshen browser adapter dependency is missing: ${required}`)
+    }
   }
+  const connectionSchemaAnchor = [
+    '\t\t\tid: string().min(1),',
+    '\t\t\ttrust: union([literal("system"), literal("user")]),',
+    '\t\t\tisDefault: boolean(),',
+  ].join('\n')
+  patchFile(connectionPath, [[connectionSchemaAnchor, [
+    '\t\t\tid: string().min(1),',
+    '\t\t\ttrust: union([literal("system"), literal("user")]),',
+    '\t\t\tmanagedBy: string().min(1).optional(),',
+    '\t\t\tisDefault: boolean(),',
+  ].join('\n')]])
+
   const englishAnchor = '\t\t\tpresetCordisDescription: "Built for creating custom agent presets, with all Standard mode capabilities plus runtime inspection, plugin experiments, and preset-authoring guidance.",'
   const chineseAnchor = '\t\t\tpresetCordisDescription: "用于创建自定义 Agent preset：具备标准模式的全部能力，并提供运行时检查、插件实验和 preset 创作指导。",'
   const mappingAnchor = [

--- a/plugins/liangshen/src/upstream-adapter.mjs
+++ b/plugins/liangshen/src/upstream-adapter.mjs
@@ -7,6 +7,8 @@ const LIANGSHEN_METADATA = {
   name: '梁神模式',
   description: '主 Agent 与子 Agent 首轮均保持 Minimal 双工具，首次工具调用后开放完整目录，压缩后重新锚定。',
 }
+const LIANGSHEN_OWNER = '@deepseek-harness-tui/dsh-tui'
+const LIANGSHEN_MARKER = '.dsh-tui-managed.json'
 
 const LIANGSHEN_MESSAGES = {
   en: {
@@ -16,7 +18,7 @@ const LIANGSHEN_MESSAGES = {
   zh: {
     name: LIANGSHEN_METADATA.name,
     description: LIANGSHEN_METADATA.description,
-  }
+  },
 }
 
 function replaceRequired(source, before, after, path) {
@@ -38,12 +40,114 @@ function patchFile(path, replacements) {
 }
 
 /**
+ * Carry the managed-preset marker through the pinned Host roster and API.
+ * Display strings stay ordinary user metadata; only the package-owned marker
+ * can authorize the downstream presentation adapters.
+ */
+export function adaptDshLiangshenOwnership(runtimeRoot) {
+  const rosterPath = dshPackageFilePath(
+    runtimeRoot,
+    'dsh-agent-presets',
+    'lib',
+    'index.js',
+  )
+  const apiPath = dshPackageFilePath(
+    runtimeRoot,
+    'dsh-host-apiproxy',
+    'lib',
+    'index.js',
+  )
+  for (const path of [rosterPath, apiPath]) {
+    if (!existsSync(path)) {
+      throw new Error(`Liangshen ownership adapter dependency is missing: ${path}`)
+    }
+  }
+
+  const metadataAnchor = 'const METADATA_FILE = "preset.yml";'
+  const scanAnchor = 'async function scanRoot(root) {'
+  const rosterAnchor = [
+    '\t\tconst metadata = await readPresetMetadata(directory);',
+    '\t\tfound.push({',
+    '\t\t\tid: child.name,',
+    '\t\t\ttrust: root.trust,',
+    '\t\t\tpath,',
+    '\t\t\t...metadata,',
+    '\t\t\t...broken === void 0 ? {} : { broken }',
+    '\t\t});',
+  ].join('\n')
+  patchFile(rosterPath, [
+    [metadataAnchor, [
+      metadataAnchor,
+      `const OH_DSH_LIANGSHEN_MARKER = ${JSON.stringify(LIANGSHEN_MARKER)};`,
+      `const OH_DSH_LIANGSHEN_OWNER = ${JSON.stringify(LIANGSHEN_OWNER)};`,
+    ].join('\n')],
+    [scanAnchor, [
+      'async function ohDshManagedPresetOwner(directory, id) {',
+      `\tif (id !== ${JSON.stringify(LIANGSHEN_METADATA.id)}) return void 0;`,
+      '\ttry {',
+      '\t\tconst marker = JSON.parse(await readFile(join(directory, OH_DSH_LIANGSHEN_MARKER), "utf8"));',
+      '\t\treturn typeof marker === "object" && marker !== null && !Array.isArray(marker)',
+      '\t\t\t&& marker.owner === OH_DSH_LIANGSHEN_OWNER && marker.preset === id',
+      '\t\t\t? marker.owner',
+      '\t\t\t: void 0;',
+      '\t} catch {',
+      '\t\treturn void 0;',
+      '\t}',
+      '}',
+      scanAnchor,
+    ].join('\n')],
+    [rosterAnchor, [
+      '\t\tconst metadata = await readPresetMetadata(directory);',
+      '\t\tconst managedBy = await ohDshManagedPresetOwner(directory, child.name);',
+      '\t\tfound.push({',
+      '\t\t\tid: child.name,',
+      '\t\t\ttrust: root.trust,',
+      '\t\t\tpath,',
+      '\t\t\t...managedBy === void 0 ? {} : { managedBy },',
+      '\t\t\t...metadata,',
+      '\t\t\t...broken === void 0 ? {} : { broken }',
+      '\t\t});',
+    ].join('\n')],
+  ])
+
+  const apiRosterAnchor = [
+    '\t\t\t\t\t\tid: preset.id,',
+    '\t\t\t\t\t\ttrust: preset.trust,',
+    '\t\t\t\t\t\tisDefault: preset.id === defaultId,',
+  ].join('\n')
+  const apiSchemaAnchor = [
+    '\tid: z$1.string().min(1),',
+    '\ttrust: z$1.union([z$1.literal("system"), z$1.literal("user")]),',
+    '\tisDefault: z$1.boolean(),',
+  ].join('\n')
+  patchFile(apiPath, [
+    [apiRosterAnchor, [
+      '\t\t\t\t\t\tid: preset.id,',
+      '\t\t\t\t\t\ttrust: preset.trust,',
+      '\t\t\t\t\t\t...preset.managedBy === void 0 ? {} : { managedBy: preset.managedBy },',
+      '\t\t\t\t\t\tisDefault: preset.id === defaultId,',
+    ].join('\n')],
+    [apiSchemaAnchor, [
+      '\tid: z$1.string().min(1),',
+      '\ttrust: z$1.union([z$1.literal("system"), z$1.literal("user")]),',
+      '\tmanagedBy: z$1.string().min(1).optional(),',
+      '\tisDefault: z$1.boolean(),',
+    ].join('\n')],
+  ])
+}
+
+/**
  * Adapt the pinned DSH browser preset renderer inside an assembled runtime.
  * Exact anchors make a DSH package change fail staging instead of silently
  * returning to mixed-language Liangshen copy.
  */
 export function adaptDshLiangshenPresentation(runtimeRoot) {
-  const path = dshAgentPresetClientPath(runtimeRoot)
+  const path = dshPackageFilePath(
+    runtimeRoot,
+    'dsh-client-ui-agent-preset',
+    'lib',
+    'client.js',
+  )
   if (!existsSync(path)) {
     throw new Error('dsh-client-ui-agent-preset is missing from the staged runtime')
   }
@@ -75,12 +179,23 @@ export function adaptDshLiangshenPresentation(runtimeRoot) {
       '\t\t\t}',
     ].join('\n')],
     [resolverAnchor, [
-      `\t\t\tconst isOhDshLiangshen = preset.id === ${JSON.stringify(LIANGSHEN_METADATA.id)}`,
+      `\t\t\tconst isOhDshLiangshen = preset.managedBy === ${JSON.stringify(LIANGSHEN_OWNER)}`,
+      `\t\t\t\t&& preset.id === ${JSON.stringify(LIANGSHEN_METADATA.id)}`,
       `\t\t\t\t&& preset.name === ${JSON.stringify(LIANGSHEN_METADATA.name)}`,
       `\t\t\t\t&& preset.description === ${JSON.stringify(LIANGSHEN_METADATA.description)};`,
       '\t\t\tconst keys = preset.trust === "system" || isOhDshLiangshen',
       '\t\t\t\t? BUILT_IN_PRESET_KEYS[preset.id]',
       '\t\t\t\t: void 0;',
+    ].join('\n')],
+    [[
+      '\t\t\t\tid: preset.id,',
+      '\t\t\t\ttrust: preset.trust,',
+      '\t\t\t\t...preset.name === void 0 ? {} : { name: preset.name },',
+    ].join('\n'), [
+      '\t\t\t\tid: preset.id,',
+      '\t\t\t\ttrust: preset.trust,',
+      '\t\t\t\t...preset.managedBy === void 0 ? {} : { managedBy: preset.managedBy },',
+      '\t\t\t\t...preset.name === void 0 ? {} : { name: preset.name },',
     ].join('\n')],
   ])
 }
@@ -112,7 +227,8 @@ export function adaptTuiLiangshenPresentation(packageDir) {
     ].join('\n')
   const channelReplacement = [
       '                return list.map(preset => {',
-      `                    const isOhDshLiangshen = preset.id === ${JSON.stringify(LIANGSHEN_METADATA.id)}`,
+      `                    const isOhDshLiangshen = preset.managedBy === ${JSON.stringify(LIANGSHEN_OWNER)}`,
+      `                        && preset.id === ${JSON.stringify(LIANGSHEN_METADATA.id)}`,
       `                        && preset.name === ${JSON.stringify(LIANGSHEN_METADATA.name)}`,
       `                        && preset.description === ${JSON.stringify(LIANGSHEN_METADATA.description)};`,
       '                    return {',
@@ -129,27 +245,19 @@ export function adaptTuiLiangshenPresentation(packageDir) {
   patchFile(channelPath, [[channelAnchor, channelReplacement]])
 }
 
-/** Resolve the pinned DSH browser bundle in pnpm or hoisted deployments. */
-function dshAgentPresetClientPath(runtimeRoot) {
-  const hoisted = join(
-    runtimeRoot,
+/** Resolve one pinned DSH package file in pnpm or hoisted deployments. */
+function dshPackageFilePath(runtimeRoot, packageName, ...segments) {
+  const packagePath = join(
     'node_modules',
     '@deepseek-ai',
-    'dsh-client-ui-agent-preset',
-    'lib',
-    'client.js',
+    packageName,
+    ...segments,
   )
+  const hoisted = join(runtimeRoot, packagePath)
   if (existsSync(hoisted)) return hoisted
 
   const store = join(runtimeRoot, 'node_modules', '.pnpm')
   if (existsSync(store)) {
-    const packagePath = join(
-      'node_modules',
-      '@deepseek-ai',
-      'dsh-client-ui-agent-preset',
-      'lib',
-      'client.js',
-    )
     const entry = readdirSync(store, { withFileTypes: true })
       .find(candidate => candidate.isDirectory()
         && existsSync(join(store, candidate.name, packagePath)))
@@ -166,9 +274,10 @@ const invokedPath = process.argv[1] === undefined
 if (invokedPath === import.meta.url) {
   const [surface, target] = process.argv.slice(2)
   if (target === undefined || process.argv.length !== 4) {
-    throw new Error('usage: node upstream-adapter.mjs <dsh|tui> <runtime-or-package-root>')
+    throw new Error('usage: node upstream-adapter.mjs <ownership|dsh|tui> <runtime-or-package-root>')
   }
-  if (surface === 'dsh') adaptDshLiangshenPresentation(resolve(target))
+  if (surface === 'ownership') adaptDshLiangshenOwnership(resolve(target))
+  else if (surface === 'dsh') adaptDshLiangshenPresentation(resolve(target))
   else if (surface === 'tui') adaptTuiLiangshenPresentation(resolve(target))
   else throw new Error(`unknown Liangshen presentation surface: ${String(surface)}`)
 }

--- a/plugins/liangshen/src/upstream-adapter.mjs
+++ b/plugins/liangshen/src/upstream-adapter.mjs
@@ -143,19 +143,18 @@ function dshAgentPresetClientPath(runtimeRoot) {
 
   const store = join(runtimeRoot, 'node_modules', '.pnpm')
   if (existsSync(store)) {
+    const packagePath = join(
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-client-ui-agent-preset',
+      'lib',
+      'client.js',
+    )
     const entry = readdirSync(store, { withFileTypes: true })
       .find(candidate => candidate.isDirectory()
-        && candidate.name.startsWith('@deepseek-ai+dsh-client-ui-agent-preset@'))
+        && existsSync(join(store, candidate.name, packagePath)))
     if (entry !== undefined) {
-      return join(
-        store,
-        entry.name,
-        'node_modules',
-        '@deepseek-ai',
-        'dsh-client-ui-agent-preset',
-        'lib',
-        'client.js',
-      )
+      return join(store, entry.name, packagePath)
     }
   }
   return hoisted

--- a/plugins/liangshen/src/upstream-adapter.mjs
+++ b/plugins/liangshen/src/upstream-adapter.mjs
@@ -1,0 +1,175 @@
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const LIANGSHEN_METADATA = {
+  id: 'liangshen',
+  name: '梁神模式',
+  description: '主 Agent 与子 Agent 首轮均保持 Minimal 双工具，首次工具调用后开放完整目录，压缩后重新锚定。',
+}
+
+const LIANGSHEN_MESSAGES = {
+  en: {
+    name: 'Liangshen mode',
+    description: 'Keeps the main agent and subagents on the Minimal two-tool bootstrap for the first model request, exposes the full catalog after the first tool call, and re-anchors after compaction.',
+  },
+  zh: {
+    name: LIANGSHEN_METADATA.name,
+    description: LIANGSHEN_METADATA.description,
+  }
+}
+
+function replaceRequired(source, before, after, path) {
+  if (source.includes(after)) return source
+  const first = source.indexOf(before)
+  if (first === -1 || source.indexOf(before, first + before.length) !== -1) {
+    throw new Error(`Liangshen presentation adapter seam changed: ${path}`)
+  }
+  return source.slice(0, first) + after + source.slice(first + before.length)
+}
+
+function patchFile(path, replacements) {
+  const source = readFileSync(path, 'utf8')
+  const next = replacements.reduce(
+    (current, [before, after]) => replaceRequired(current, before, after, path),
+    source,
+  )
+  if (next !== source) writeFileSync(path, next)
+}
+
+/**
+ * Adapt the pinned DSH browser preset renderer inside an assembled runtime.
+ * Exact anchors make a DSH package change fail staging instead of silently
+ * returning to mixed-language Liangshen copy.
+ */
+export function adaptDshLiangshenPresentation(runtimeRoot) {
+  const path = dshAgentPresetClientPath(runtimeRoot)
+  if (!existsSync(path)) {
+    throw new Error('dsh-client-ui-agent-preset is missing from the staged runtime')
+  }
+  const englishAnchor = '\t\t\tpresetCordisDescription: "Built for creating custom agent presets, with all Standard mode capabilities plus runtime inspection, plugin experiments, and preset-authoring guidance.",'
+  const chineseAnchor = '\t\t\tpresetCordisDescription: "用于创建自定义 Agent preset：具备标准模式的全部能力，并提供运行时检查、插件实验和 preset 创作指导。",'
+  const mappingAnchor = [
+    '\t\t\tcordis: {',
+    '\t\t\t\tname: "presetCordisName",',
+    '\t\t\t\tdescription: "presetCordisDescription"',
+    '\t\t\t}',
+  ].join('\n')
+  const resolverAnchor = '\t\t\tconst keys = preset.trust === "system" ? BUILT_IN_PRESET_KEYS[preset.id] : void 0;'
+  patchFile(path, [
+    [englishAnchor, [
+      englishAnchor,
+      `\t\t\tpresetLiangshenName: ${JSON.stringify(LIANGSHEN_MESSAGES.en.name)},`,
+      `\t\t\tpresetLiangshenDescription: ${JSON.stringify(LIANGSHEN_MESSAGES.en.description)},`,
+    ].join('\n')],
+    [chineseAnchor, [
+      chineseAnchor,
+      `\t\t\tpresetLiangshenName: ${JSON.stringify(LIANGSHEN_MESSAGES.zh.name)},`,
+      `\t\t\tpresetLiangshenDescription: ${JSON.stringify(LIANGSHEN_MESSAGES.zh.description)},`,
+    ].join('\n')],
+    [mappingAnchor, [
+      mappingAnchor + ',',
+      '\t\t\tliangshen: {',
+      '\t\t\t\tname: "presetLiangshenName",',
+      '\t\t\t\tdescription: "presetLiangshenDescription"',
+      '\t\t\t}',
+    ].join('\n')],
+    [resolverAnchor, [
+      `\t\t\tconst isOhDshLiangshen = preset.id === ${JSON.stringify(LIANGSHEN_METADATA.id)}`,
+      `\t\t\t\t&& preset.name === ${JSON.stringify(LIANGSHEN_METADATA.name)}`,
+      `\t\t\t\t&& preset.description === ${JSON.stringify(LIANGSHEN_METADATA.description)};`,
+      '\t\t\tconst keys = preset.trust === "system" || isOhDshLiangshen',
+      '\t\t\t\t? BUILT_IN_PRESET_KEYS[preset.id]',
+      '\t\t\t\t: void 0;',
+    ].join('\n')],
+  ])
+}
+
+/**
+ * Adapt the pinned dsh-TUI preset renderer inside its copied package.
+ * The renderer receives localized metadata only for the canonical managed
+ * copy; another user-authored `liangshen` preset keeps its own display text.
+ */
+export function adaptTuiLiangshenPresentation(packageDir) {
+  const types = join(packageDir, 'lib', 'types')
+  const messagesPath = join(types, 'i18n.js')
+  const messagesAnchor = "    'preset-unavailable': { zh: 'Preset 不可用——当前组合未挂载 agent-presets 名册', en: 'Preset unavailable — the agent-presets roster is not mounted' },"
+  patchFile(messagesPath, [[messagesAnchor, [
+      messagesAnchor,
+      `    'preset-liangshen-name': { zh: ${JSON.stringify(LIANGSHEN_MESSAGES.zh.name)}, en: ${JSON.stringify(LIANGSHEN_MESSAGES.en.name)} },`,
+      `    'preset-liangshen-description': { zh: ${JSON.stringify(LIANGSHEN_MESSAGES.zh.description)}, en: ${JSON.stringify(LIANGSHEN_MESSAGES.en.description)} },`,
+    ].join('\n')]])
+
+  const channelPath = join(types, 'dsh-adapter', 'channel.js')
+  const channelAnchor = [
+      '                return list.map(preset => ({',
+      '                    id: preset.id,',
+      '                    ...(preset.name === undefined ? {} : { name: preset.name }),',
+      '                    ...(preset.description === undefined ? {} : { description: preset.description }),',
+      '                    ...(preset.broken === undefined ? {} : { broken: preset.broken }),',
+      '                    isDefault: preset.id === presets.defaultId,',
+      '                }));',
+    ].join('\n')
+  const channelReplacement = [
+      '                return list.map(preset => {',
+      `                    const isOhDshLiangshen = preset.id === ${JSON.stringify(LIANGSHEN_METADATA.id)}`,
+      `                        && preset.name === ${JSON.stringify(LIANGSHEN_METADATA.name)}`,
+      `                        && preset.description === ${JSON.stringify(LIANGSHEN_METADATA.description)};`,
+      '                    return {',
+      '                        id: preset.id,',
+      "                        ...(isOhDshLiangshen ? { name: t('preset-liangshen-name') }",
+      '                            : preset.name === undefined ? {} : { name: preset.name }),',
+      "                        ...(isOhDshLiangshen ? { description: t('preset-liangshen-description') }",
+      '                            : preset.description === undefined ? {} : { description: preset.description }),',
+      '                        ...(preset.broken === undefined ? {} : { broken: preset.broken }),',
+      '                        isDefault: preset.id === presets.defaultId,',
+      '                    };',
+      '                });',
+    ].join('\n')
+  patchFile(channelPath, [[channelAnchor, channelReplacement]])
+}
+
+/** Resolve the pinned DSH browser bundle in pnpm or hoisted deployments. */
+function dshAgentPresetClientPath(runtimeRoot) {
+  const hoisted = join(
+    runtimeRoot,
+    'node_modules',
+    '@deepseek-ai',
+    'dsh-client-ui-agent-preset',
+    'lib',
+    'client.js',
+  )
+  if (existsSync(hoisted)) return hoisted
+
+  const store = join(runtimeRoot, 'node_modules', '.pnpm')
+  if (existsSync(store)) {
+    const entry = readdirSync(store, { withFileTypes: true })
+      .find(candidate => candidate.isDirectory()
+        && candidate.name.startsWith('@deepseek-ai+dsh-client-ui-agent-preset@'))
+    if (entry !== undefined) {
+      return join(
+        store,
+        entry.name,
+        'node_modules',
+        '@deepseek-ai',
+        'dsh-client-ui-agent-preset',
+        'lib',
+        'client.js',
+      )
+    }
+  }
+  return hoisted
+}
+
+const invokedPath = process.argv[1] === undefined
+  ? null
+  : pathToFileURL(resolve(process.argv[1])).href
+if (invokedPath === import.meta.url) {
+  const [surface, target] = process.argv.slice(2)
+  if (target === undefined || process.argv.length !== 4) {
+    throw new Error('usage: node upstream-adapter.mjs <dsh|tui> <runtime-or-package-root>')
+  }
+  if (surface === 'dsh') adaptDshLiangshenPresentation(resolve(target))
+  else if (surface === 'tui') adaptTuiLiangshenPresentation(resolve(target))
+  else throw new Error(`unknown Liangshen presentation surface: ${String(surface)}`)
+}

--- a/scripts/smoke-runtime.mjs
+++ b/scripts/smoke-runtime.mjs
@@ -11,7 +11,7 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import electronBinary from 'electron'
 import { DSH_SOURCE_SPEC } from './dsh-source.mjs'
 import { bundledRuntimePaths, runtimeSearchPath } from '../src/runtime-paths.ts'
@@ -151,6 +151,43 @@ try {
     'liangshen',
     'agent.cordis.yml',
   )), 'Desktop Liangshen plugin did not install its preset')
+  const agentPresetModule = await import(pathToFileURL(join(
+    resources,
+    'dsh-runtime',
+    'node_modules',
+    '@deepseek-ai',
+    'dsh-agent-presets',
+    'lib',
+    'index.js',
+  )).href)
+  const managedRoster = await agentPresetModule.discoverPresets([{
+    path: join(dshHome, '.agent-presets'),
+    trust: 'user',
+  }])
+  const managedLiangshen = managedRoster.find(preset => preset.id === 'liangshen')
+  assert.equal(managedLiangshen?.managedBy, '@deepseek-harness-tui/dsh-tui')
+
+  const unmanagedRoot = join(smokeRoot, 'unmanaged-presets')
+  const unmanagedLiangshen = join(unmanagedRoot, 'liangshen')
+  mkdirSync(unmanagedLiangshen, { recursive: true })
+  writeFileSync(join(unmanagedLiangshen, 'agent.cordis.yml'), '[]\n')
+  writeFileSync(join(unmanagedLiangshen, 'preset.yml'), [
+    'name: 梁神模式',
+    'description: 主 Agent 与子 Agent 首轮均保持 Minimal 双工具，首次工具调用后开放完整目录，压缩后重新锚定。',
+    '',
+  ].join('\n'))
+  const unmanagedRoster = await agentPresetModule.discoverPresets([{
+    path: unmanagedRoot,
+    trust: 'user',
+  }])
+  assert.equal(unmanagedRoster[0]?.trust, 'user')
+  assert.equal(unmanagedRoster[0]?.name, '梁神模式')
+  assert.equal(
+    unmanagedRoster[0]?.description,
+    '主 Agent 与子 Agent 首轮均保持 Minimal 双工具，首次工具调用后开放完整目录，压缩后重新锚定。',
+  )
+  assert.equal(unmanagedRoster[0]?.managedBy, undefined)
+
   const indexResponse = await fetch(base)
   const index = await indexResponse.text()
   assert.equal(indexResponse.status, 200)
@@ -166,6 +203,7 @@ try {
   assert.equal(agentPresetBundleResponse.status, 200)
   assert.match(agentPresetBundle, /presetLiangshenName/)
   assert.match(agentPresetBundle, /Liangshen mode/)
+  assert.match(agentPresetBundle, /preset\.managedBy/)
 
   const loaded = []
   for (const pluginId of BUNDLED_DESKTOP_CLIENT_PLUGINS) {

--- a/scripts/smoke-runtime.mjs
+++ b/scripts/smoke-runtime.mjs
@@ -157,6 +157,16 @@ try {
   assert.match(index, /<div id="root"><\/div>/)
 
   const bootEntries = parseBootEntries(index)
+  const agentPresetClient = bootEntries.find(
+    entry => entry.id === '@deepseek-ai/dsh-client-ui-agent-preset',
+  )
+  assert.ok(agentPresetClient, 'DSH client graph is missing the Agent preset UI')
+  const agentPresetBundleResponse = await fetch(new URL(agentPresetClient.url, base))
+  const agentPresetBundle = await agentPresetBundleResponse.text()
+  assert.equal(agentPresetBundleResponse.status, 200)
+  assert.match(agentPresetBundle, /presetLiangshenName/)
+  assert.match(agentPresetBundle, /Liangshen mode/)
+
   const loaded = []
   for (const pluginId of BUNDLED_DESKTOP_CLIENT_PLUGINS) {
     const row = bootEntries.find(entry => entry.id === pluginId)

--- a/scripts/smoke-web.mjs
+++ b/scripts/smoke-web.mjs
@@ -198,6 +198,16 @@ try {
 
   // The Oh-DSH web plugins enroll their browser entries in the client graph.
   const bootEntries = parseBootEntries(index)
+  const agentPresetClient = bootEntries.find(
+    entry => entry.id === '@deepseek-ai/dsh-client-ui-agent-preset',
+  )
+  assert.ok(agentPresetClient, 'DSH client graph is missing the Agent preset UI')
+  const agentPresetBundleResponse = await fetch(new URL(agentPresetClient.url, base))
+  const agentPresetBundle = await agentPresetBundleResponse.text()
+  assert.equal(agentPresetBundleResponse.status, 200)
+  assert.match(agentPresetBundle, /presetLiangshenName/)
+  assert.match(agentPresetBundle, /Liangshen mode/)
+
   const loaded = []
   for (const pluginId of [
     '@oh-dsh/web',

--- a/scripts/smoke-web.mjs
+++ b/scripts/smoke-web.mjs
@@ -207,6 +207,7 @@ try {
   assert.equal(agentPresetBundleResponse.status, 200)
   assert.match(agentPresetBundle, /presetLiangshenName/)
   assert.match(agentPresetBundle, /Liangshen mode/)
+  assert.match(agentPresetBundle, /preset\.managedBy/)
 
   const loaded = []
   for (const pluginId of [

--- a/scripts/stage-dsh.mjs
+++ b/scripts/stage-dsh.mjs
@@ -36,6 +36,10 @@ import {
   restoreLandlockLauncher,
 } from './landlock-launcher.mjs'
 import { resolveNodeDistributionPlatform } from '../src/node-platform.ts'
+import {
+  adaptDshLiangshenPresentation,
+  adaptTuiLiangshenPresentation,
+} from '../plugins/liangshen/src/upstream-adapter.mjs'
 import { adaptTuiRendererPackage } from './tui-upstream-adapter.mjs'
 import { restoreSettingsBoundary } from './settings-boundary.mjs'
 
@@ -1203,6 +1207,7 @@ function installDesktopPackages(surface = 'all') {
     }
     if (manifest.name === '@deepseek-harness-tui/dsh-tui') {
       adaptTuiRendererPackage(packageDir)
+      adaptTuiLiangshenPresentation(packageDir)
     }
     installedVersions[manifest.name] = manifest.version
   }
@@ -1401,6 +1406,7 @@ restoreExecutableHelpers()
 console.log('Normalizing runtime links')
 normalizeRuntimeLinks()
 restoreSettingsBoundary(runtime)
+if (stageSurface !== 'tui') adaptDshLiangshenPresentation(runtime)
 ensureLinuxLandlockLauncher()
 assertSelfContained(runtime, 'DSH runtime')
 ensureNodeRuntime()

--- a/scripts/stage-dsh.mjs
+++ b/scripts/stage-dsh.mjs
@@ -37,6 +37,7 @@ import {
 } from './landlock-launcher.mjs'
 import { resolveNodeDistributionPlatform } from '../src/node-platform.ts'
 import {
+  adaptDshLiangshenOwnership,
   adaptDshLiangshenPresentation,
   adaptTuiLiangshenPresentation,
 } from '../plugins/liangshen/src/upstream-adapter.mjs'
@@ -1406,6 +1407,7 @@ restoreExecutableHelpers()
 console.log('Normalizing runtime links')
 normalizeRuntimeLinks()
 restoreSettingsBoundary(runtime)
+adaptDshLiangshenOwnership(runtime)
 if (stageSurface !== 'tui') adaptDshLiangshenPresentation(runtime)
 ensureLinuxLandlockLauncher()
 assertSelfContained(runtime, 'DSH runtime')

--- a/tests/liangshen.test.ts
+++ b/tests/liangshen.test.ts
@@ -1,10 +1,23 @@
 import assert from 'node:assert/strict'
-import { cpSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { test } from 'node:test'
 import { apply, installLiangshenPreset } from '../plugins/liangshen/src/index.ts'
+import {
+  adaptDshLiangshenPresentation,
+  adaptTuiLiangshenPresentation,
+} from '../plugins/liangshen/src/upstream-adapter.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const source = join(root, 'upstream', 'dsh-TUI', 'presets', 'liangshen')
@@ -51,6 +64,89 @@ test('Liangshen plugin preserves an unmanaged user preset', () => {
 function requireFile(path: string): string {
   return readFileSync(path, 'utf8')
 }
+
+function pinnedAgentPresetClient(): string {
+  const store = join(root, 'node_modules', '.pnpm')
+  const entry = readdirSync(store, { withFileTypes: true })
+    .find(candidate => candidate.isDirectory()
+      && candidate.name.startsWith('@deepseek-ai+dsh-client-ui-agent-preset@'))
+  assert.ok(entry, 'pinned dsh-client-ui-agent-preset package is unavailable')
+  return join(
+    store,
+    entry.name,
+    'node_modules',
+    '@deepseek-ai',
+    'dsh-client-ui-agent-preset',
+    'lib',
+    'client.js',
+  )
+}
+
+test('Liangshen adapters localize the pinned browser and TUI preset renderers', () => {
+  const temp = mkdtempSync(join(tmpdir(), 'oh-dsh-liangshen-presentation-'))
+  try {
+    const runtime = join(temp, 'runtime')
+    const browserClient = join(
+      runtime,
+      'node_modules',
+      '.pnpm',
+      '@deepseek-ai+dsh-client-ui-agent-preset@fixture',
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-client-ui-agent-preset',
+      'lib',
+      'client.js',
+    )
+    mkdirSync(dirname(browserClient), { recursive: true })
+    cpSync(pinnedAgentPresetClient(), browserClient)
+    adaptDshLiangshenPresentation(runtime)
+    const browserSource = requireFile(browserClient)
+    assert.match(browserSource, /Liangshen mode/)
+    assert.match(browserSource, /preset\.name === "梁神模式"/)
+    assert.match(browserSource, /preset\.description === "主 Agent 与子 Agent/)
+
+    const hoistedRuntime = join(temp, 'hoisted-runtime')
+    const hoistedClient = join(
+      hoistedRuntime,
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-client-ui-agent-preset',
+      'lib',
+      'client.js',
+    )
+    mkdirSync(dirname(hoistedClient), { recursive: true })
+    cpSync(pinnedAgentPresetClient(), hoistedClient)
+    adaptDshLiangshenPresentation(hoistedRuntime)
+    assert.match(requireFile(hoistedClient), /Liangshen mode/)
+
+    const tui = join(temp, 'tui')
+    const tuiTypes = join(tui, 'lib', 'types')
+    mkdirSync(join(tuiTypes, 'dsh-adapter'), { recursive: true })
+    cpSync(join(root, 'upstream', 'dsh-TUI', 'lib', 'types', 'i18n.js'), join(tuiTypes, 'i18n.js'))
+    cpSync(
+      join(root, 'upstream', 'dsh-TUI', 'lib', 'types', 'dsh-adapter', 'channel.js'),
+      join(tuiTypes, 'dsh-adapter', 'channel.js'),
+    )
+    adaptTuiLiangshenPresentation(tui)
+    assert.match(requireFile(join(tuiTypes, 'i18n.js')), /Liangshen mode/)
+    assert.match(requireFile(join(tuiTypes, 'dsh-adapter', 'channel.js')), /isOhDshLiangshen/)
+
+    assert.doesNotThrow(() => {
+      adaptDshLiangshenPresentation(runtime)
+      adaptDshLiangshenPresentation(hoistedRuntime)
+      adaptTuiLiangshenPresentation(tui)
+    })
+  } finally {
+    rmSync(temp, { recursive: true, force: true })
+  }
+})
+
+test('Nix applies Liangshen presentation adapters to its copied runtimes', () => {
+  const nix = requireFile(join(root, 'nix', 'oh-dsh.nix'))
+  assert.equal((nix.match(/plugins\/liangshen\/src\/upstream-adapter\.mjs/g) ?? []).length, 2)
+  assert.match(nix, /tui-renderer/)
+  assert.match(nix, /dsh \$out\/dsh-runtime/)
+})
 
 test('Liangshen plugin skips preset installation in read-only viewer mode', () => {
   const temp = mkdtempSync(join(tmpdir(), 'oh-dsh-liangshen-readonly-'))

--- a/tests/liangshen.test.ts
+++ b/tests/liangshen.test.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url'
 import { test } from 'node:test'
 import { apply, installLiangshenPreset } from '../plugins/liangshen/src/index.ts'
 import {
+  adaptDshLiangshenOwnership,
   adaptDshLiangshenPresentation,
   adaptTuiLiangshenPresentation,
 } from '../plugins/liangshen/src/upstream-adapter.mjs'
@@ -65,39 +66,70 @@ function requireFile(path: string): string {
   return readFileSync(path, 'utf8')
 }
 
-const AGENT_PRESET_CLIENT_PATH = join(
-  'node_modules',
-  '@deepseek-ai',
-  'dsh-client-ui-agent-preset',
-  'lib',
-  'client.js',
-)
-
-function pinnedAgentPresetClient(): string {
+function pinnedPackageFile(packageName: string, ...segments: string[]): string {
   const store = join(root, 'node_modules', '.pnpm')
+  const packagePath = join('node_modules', '@deepseek-ai', packageName, ...segments)
   const entry = readdirSync(store, { withFileTypes: true })
     .find(candidate => candidate.isDirectory()
-      && existsSync(join(store, candidate.name, AGENT_PRESET_CLIENT_PATH)))
-  assert.ok(entry, 'pinned dsh-client-ui-agent-preset package is unavailable')
-  return join(store, entry.name, AGENT_PRESET_CLIENT_PATH)
+      && existsSync(join(store, candidate.name, packagePath)))
+  assert.ok(entry, `pinned @deepseek-ai/${packageName} package is unavailable`)
+  return join(store, entry.name, packagePath)
 }
 
 test('Liangshen adapters localize the pinned browser and TUI preset renderers', () => {
   const temp = mkdtempSync(join(tmpdir(), 'oh-dsh-liangshen-presentation-'))
   try {
     const runtime = join(temp, 'runtime')
+    const agentPresetHost = join(
+      runtime,
+      'node_modules',
+      '.pnpm',
+      'agent-preset-host-hash',
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-agent-presets',
+      'lib',
+      'index.js',
+    )
+    const apiProxyHost = join(
+      runtime,
+      'node_modules',
+      '.pnpm',
+      'api-proxy-host-hash',
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-host-apiproxy',
+      'lib',
+      'index.js',
+    )
     const browserClient = join(
       runtime,
       'node_modules',
       '.pnpm',
       'virtual-store-hash',
-      AGENT_PRESET_CLIENT_PATH,
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-client-ui-agent-preset',
+      'lib',
+      'client.js',
     )
-    mkdirSync(dirname(browserClient), { recursive: true })
-    cpSync(pinnedAgentPresetClient(), browserClient)
+    for (const path of [agentPresetHost, apiProxyHost, browserClient]) {
+      mkdirSync(dirname(path), { recursive: true })
+    }
+    cpSync(pinnedPackageFile('dsh-agent-presets', 'lib', 'index.js'), agentPresetHost)
+    cpSync(pinnedPackageFile('dsh-host-apiproxy', 'lib', 'index.js'), apiProxyHost)
+    cpSync(pinnedPackageFile('dsh-client-ui-agent-preset', 'lib', 'client.js'), browserClient)
+    adaptDshLiangshenOwnership(runtime)
     adaptDshLiangshenPresentation(runtime)
+    const hostSource = requireFile(agentPresetHost)
+    const apiSource = requireFile(apiProxyHost)
     const browserSource = requireFile(browserClient)
+    assert.match(hostSource, /ohDshManagedPresetOwner/)
+    assert.match(hostSource, /managedBy/)
+    assert.match(apiSource, /managedBy: preset\.managedBy/)
+    assert.match(apiSource, /managedBy: z\$1\.string/)
     assert.match(browserSource, /Liangshen mode/)
+    assert.match(browserSource, /preset\.managedBy === "@deepseek-harness-tui\/dsh-tui"/)
     assert.match(browserSource, /preset\.name === "梁神模式"/)
     assert.match(browserSource, /preset\.description === "主 Agent 与子 Agent/)
 
@@ -111,7 +143,7 @@ test('Liangshen adapters localize the pinned browser and TUI preset renderers', 
       'client.js',
     )
     mkdirSync(dirname(hoistedClient), { recursive: true })
-    cpSync(pinnedAgentPresetClient(), hoistedClient)
+    cpSync(pinnedPackageFile('dsh-client-ui-agent-preset', 'lib', 'client.js'), hoistedClient)
     adaptDshLiangshenPresentation(hoistedRuntime)
     assert.match(requireFile(hoistedClient), /Liangshen mode/)
 
@@ -125,9 +157,13 @@ test('Liangshen adapters localize the pinned browser and TUI preset renderers', 
     )
     adaptTuiLiangshenPresentation(tui)
     assert.match(requireFile(join(tuiTypes, 'i18n.js')), /Liangshen mode/)
-    assert.match(requireFile(join(tuiTypes, 'dsh-adapter', 'channel.js')), /isOhDshLiangshen/)
+    assert.match(
+      requireFile(join(tuiTypes, 'dsh-adapter', 'channel.js')),
+      /preset\.managedBy === "@deepseek-harness-tui\/dsh-tui"/,
+    )
 
     assert.doesNotThrow(() => {
+      adaptDshLiangshenOwnership(runtime)
       adaptDshLiangshenPresentation(runtime)
       adaptDshLiangshenPresentation(hoistedRuntime)
       adaptTuiLiangshenPresentation(tui)
@@ -139,8 +175,9 @@ test('Liangshen adapters localize the pinned browser and TUI preset renderers', 
 
 test('Nix applies Liangshen presentation adapters to its copied runtimes', () => {
   const nix = requireFile(join(root, 'nix', 'oh-dsh.nix'))
-  assert.equal((nix.match(/plugins\/liangshen\/src\/upstream-adapter\.mjs/g) ?? []).length, 2)
+  assert.equal((nix.match(/plugins\/liangshen\/src\/upstream-adapter\.mjs/g) ?? []).length, 3)
   assert.match(nix, /tui-renderer/)
+  assert.match(nix, /ownership \$out\/dsh-runtime/)
   assert.match(nix, /dsh \$out\/dsh-runtime/)
 })
 

--- a/tests/liangshen.test.ts
+++ b/tests/liangshen.test.ts
@@ -113,21 +113,35 @@ test('Liangshen adapters localize the pinned browser and TUI preset renderers', 
       'lib',
       'client.js',
     )
-    for (const path of [agentPresetHost, apiProxyHost, browserClient]) {
+    const connectionClient = join(
+      runtime,
+      'node_modules',
+      '.pnpm',
+      'connection-client-hash',
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-client-connection',
+      'lib',
+      'client.js',
+    )
+    for (const path of [agentPresetHost, apiProxyHost, browserClient, connectionClient]) {
       mkdirSync(dirname(path), { recursive: true })
     }
     cpSync(pinnedPackageFile('dsh-agent-presets', 'lib', 'index.js'), agentPresetHost)
     cpSync(pinnedPackageFile('dsh-host-apiproxy', 'lib', 'index.js'), apiProxyHost)
     cpSync(pinnedPackageFile('dsh-client-ui-agent-preset', 'lib', 'client.js'), browserClient)
+    cpSync(pinnedPackageFile('dsh-client-connection', 'lib', 'client.js'), connectionClient)
     adaptDshLiangshenOwnership(runtime)
     adaptDshLiangshenPresentation(runtime)
     const hostSource = requireFile(agentPresetHost)
     const apiSource = requireFile(apiProxyHost)
     const browserSource = requireFile(browserClient)
+    const connectionSource = requireFile(connectionClient)
     assert.match(hostSource, /ohDshManagedPresetOwner/)
     assert.match(hostSource, /managedBy/)
     assert.match(apiSource, /managedBy: preset\.managedBy/)
     assert.match(apiSource, /managedBy: z\$1\.string/)
+    assert.match(connectionSource, /managedBy: string\(\)\.min\(1\)\.optional\(\)/)
     assert.match(browserSource, /Liangshen mode/)
     assert.match(browserSource, /preset\.managedBy === "@deepseek-harness-tui\/dsh-tui"/)
     assert.match(browserSource, /preset\.name === "梁神模式"/)
@@ -142,8 +156,18 @@ test('Liangshen adapters localize the pinned browser and TUI preset renderers', 
       'lib',
       'client.js',
     )
+    const hoistedConnection = join(
+      hoistedRuntime,
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-client-connection',
+      'lib',
+      'client.js',
+    )
     mkdirSync(dirname(hoistedClient), { recursive: true })
+    mkdirSync(dirname(hoistedConnection), { recursive: true })
     cpSync(pinnedPackageFile('dsh-client-ui-agent-preset', 'lib', 'client.js'), hoistedClient)
+    cpSync(pinnedPackageFile('dsh-client-connection', 'lib', 'client.js'), hoistedConnection)
     adaptDshLiangshenPresentation(hoistedRuntime)
     assert.match(requireFile(hoistedClient), /Liangshen mode/)
 

--- a/tests/liangshen.test.ts
+++ b/tests/liangshen.test.ts
@@ -65,21 +65,21 @@ function requireFile(path: string): string {
   return readFileSync(path, 'utf8')
 }
 
+const AGENT_PRESET_CLIENT_PATH = join(
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-client-ui-agent-preset',
+  'lib',
+  'client.js',
+)
+
 function pinnedAgentPresetClient(): string {
   const store = join(root, 'node_modules', '.pnpm')
   const entry = readdirSync(store, { withFileTypes: true })
     .find(candidate => candidate.isDirectory()
-      && candidate.name.startsWith('@deepseek-ai+dsh-client-ui-agent-preset@'))
+      && existsSync(join(store, candidate.name, AGENT_PRESET_CLIENT_PATH)))
   assert.ok(entry, 'pinned dsh-client-ui-agent-preset package is unavailable')
-  return join(
-    store,
-    entry.name,
-    'node_modules',
-    '@deepseek-ai',
-    'dsh-client-ui-agent-preset',
-    'lib',
-    'client.js',
-  )
+  return join(store, entry.name, AGENT_PRESET_CLIENT_PATH)
 }
 
 test('Liangshen adapters localize the pinned browser and TUI preset renderers', () => {
@@ -90,12 +90,8 @@ test('Liangshen adapters localize the pinned browser and TUI preset renderers', 
       runtime,
       'node_modules',
       '.pnpm',
-      '@deepseek-ai+dsh-client-ui-agent-preset@fixture',
-      'node_modules',
-      '@deepseek-ai',
-      'dsh-client-ui-agent-preset',
-      'lib',
-      'client.js',
+      'virtual-store-hash',
+      AGENT_PRESET_CLIENT_PATH,
     )
     mkdirSync(dirname(browserClient), { recursive: true })
     cpSync(pinnedAgentPresetClient(), browserClient)

--- a/tests/tui.test.ts
+++ b/tests/tui.test.ts
@@ -15,6 +15,7 @@ import type { Readable } from 'node:stream'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import { TUI_BUNDLES, TUI_PROFILE } from '../src/profile.ts'
+import { adaptTuiLiangshenPresentation } from '../plugins/liangshen/src/upstream-adapter.mjs'
 import { adaptTuiRendererPackage } from '../scripts/tui-upstream-adapter.mjs'
 import {
   DEFAULT_TUI_HOME,
@@ -185,6 +186,7 @@ test('TUI upstream adapter removes legacy terminal branding and scopes storage',
   })
   try {
     adaptTuiRendererPackage(root)
+    adaptTuiLiangshenPresentation(root)
     const paths = readFileSync(join(lib, 'utils', 'paths.js'), 'utf8')
     assert.match(paths, /OH_DSH_TUI_CONFIG_HOME/)
     assert.match(paths, /LEGACY_DATA_DIR = DATA_DIR/)
@@ -238,8 +240,11 @@ test('TUI upstream adapter removes legacy terminal branding and scopes storage',
     const messages = readFileSync(join(lib, 'i18n.js'), 'utf8')
     assert.match(messages, /~\/\.ohdsh\/tui/)
     assert.doesNotMatch(messages, /dsh-tui|~\/\.dsh-tui/)
+    assert.match(messages, /Liangshen mode/)
+    assert.match(messages, /preset-liangshen-description/)
     const channel = readFileSync(join(lib, 'dsh-adapter', 'channel.js'), 'utf8')
     assert.match(channel, /oh-dsh-tui-export-/)
+    assert.match(channel, /isOhDshLiangshen/)
     assert.doesNotMatch(
       channel,
       /const fileName = `dsh-tui-export-|join\(userHome, '\.dsh-tui\//,
@@ -258,7 +263,10 @@ test('TUI upstream adapter removes legacy terminal branding and scopes storage',
     assert.doesNotMatch(customTheme, /\[dsh-tui\]|~\/\.dsh-tui/)
     const pluginStorage = readFileSync(join(lib, 'dsh-adapter', 'plugin-storage.js'), 'utf8')
     assert.doesNotMatch(pluginStorage, /~\/\.dsh-tui/)
-    assert.doesNotThrow(() => { adaptTuiRendererPackage(root) })
+    assert.doesNotThrow(() => {
+      adaptTuiRendererPackage(root)
+      adaptTuiLiangshenPresentation(root)
+    })
   } finally {
     rmSync(root, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Scope

- Localize the canonical managed Liangshen preset as `Liangshen mode` in English and `梁神模式` in Chinese across Desktop, Web, and TUI.
- Derive a path-free `managedBy` owner from the package-owned marker and carry it through the DSH roster, Host API, browser response schema, and TUI projection.
- Require managed ownership plus canonical metadata before localization; unmanaged presets with the same id or display text remain literal.
- Apply exact, idempotent adapters during regular and Nix staging so pinned upstream layout drift fails packaging.
- Resolve pnpm virtual-store packages by nested package layout so shortened Windows store names remain supported.
- Update the bilingual Agent Note with the localization and compatibility contract.

## Demo

![Liangshen mode switches between English and Chinese](https://github.com/hust-open-atom-club/oh-dsh/blob/liangshen-localization-assets/liangshen-localization-1ae39d0.gif?raw=true)

- Demonstrated commit: `1ae39d0208bfb1afcc4b7b98fd0400a478bb8322`
- Served tree: `/Users/zevorn/oh-dsh-liangshen-localization` from `codex/liangshen-localization`
- Origin: `http://127.0.0.1:61322/`, backed by the real staged Oh-DSH Web server
- State: fresh scratch DSH home, agents home, workspace, and browser tab; the normal credential store was seeded only for model authentication
- Mode flags: update checks disabled; an SSH-like launch marker selected the production browse directory picker so automation did not open a native OS dialog
- Transport: real DSH server and client graph; no fixtures, mock transports, synthetic event injection, or test-only hooks
- Real model round: yes; DeepSeek-V4-Flash under Liangshen mode returned the unique visible paragraph `MANAGED OWNERSHIP VERIFIED`
- Desktop verification: the same staged browser client is packaged for Desktop, and the branch Desktop was manually confirmed in English

## Verification

- `node --test tests/liangshen.test.ts tests/tui.test.ts` — 12 passed
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run stage:dsh -- --surface all`
- `pnpm run stage:dsh -- --surface web`
- `pnpm run stage:dsh -- --surface tui`
- `pnpm run smoke:runtime` — managed marker projected; identical unmarked metadata remained literal and user-trusted
- `pnpm run smoke:web`
- `node scripts/build-tui.mjs`
- Agent Note format, archive, and bilingual pairing checks
- Full suite: 306 passed, 9 skipped; 3 existing self-update assertions read the local installed Desktop launcher record and are unrelated to this diff