### PR TITLE
website: offer AtomGit and GitHub release downloads

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-26-website-release-download-mirrors.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-website-release-download-mirrors.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-website-release-download-mirrors.md
+2026-08-26-website-release-download-mirrors.md: af6fcfb8e817ac5713aad0258b2c7098edede78c
+2026-08-26-website-release-download-mirrors.zh.md: 26c5962bc9fc2831d2f244ef746810f005f64454

--- a/.agents/notes/implemented/feature/2026-08-26-website-release-download-mirrors.md
+++ b/.agents/notes/implemented/feature/2026-08-26-website-release-download-mirrors.md
@@ -1,0 +1,54 @@
+# Agent Note: Explicit release download mirrors
+
+Status: implemented
+
+English | [中文](2026-08-26-website-release-download-mirrors.zh.md)
+
+## Problem
+
+The website resolved its platform-specific release asset only from GitHub.
+GitHub may be slow or unreachable on some mainland China networks, while the
+same release assets are copied to AtomGit. Replacing the existing download or
+routing visitors by inferred location would either remove a working path or
+hide which host supplies the binary.
+
+## Decision
+
+The download dialog presents three explicit actions: Star the repository on
+GitHub and continue the GitHub download, download directly from GitHub without
+the Star step, or download from the AtomGit mirror. Both GitHub actions share
+the asset selected from GitHub's latest Release response. The AtomGit action
+resolves the matching platform and architecture independently from AtomGit's
+latest Release response and falls back to the AtomGit Releases page.
+
+The page does not infer a visitor's country or automatically switch providers.
+AtomGit is a mirror only: choosing it never opens GitHub or asks for a Star.
+Installer and in-application update traffic remain outside this website choice.
+
+## Alternatives considered
+
+**Route automatically by IP address.** Rejected because VPNs, proxies, travel,
+and geolocation errors make country an unreliable signal, and automatic
+routing conceals the selected artifact host from the visitor.
+
+**Replace direct GitHub download with AtomGit.** Rejected because the existing
+no-Star GitHub path remains useful and the mirror is an additional recovery
+path, not the new source of truth.
+
+**Attach the Star prompt to AtomGit.** Rejected because AtomGit only mirrors
+the GitHub Release and does not require a repository-promotion side effect.
+
+## Consequences
+
+Visitors choose the host that works for their network without losing either
+GitHub workflow. Each provider can fail or lag independently, so the dialog may
+temporarily resolve different latest versions; provider-specific fallback
+links remain usable in that state. The website performs one latest-Release
+request per provider and reuses the same platform and architecture matching
+for both responses.
+
+## Testing
+
+JavaScript syntax, typecheck, the Pages build, provider-selector inspection,
+Agent Note format and classification, and bilingual pairing gates cover the
+shipped dialog and its decision record.

--- a/.agents/notes/implemented/feature/2026-08-26-website-release-download-mirrors.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-website-release-download-mirrors.zh.md
@@ -1,0 +1,45 @@
+# Agent Note: 显式选择 Release 下载镜像
+
+Status: implemented
+
+[English](2026-08-26-website-release-download-mirrors.md) | 中文
+
+## Problem
+
+网站原本只从 GitHub 解析与平台匹配的 Release 产物。GitHub 在部分中国大陆网络中
+可能较慢或无法访问，而同一批 Release 产物会被复制到 AtomGit。直接替换现有下载
+入口，或根据推断的所在地自动分流，都会移除一个可用路径，或者隐藏二进制实际来自
+哪个托管平台。
+
+## Decision
+
+下载对话框显式提供三个操作：前往 GitHub 为仓库点亮 Star 并继续 GitHub 下载、
+不经过 Star 直接从 GitHub 下载，或者从 AtomGit 镜像下载。两个 GitHub 操作共享
+从 GitHub 最新 Release 响应中选出的产物。AtomGit 操作从 AtomGit 最新 Release
+响应中独立解析匹配的平台和架构，并在失败时回退到 AtomGit Releases 页面。
+
+页面不推断访问者所在国家，也不自动切换提供方。AtomGit 仅作为镜像：选择它不会
+打开 GitHub，也不会请求 Star。安装脚本和应用内更新流量不受这个网站选项影响。
+
+## Alternatives considered
+
+**按 IP 地址自动分流。** 不采用：VPN、代理、旅行和地理定位误差都会让国家信息
+变得不可靠，而且自动分流会向访问者隐藏所选产物的实际托管平台。
+
+**用 AtomGit 替换直接 GitHub 下载。** 不采用：原有的无 Star GitHub 路径仍然
+有用；镜像是额外的恢复路径，而不是新的真源。
+
+**让 AtomGit 下载也触发 Star 提示。** 不采用：AtomGit 只镜像 GitHub Release，
+不应附带推广仓库的副作用。
+
+## Consequences
+
+访问者可以根据网络情况选择托管平台，同时保留两种 GitHub 流程。各提供方可能独立
+失败或出现同步延迟，因此对话框可能暂时解析出不同的最新版本；此时各平台专属的回退
+链接仍然可用。网站会分别请求两个提供方的最新 Release，并对两份响应复用相同的平台
+和架构匹配逻辑。
+
+## Testing
+
+JavaScript 语法、类型检查、Pages 构建、提供方选择器检查、Agent Note 格式与分类，
+以及双语配对门禁共同覆盖已发布的对话框及其决策记录。

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write docs/usage.md
-usage.md: 1df7e44e28e65d3ce7af7f5f5764ba532bb5a55c
-usage.zh.md: 8033e3e52e0275be986daa380aff4fa679b9a5cf
+usage.md: ef631ae9b025e034703993b9c768c577696e9bb6
+usage.zh.md: dda7fbfea1d71bb74f56bca35bf82af4d64ca871

--- a/website/index.html
+++ b/website/index.html
@@ -253,14 +253,14 @@
             </button>
             <p class="dialog-kicker" data-i18n="downloadReady">准备下载</p>
             <h2 id="download-dialog-title" data-i18n="downloadTitle">
-                选择下载渠道
+                下载前，顺手点亮一颗 Star？
             </h2>
             <p
                 id="download-dialog-description"
                 class="dialog-description"
                 data-i18n="downloadDescription"
             >
-                请选择适合当前网络的渠道；国内网络可优先尝试 AtomGit。
+                Oh-DSH 完全开源。可前往 GitHub 点亮 Star 并继续下载，或直接使用 AtomGit 镜像；国内网络下可能更快。
             </p>
             <p class="detected-platform">
                 <span data-i18n="detectedPlatform">已识别当前平台</span>
@@ -269,18 +269,23 @@
             <div class="dialog-actions">
                 <a
                     class="dialog-primary"
-                    href="https://atomgit.com/hust-open-atom-club/oh-dsh/releases"
-                    data-atomgit-download
+                    href="https://github.com/hust-open-atom-club/oh-dsh/releases/latest"
+                    data-github-download
                 >
-                    <span data-i18n="atomgitDownload">从 AtomGit 下载</span>
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path
+                            d="m12 2.8 2.8 5.7 6.3.9-4.6 4.4 1.1 6.3-5.6-3-5.6 3 1.1-6.3-4.6-4.4 6.3-.9L12 2.8Z"
+                        ></path>
+                    </svg>
+                    <span data-i18n="starAndDownload">去 GitHub Star，并继续下载</span>
                 </a>
                 <a
                     class="dialog-secondary"
-                    href="https://github.com/hust-open-atom-club/oh-dsh/releases/latest"
-                    data-github-download
-                    data-i18n="githubDownload"
+                    href="https://atomgit.com/hust-open-atom-club/oh-dsh/releases"
+                    data-atomgit-download
+                    data-i18n="atomgitMirrorDownload"
                 >
-                    从 GitHub 下载
+                    从 AtomGit 镜像下载
                 </a>
             </div>
         </dialog>

--- a/website/index.html
+++ b/website/index.html
@@ -253,14 +253,14 @@
             </button>
             <p class="dialog-kicker" data-i18n="downloadReady">准备下载</p>
             <h2 id="download-dialog-title" data-i18n="downloadTitle">
-                下载前，顺手点亮一颗 Star？
+                选择下载渠道
             </h2>
             <p
                 id="download-dialog-description"
                 class="dialog-description"
                 data-i18n="downloadDescription"
             >
-                Oh-DSH 完全开源。你的 Star 会帮助更多开发者发现它，随后我们会继续下载。
+                请选择适合当前网络的渠道；国内网络可优先尝试 AtomGit。
             </p>
             <p class="detected-platform">
                 <span data-i18n="detectedPlatform">已识别当前平台</span>
@@ -269,23 +269,18 @@
             <div class="dialog-actions">
                 <a
                     class="dialog-primary"
-                    href="https://github.com/hust-open-atom-club/oh-dsh/releases/latest"
-                    data-star-download
+                    href="https://atomgit.com/hust-open-atom-club/oh-dsh/releases"
+                    data-atomgit-download
                 >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                        <path
-                            d="m12 2.8 2.8 5.7 6.3.9-4.6 4.4 1.1 6.3-5.6-3-5.6 3 1.1-6.3-4.6-4.4 6.3-.9L12 2.8Z"
-                        ></path>
-                    </svg>
-                    <span data-i18n="starAndDownload">去 GitHub Star，并继续下载</span>
+                    <span data-i18n="atomgitDownload">从 AtomGit 下载</span>
                 </a>
                 <a
                     class="dialog-secondary"
                     href="https://github.com/hust-open-atom-club/oh-dsh/releases/latest"
-                    data-direct-download
-                    data-i18n="directDownload"
+                    data-github-download
+                    data-i18n="githubDownload"
                 >
-                    直接下载
+                    从 GitHub 下载
                 </a>
             </div>
         </dialog>

--- a/website/index.html
+++ b/website/index.html
@@ -270,7 +270,7 @@
                 <a
                     class="dialog-primary"
                     href="https://github.com/hust-open-atom-club/oh-dsh/releases/latest"
-                    data-github-download
+                    data-star-download
                 >
                     <svg viewBox="0 0 24 24" aria-hidden="true">
                         <path
@@ -278,6 +278,14 @@
                         ></path>
                     </svg>
                     <span data-i18n="starAndDownload">去 GitHub Star，并继续下载</span>
+                </a>
+                <a
+                    class="dialog-secondary"
+                    href="https://github.com/hust-open-atom-club/oh-dsh/releases/latest"
+                    data-github-download
+                    data-i18n="githubDirectDownload"
+                >
+                    直接从 GitHub 下载
                 </a>
                 <a
                     class="dialog-secondary"

--- a/website/site.css
+++ b/website/site.css
@@ -657,12 +657,23 @@ html:lang(zh-CN) .hero-title-surfaces {
 }
 
 .dialog-primary {
+    gap: 9px;
     color: #0a0d14;
     background: #f5f7fb;
 }
 
 .dialog-primary:hover {
     background: #ffffff;
+}
+
+.dialog-primary svg {
+    width: 17px;
+    height: 17px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.7;
 }
 
 .dialog-secondary {

--- a/website/site.css
+++ b/website/site.css
@@ -657,23 +657,12 @@ html:lang(zh-CN) .hero-title-surfaces {
 }
 
 .dialog-primary {
-    gap: 9px;
     color: #0a0d14;
     background: #f5f7fb;
 }
 
 .dialog-primary:hover {
     background: #ffffff;
-}
-
-.dialog-primary svg {
-    width: 17px;
-    height: 17px;
-    fill: none;
-    stroke: currentColor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-width: 1.7;
 }
 
 .dialog-secondary {

--- a/website/site.js
+++ b/website/site.js
@@ -40,6 +40,7 @@ const translations = {
             "Oh-DSH 完全开源。可前往 GitHub 点亮 Star 并继续下载，或直接使用 AtomGit 镜像；国内网络下可能更快。",
         detectedPlatform: "已识别当前平台",
         starAndDownload: "去 GitHub Star，并继续下载",
+        githubDirectDownload: "直接从 GitHub 下载",
         atomgitMirrorDownload: "从 AtomGit 镜像下载",
         unknownPlatform: "其他平台",
         footer: "开放、可组合的 DeepSeek Harness 工作台",
@@ -72,6 +73,7 @@ const translations = {
             "Oh-DSH is fully open source. Star it on GitHub and continue downloading, or use the AtomGit mirror directly; it may be faster in mainland China.",
         detectedPlatform: "Detected platform",
         starAndDownload: "Star on GitHub and continue",
+        githubDirectDownload: "Download directly from GitHub",
         atomgitMirrorDownload: "Download from AtomGit mirror",
         unknownPlatform: "Other platform",
         footer: "An open, composable DeepSeek Harness workbench",
@@ -100,6 +102,7 @@ const elements = {
     particles: document.querySelector("[data-harness-particles]"),
     qqGroupLink: document.querySelector("[data-qq-group-link]"),
     starCount: document.querySelector("[data-star-count]"),
+    starDownload: document.querySelector("[data-star-download]"),
 };
 
 const installCommands = {
@@ -356,16 +359,24 @@ function chooseReleaseAsset(assets) {
     })[0];
 }
 
-function loadReleaseDownload(apiUrl, fallbackUrl, element) {
+function setDownloadUrls(elements, url) {
+    elements.forEach((element) => {
+        element.href = url;
+    });
+}
+
+function loadReleaseDownloads(apiUrl, fallbackUrl, elements) {
     return fetch(apiUrl)
         .then((response) => (response.ok ? response.json() : Promise.reject()))
         .then((release) => {
             const asset = chooseReleaseAsset(release.assets ?? []);
-            element.href =
-                asset?.browser_download_url ?? release.html_url ?? fallbackUrl;
+            setDownloadUrls(
+                elements,
+                asset?.browser_download_url ?? release.html_url ?? fallbackUrl,
+            );
         })
         .catch(() => {
-            element.href = fallbackUrl;
+            setDownloadUrls(elements, fallbackUrl);
         });
 }
 
@@ -472,7 +483,7 @@ if (elements.qqGroupLink) {
     elements.qqGroupLink.addEventListener("click", openQqGroup);
 }
 
-elements.githubDownload.addEventListener("click", () => {
+elements.starDownload.addEventListener("click", () => {
     window.open(repositoryUrl, "_blank", "noopener,noreferrer");
 });
 
@@ -594,15 +605,15 @@ if (typeof fetch === "function") {
         : Promise.resolve();
 
     architecturePromise.then(() => {
-        void loadReleaseDownload(
+        void loadReleaseDownloads(
             atomgitReleaseApiUrl,
             atomgitReleasesUrl,
-            elements.atomgitDownload,
+            [elements.atomgitDownload],
         );
-        void loadReleaseDownload(
+        void loadReleaseDownloads(
             releaseApiUrl,
             latestReleaseUrl,
-            elements.githubDownload,
+            [elements.starDownload, elements.githubDownload],
         );
     });
 }

--- a/website/site.js
+++ b/website/site.js
@@ -35,12 +35,12 @@ const translations = {
         copyCommand: "复制",
         copiedCommand: "已复制",
         downloadReady: "准备下载",
-        downloadTitle: "选择下载渠道",
+        downloadTitle: "下载前，顺手点亮一颗 Star？",
         downloadDescription:
-            "请选择适合当前网络的渠道；国内网络可优先尝试 AtomGit。",
+            "Oh-DSH 完全开源。可前往 GitHub 点亮 Star 并继续下载，或直接使用 AtomGit 镜像；国内网络下可能更快。",
         detectedPlatform: "已识别当前平台",
-        atomgitDownload: "从 AtomGit 下载",
-        githubDownload: "从 GitHub 下载",
+        starAndDownload: "去 GitHub Star，并继续下载",
+        atomgitMirrorDownload: "从 AtomGit 镜像下载",
         unknownPlatform: "其他平台",
         footer: "开放、可组合的 DeepSeek Harness 工作台",
         qqGroup: "QQ 群",
@@ -67,12 +67,12 @@ const translations = {
         copyCommand: "Copy",
         copiedCommand: "Copied",
         downloadReady: "Ready to download",
-        downloadTitle: "Choose a download source",
+        downloadTitle: "Before you go, leave us a Star?",
         downloadDescription:
-            "Choose the source that works best for your network. AtomGit may be faster in mainland China.",
+            "Oh-DSH is fully open source. Star it on GitHub and continue downloading, or use the AtomGit mirror directly; it may be faster in mainland China.",
         detectedPlatform: "Detected platform",
-        atomgitDownload: "Download from AtomGit",
-        githubDownload: "Download from GitHub",
+        starAndDownload: "Star on GitHub and continue",
+        atomgitMirrorDownload: "Download from AtomGit mirror",
         unknownPlatform: "Other platform",
         footer: "An open, composable DeepSeek Harness workbench",
         qqGroup: "QQ Group",
@@ -471,6 +471,10 @@ function openQqGroup(event) {
 if (elements.qqGroupLink) {
     elements.qqGroupLink.addEventListener("click", openQqGroup);
 }
+
+elements.githubDownload.addEventListener("click", () => {
+    window.open(repositoryUrl, "_blank", "noopener,noreferrer");
+});
 
 function cachedDownloadCount() {
     try {

--- a/website/site.js
+++ b/website/site.js
@@ -613,7 +613,11 @@ if (typeof fetch === "function") {
         void loadReleaseDownloads(
             releaseApiUrl,
             latestReleaseUrl,
-            [elements.starDownload, elements.githubDownload],
+            [
+                elements.downloadTrigger,
+                elements.starDownload,
+                elements.githubDownload,
+            ],
         );
     });
 }

--- a/website/site.js
+++ b/website/site.js
@@ -2,6 +2,11 @@ const repositoryUrl = "https://github.com/hust-open-atom-club/oh-dsh";
 const latestReleaseUrl = `${repositoryUrl}/releases/latest`;
 const releaseApiUrl =
     "https://api.github.com/repos/hust-open-atom-club/oh-dsh/releases/latest";
+const atomgitRepositoryUrl =
+    "https://atomgit.com/hust-open-atom-club/oh-dsh";
+const atomgitReleasesUrl = `${atomgitRepositoryUrl}/releases`;
+const atomgitReleaseApiUrl =
+    "https://api.atomgit.com/api/v5/repos/hust-open-atom-club/oh-dsh/releases/latest";
 const releasesApiUrl =
     "https://api.github.com/repos/hust-open-atom-club/oh-dsh/releases?per_page=100";
 const downloadsCacheKey = "oh-dsh-site-downloads";
@@ -30,12 +35,12 @@ const translations = {
         copyCommand: "复制",
         copiedCommand: "已复制",
         downloadReady: "准备下载",
-        downloadTitle: "下载前，顺手点亮一颗 Star？",
+        downloadTitle: "选择下载渠道",
         downloadDescription:
-            "Oh-DSH 完全开源。你的 Star 会帮助更多开发者发现它，随后我们会继续下载。",
+            "请选择适合当前网络的渠道；国内网络可优先尝试 AtomGit。",
         detectedPlatform: "已识别当前平台",
-        starAndDownload: "去 GitHub Star，并继续下载",
-        directDownload: "直接下载",
+        atomgitDownload: "从 AtomGit 下载",
+        githubDownload: "从 GitHub 下载",
         unknownPlatform: "其他平台",
         footer: "开放、可组合的 DeepSeek Harness 工作台",
         qqGroup: "QQ 群",
@@ -62,12 +67,12 @@ const translations = {
         copyCommand: "Copy",
         copiedCommand: "Copied",
         downloadReady: "Ready to download",
-        downloadTitle: "Before you go, leave us a Star?",
+        downloadTitle: "Choose a download source",
         downloadDescription:
-            "Oh-DSH is fully open source. Your Star helps more developers find it, and your download will continue.",
+            "Choose the source that works best for your network. AtomGit may be faster in mainland China.",
         detectedPlatform: "Detected platform",
-        starAndDownload: "Star on GitHub and continue",
-        directDownload: "Download directly",
+        atomgitDownload: "Download from AtomGit",
+        githubDownload: "Download from GitHub",
         unknownPlatform: "Other platform",
         footer: "An open, composable DeepSeek Harness workbench",
         qqGroup: "QQ Group",
@@ -79,10 +84,10 @@ const translations = {
 };
 
 const elements = {
+    atomgitDownload: document.querySelector("[data-atomgit-download]"),
     descriptionMeta: document.querySelector('meta[name="description"]'),
     dialog: document.querySelector("[data-download-dialog]"),
     dialogClose: document.querySelector("[data-dialog-close]"),
-    directDownload: document.querySelector("[data-direct-download]"),
     downloadCount: document.querySelector("[data-download-count]"),
     downloadTrigger: document.querySelector("[data-download-trigger]"),
     installCaption: document.querySelector("[data-install-caption]"),
@@ -90,11 +95,11 @@ const elements = {
     installCopy: document.querySelector("[data-install-copy]"),
     installCopyLabel: document.querySelector("[data-install-copy] [data-i18n]"),
     languageToggle: document.querySelector("[data-language-toggle]"),
+    githubDownload: document.querySelector("[data-github-download]"),
     platformLabel: document.querySelector("[data-platform-label]"),
     particles: document.querySelector("[data-harness-particles]"),
     qqGroupLink: document.querySelector("[data-qq-group-link]"),
     starCount: document.querySelector("[data-star-count]"),
-    starDownload: document.querySelector("[data-star-download]"),
 };
 
 const installCommands = {
@@ -351,10 +356,17 @@ function chooseReleaseAsset(assets) {
     })[0];
 }
 
-function setDownloadUrl(url) {
-    elements.downloadTrigger.href = url;
-    elements.directDownload.href = url;
-    elements.starDownload.href = url;
+function loadReleaseDownload(apiUrl, fallbackUrl, element) {
+    return fetch(apiUrl)
+        .then((response) => (response.ok ? response.json() : Promise.reject()))
+        .then((release) => {
+            const asset = chooseReleaseAsset(release.assets ?? []);
+            element.href =
+                asset?.browser_download_url ?? release.html_url ?? fallbackUrl;
+        })
+        .catch(() => {
+            element.href = fallbackUrl;
+        });
 }
 
 function showCopyFeedback() {
@@ -459,10 +471,6 @@ function openQqGroup(event) {
 if (elements.qqGroupLink) {
     elements.qqGroupLink.addEventListener("click", openQqGroup);
 }
-
-elements.starDownload.addEventListener("click", () => {
-    window.open(repositoryUrl, "_blank", "noopener,noreferrer");
-});
 
 function cachedDownloadCount() {
     try {
@@ -581,16 +589,18 @@ if (typeof fetch === "function") {
               .catch(() => {})
         : Promise.resolve();
 
-    architecturePromise
-        .then(() => fetch(releaseApiUrl))
-        .then((response) => (response.ok ? response.json() : Promise.reject()))
-        .then((release) => {
-            const asset = chooseReleaseAsset(release.assets ?? []);
-            setDownloadUrl(
-                asset?.browser_download_url ?? release.html_url ?? latestReleaseUrl,
-            );
-        })
-        .catch(() => setDownloadUrl(latestReleaseUrl));
+    architecturePromise.then(() => {
+        void loadReleaseDownload(
+            atomgitReleaseApiUrl,
+            atomgitReleasesUrl,
+            elements.atomgitDownload,
+        );
+        void loadReleaseDownload(
+            releaseApiUrl,
+            latestReleaseUrl,
+            elements.githubDownload,
+        );
+    });
 }
 
 applyLanguage(preferredLanguage());


### PR DESCRIPTION
## Summary

- replace the star-and-download prompt with explicit AtomGit and GitHub
  download actions
- resolve each host's latest platform and architecture asset independently
- fall back per host to its Releases page when lookup or matching fails

## Verification

- `pnpm run typecheck`
- `pnpm test` (316 tests: 307 passed, 9 skipped)
- `pnpm run build`
- `pnpm run build:pages`
- `node --check website/site.js`
- `git diff --check`

## Related issues

None.
