### PR TITLE
desktop: minimize Windows close to the system tray

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.md
+2026-08-26-win32-close-to-tray.md: 81f68d7d64f7e23a135f29f124cd97c3ff0ea945
+2026-08-26-win32-close-to-tray.zh.md: fe48c1979c08e4a70052dd29f3955ad8b24c9be7

--- a/.agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.md
+++ b/.agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.md
@@ -1,0 +1,28 @@
+# Agent Note: Windows close minimizes Oh-DSH Desktop to the system tray
+
+Status: implemented
+
+English | [中文](2026-08-26-win32-close-to-tray.zh.md)
+
+## Problem
+
+On Windows, every close gesture — the custom titlebar's × button, the application menu's Close Window role, and the `desktop:window-close` IPC they funnel into — ran `window.close()` to completion, so `window-all-closed` fired and the whole application quit, taking the supervised DSH runtime and every live session with it. One mis-click on × destroyed the workbench state, and nothing told the user that closing the window meant exiting the process tree. Desktop workbench apps on Windows conventionally keep running from the system tray instead.
+
+## Decision
+
+Close-to-tray is a main-process-only decision in `src/main.ts`. A `Tray` is created on win32 after `app.whenReady()` (icon: the packaged `resources/oh-dsh-desktop.png` or the dev `assets/icons/16x16.png`, resized to `16 × scaleFactor` DIPs of the primary display); macOS and Linux never get one. The main window's `close` handler calls `event.preventDefault()` + `window.hide()` only when the tray exists, the window is not a plugin preview, and no quit is already in progress — otherwise close behaves exactly as before. `window-all-closed` no longer quits while the tray owns the hidden window and no quit is running, and `will-quit` destroys the tray so no orphan icon survives the process. The tray's click and its menu (**Show Main Window** / **Quit**) share `revealMainWindow()` with the macOS `activate` path; a second instance launch re-focuses the hidden window through the existing `second-instance` handler. The first hide of a session shows one `displayBalloon` notice saying the app keeps running in the tray. Tray labels live in the same bilingual `labels()` table as the application menu and are rebuilt whenever `buildMenu()` re-runs, so the tray follows the menu locale. The renderer, preload, and contracts are untouched: `desktop:window-close` still just calls `window.close()`, and Electron alone owns the hide-or-quit semantics — matching the desktop-titlebar boundary where the renderer owns the chrome row and Electron owns the BrowserWindow lifecycle. A missing or empty icon makes `createTray()` return `undefined`, which silently falls back to plain close-quits instead of trapping a window with no tray. `tests/desktop-tray.test.ts` pins the interception gate, the quit paths, the fallback, and the bilingual menu with static assertions.
+
+## Alternatives considered
+
+- **Tray on every platform.** Rejected: macOS already keeps the app in the Dock with `activate`-to-reveal, and Linux tray support depends on the desktop environment (GNOME ships without an extension); keeping macOS/Linux behavior byte-identical is a repository rule, and the problem only exists on Windows.
+- **A close confirmation dialog (quit vs minimize).** Rejected: it interrupts every close, while a tray plus one balloon notice achieves the same informed choice after the fact.
+- **A user preference toggling close behavior.** Rejected for now: it needs cross-surface settings storage and UI for little gain, and would add a new persisted preference surface the data-root rules discourage.
+- **Also routing minimize to the tray.** Rejected: taskbar minimize is the Windows expectation; only the quit intent behind × is redirected, keeping the semantics auditable in one place.
+- **A renderer-visible tray API on `DesktopBridge`.** Rejected: the hide-or-quit decision belongs to the Electron lifecycle, not the page; a main-process-only interception is the smallest diff and leaves the bridge contract frozen.
+
+## Consequences
+
+- Windows users closing the window keep the DSH runtime and sessions alive in the tray; they exit through the tray or application menu's Quit, both of which reach `app.quit()` and the existing ordered shutdown (including install-on-quit updates, which bypass the interception through the `quitting`/`quittingForUpdate` gates).
+- macOS and Linux behavior is unchanged, and a failed tray-icon load degrades to the old close-quits instead of a stuck hidden window.
+- A hidden window whose runtime dies shows the error splash on the next reveal; `revealMainWindow()` only shows the existing window, it never rebuilds one behind the user's back.
+- Automated coverage is static-assertion only; real tray rendering, balloon behavior, and multi-monitor DPI need a manual Windows smoke before release.

--- a/.agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.zh.md
+++ b/.agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.zh.md
@@ -1,0 +1,28 @@
+# Agent Note: Windows 关闭窗口最小化到系统托盘
+
+Status: implemented
+
+[English](2026-08-26-win32-close-to-tray.md) | 中文
+
+## 问题
+
+在 Windows 上，所有关闭手势——自定义标题栏的 × 按钮、应用菜单的"关闭窗口"role，以及它们最终汇入的 `desktop:window-close` IPC——都会完整执行 `window.close()`，随后 `window-all-closed` 触发、整个应用退出，被监管的 DSH 运行时与所有活跃会话一并被带走。在 × 上的一次误点击就摧毁了工作台状态，且没有任何提示告诉用户关闭窗口意味着退出整个进程树。Windows 上的桌面工作台类应用惯例是从系统托盘保持运行。
+
+## 决策
+
+关闭到托盘是 `src/main.ts` 中纯主进程的决策。win32 上在 `app.whenReady()` 之后创建 `Tray`（图标：打包后的 `resources/oh-dsh-desktop.png` 或开发时的 `assets/icons/16x16.png`，缩放到主显示器 `16 × scaleFactor` DIP）；macOS 与 Linux 永远不会创建。主窗口的 `close` 处理器只在托盘存在、窗口不是插件预览、且没有退出正在进行时调用 `event.preventDefault()` + `window.hide()`——其余情况关闭行为与之前完全一致。托盘持有隐藏窗口期间 `window-all-closed` 不再退出（退出进行中除外），`will-quit` 销毁托盘，进程结束后不会残留孤儿图标。托盘的单击与其菜单（**显示主窗口** / **退出**）与 macOS 的 `activate` 路径共享 `revealMainWindow()`；二次启动经既有的 `second-instance` 处理器重新聚焦隐藏窗口。每个会话的首次隐藏会展示一次 `displayBalloon` 提示，告知应用仍在托盘运行。托盘标签与应用菜单共用同一张双语 `labels()` 表，并在每次 `buildMenu()` 重建时同步，因此托盘跟随菜单语言。渲染层、preload 与 contracts 零改动：`desktop:window-close` 仍只是调用 `window.close()`，隐藏还是退出完全由 Electron 主进程决定——契合 desktop-titlebar 的边界：渲染层拥有 chrome 行，Electron 拥有 BrowserWindow 生命周期。图标缺失或为空时 `createTray()` 返回 `undefined`，静默回退为普通的关闭即退出，而不是让窗口困在无处可去的状态。`tests/desktop-tray.test.ts` 用静态断言固定拦截门、退出路径、回退与双语菜单。
+
+## 考虑过的替代方案
+
+- **全平台托盘。** 否决：macOS 本就让应用常驻 Dock 并以 `activate` 揭示，Linux 的托盘支持取决于桌面环境（GNOME 默认无扩展即无托盘）；仓库规则要求 macOS/Linux 行为逐字节保持不变，而这个问题只存在于 Windows。
+- **关闭确认对话框（退出还是最小化）。** 否决：它打断每一次关闭；托盘加一次性 balloon 提示在事后达成同样的知情选择。
+- **控制关闭行为的用户偏好开关。** 暂时否决：需要跨 surface 的设置存储与 UI，收益有限，还会新增 data-root 规则所不建议的持久化偏好面。
+- **把最小化也路由到托盘。** 否决：最小化到任务栏是 Windows 的用户预期；只有 × 背后的退出意图被重定向，语义保持在单一可审计的位置。
+- **在 `DesktopBridge` 上暴露托盘 API 给渲染层。** 否决：隐藏还是退出的决策属于 Electron 生命周期而非页面；纯主进程拦截是最小 diff，并让 bridge 契约保持冻结。
+
+## 后果
+
+- Windows 用户关闭窗口后，DSH 运行时与会话在托盘中保持存活；通过托盘或应用菜单的退出均可退出，两者都到达 `app.quit()` 并走既有的有序停机（包括 install-on-quit 更新，它们经 `quitting`/`quittingForUpdate` 门绕过拦截）。
+- macOS 与 Linux 行为不变；托盘图标加载失败时降级为旧的关闭即退出，而不是卡死的隐藏窗口。
+- 运行时死掉的隐藏窗口在下一次揭示时显示错误 splash；`revealMainWindow()` 只显示既有窗口，绝不在用户背后重建。
+- 自动化覆盖只有静态断言；真实托盘渲染、balloon 行为与多显示器 DPI 需要在发布前于 Windows 上手动冒烟。

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write docs/usage.md
-usage.md: c8488a458933bf7b9c4230e0d265e3febcb9f733
-usage.zh.md: 9da92ec414f1005bed0c13b480de2508564fad0f
+usage.md: 1df7e44e28e65d3ce7af7f5f5764ba532bb5a55c
+usage.zh.md: 8033e3e52e0275be986daa380aff4fa679b9a5cf

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -187,6 +187,11 @@ installer may request administrator approval.
 The window title bar, menu bar, and tool strip are merged into a single row;
 open the application menu from the labels in the row's left corner.
 
+Closing the window minimizes Oh-DSH Desktop to the system tray instead of
+quitting: click the tray icon to restore the window, and use **Quit Oh-DSH
+Desktop** in the tray (or application) menu to exit. macOS and Linux keep
+their usual close behavior.
+
 ### Desktop online updates
 
 Choose **Oh-DSH Desktop -> Check for Updates...** from the application menu.

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -159,6 +159,10 @@ sudo apt install ./Oh-DSH-Desktop-*.deb
 
 窗口标题栏、菜单栏与工具条合并为一行；点击该行左角的菜单名即可打开应用菜单。
 
+关闭窗口会将 Oh-DSH Desktop 最小化到系统托盘而不是退出：点击托盘图标可恢复
+窗口，通过托盘（或应用）菜单中的 **退出 Oh-DSH Desktop** 退出应用。macOS 与
+Linux 保持原有的关闭行为。
+
 ### Desktop 在线更新
 
 在应用菜单中选择 **Oh-DSH Desktop -> 检查更新…**。更新窗口只检查

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,13 +5,17 @@ import {
   dialog,
   ipcMain,
   Menu,
+  nativeImage,
   nativeTheme,
   net,
   Notification,
+  screen,
   session,
   shell,
+  Tray,
   type IpcMainInvokeEvent,
   type MenuItemConstructorOptions,
+  type NativeImage,
 } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { createWriteStream, existsSync, mkdirSync, readFileSync, statSync, type WriteStream } from 'node:fs'
@@ -94,6 +98,8 @@ let logStream: WriteStream | undefined
 let updateWindow: BrowserWindow | undefined
 let updateManager: DesktopUpdateManager | undefined
 let runtimeUpdateManager: RuntimeUpdateManager | undefined
+let tray: Tray | undefined
+let trayHideNoticeShown = false
 let quittingForUpdate = false
 let quitting = false
 let transitioning = false
@@ -316,6 +322,21 @@ function brandIconDataUrl(): string | null {
   return `data:image/png;base64,${readFileSync(path).toString('base64')}`
 }
 
+function trayIconImage(): NativeImage | undefined {
+  // Packaged builds carry only the 512px window icon beside resources/;
+  // development has the rendered 16px set. The tray needs a small bitmap
+  // sized for the primary display, or Windows scales it blurry.
+  const packaged = join(process.resourcesPath, 'oh-dsh-desktop.png')
+  const development = join(currentDir, '..', 'assets', 'icons', '16x16.png')
+  const path = existsSync(packaged) ? packaged : existsSync(development) ? development : undefined
+  if (path === undefined) return undefined
+  const image = nativeImage.createFromPath(path)
+  if (image.isEmpty()) return undefined
+  const size = Math.max(16, Math.round(16 * screen.getPrimaryDisplay().scaleFactor))
+  const resized = image.resize({ height: size, width: size })
+  return resized.isEmpty() ? undefined : resized
+}
+
 function createWindow(options: { preview?: boolean; title?: string } = {}): BrowserWindow {
   const icon = windowIconPath()
   const window = new BrowserWindow({
@@ -348,6 +369,18 @@ function createWindow(options: { preview?: boolean; title?: string } = {}): Brow
   }
   window.on('maximize', sendWindowState)
   window.on('unmaximize', sendWindowState)
+  window.on('close', (event) => {
+    // With a tray alive, closing the main window hides it instead of
+    // quitting; preview windows and an already-running quit pass through.
+    // The tray only exists on win32, so macOS and Linux close unchanged.
+    if (options.preview === true || tray === undefined || quitting || quittingForUpdate) return
+    event.preventDefault()
+    window.hide()
+    if (!trayHideNoticeShown) {
+      trayHideNoticeShown = true
+      tray.displayBalloon({ iconType: 'info', title: PRODUCT_NAME, content: labels(menuLocale).trayNotice })
+    }
+  })
   window.on('closed', () => {
     if (mainWindow === window) mainWindow = undefined
     if (previewWindow === window) {
@@ -875,6 +908,8 @@ function labels(locale: OhDshLocale) {
     resetZoom: '重置缩放',
     settings: '设置…',
     selectAll: '全选',
+    show: '显示主窗口',
+    trayNotice: 'Oh-DSH 仍在系统托盘中运行，点击托盘图标可恢复窗口。要退出请使用托盘菜单中的“退出 Oh-DSH Desktop”。',
     toggleBottomPanel: '切换底部面板',
     toggleDevTools: '切换开发者工具',
     toggleFullscreen: '切换全屏',
@@ -922,6 +957,8 @@ function labels(locale: OhDshLocale) {
     resetZoom: 'Reset Zoom',
     settings: 'Settings…',
     selectAll: 'Select All',
+    show: 'Show Main Window',
+    trayNotice: 'Oh-DSH keeps running in the system tray. Click the tray icon to restore the window; use Quit in the tray menu to exit.',
     toggleBottomPanel: 'Toggle Bottom Panel',
     toggleDevTools: 'Toggle Developer Tools',
     toggleFullscreen: 'Toggle Full Screen',
@@ -945,6 +982,40 @@ function labels(locale: OhDshLocale) {
     sideChat: 'Side Chat',
     trajectory: 'Trajectory',
   }
+}
+
+function revealMainWindow(): void {
+  if (mainWindow !== undefined && !mainWindow.isDestroyed()) {
+    mainWindow.show()
+    mainWindow.focus()
+    return
+  }
+  mainWindow = createWindow()
+  if (runtimeUrl !== undefined) void mainWindow.loadURL(runtimeUrl.href).then(flushQueuedPaths)
+  else void showSplash({ error: true, message: 'DeepSeek Harness 未运行，请从“DSH”菜单重新启动。' })
+}
+
+function buildTrayMenu(): Menu {
+  const text = labels(menuLocale)
+  return Menu.buildFromTemplate([
+    { label: text.show, click: () => { revealMainWindow() } },
+    { type: 'separator' },
+    { label: text.quit, click: () => { app.quit() } },
+  ])
+}
+
+function createTray(): Tray | undefined {
+  // Close-to-tray is a Windows affordance; macOS and Linux keep their dock
+  // and close-quits behavior. A missing icon leaves the close behavior
+  // exactly as before instead of trapping a window with no tray.
+  if (process.platform !== 'win32') return undefined
+  const icon = trayIconImage()
+  if (icon === undefined) return undefined
+  const trayInstance = new Tray(icon)
+  trayInstance.setToolTip(PRODUCT_NAME)
+  trayInstance.setContextMenu(buildTrayMenu())
+  trayInstance.on('click', () => { revealMainWindow() })
+  return trayInstance
 }
 
 function buildMenu(locale: OhDshLocale = menuLocale): void {
@@ -1059,6 +1130,7 @@ function buildMenu(locale: OhDshLocale = menuLocale): void {
   ]
   applicationMenu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(applicationMenu)
+  tray?.setContextMenu(buildTrayMenu())
 }
 
 /** The native application menu, popped up by the in-page Windows menu bar. */
@@ -1269,23 +1341,23 @@ async function bootstrap(): Promise<void> {
   browserSession.setPermissionRequestHandler((_webContents, _permission, callback) => { callback(false) })
   browserSession.setPermissionCheckHandler(() => false)
   buildMenu(systemLocale())
+  tray = createTray()
   mainWindow = createWindow()
   await showSplash()
   const initialArguments = process.argv.slice(app.isPackaged ? 1 : 2)
   queuedPaths.push(...initialArguments.filter(argument => !argument.startsWith('-')))
   await restartRuntime()
 
-  app.on('activate', () => {
-    if (mainWindow !== undefined && !mainWindow.isDestroyed()) {
-      mainWindow.show()
-      return
-    }
-    mainWindow = createWindow()
-    if (runtimeUrl !== undefined) void mainWindow.loadURL(runtimeUrl.href).then(flushQueuedPaths)
-    else void showSplash({ error: true, message: 'DeepSeek Harness 未运行，请从“DSH”菜单重新启动。' })
-  })
+  app.on('activate', () => { revealMainWindow() })
   app.on('window-all-closed', () => {
+    // While the tray owns the hidden main window the app stays alive; a
+    // quit already in progress finishes on its own without re-entering.
+    if (process.platform === 'win32' && tray !== undefined && !quitting) return
     if (process.platform !== 'darwin') app.quit()
+  })
+  app.on('will-quit', () => {
+    tray?.destroy()
+    tray = undefined
   })
   app.on('before-quit', (event) => {
     if (quitting) return

--- a/tests/desktop-tray.test.ts
+++ b/tests/desktop-tray.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+test('desktop win32 closes to the system tray instead of quitting', () => {
+  const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
+
+  // The tray is a main-process-only affordance: the renderer keeps issuing
+  // desktop:window-close and Electron owns the hide/quit decision.
+  assert.match(main, /  Tray,\r?\n/)
+  assert.match(main, /'desktop:window-close'/)
+
+  // Closing the main window hides it only while the tray exists; preview
+  // windows, a missing tray, and a quit already in progress pass through.
+  assert.match(
+    main,
+    /window\.on\('close', \(event\) => \{[\s\S]*?options\.preview === true \|\| tray === undefined \|\| quitting \|\| quittingForUpdate[\s\S]*?event\.preventDefault\(\)[\s\S]*?window\.hide\(\)/,
+  )
+
+  // The first hide tells the user where the app went, once per session.
+  assert.match(main, /if \(!trayHideNoticeShown\) \{[\s\S]*?trayHideNoticeShown = true[\s\S]*?displayBalloon\(/)
+
+  // While the tray owns the hidden window, all-windows-closed no longer
+  // quits; a quit in progress finishes without re-entering app.quit().
+  assert.match(
+    main,
+    /app\.on\('window-all-closed', \(\) => \{[\s\S]*?process\.platform === 'win32' && tray !== undefined && !quitting[\s\S]*?return\r?\n[\s\S]*?if \(process\.platform !== 'darwin'\) app\.quit\(\)/,
+  )
+
+  // Quitting tears the tray down so no orphan icon survives the process.
+  assert.match(main, /app\.on\('will-quit', \(\) => \{[\s\S]*?tray\?\.destroy\(\)/)
+
+  // The tray only exists on win32, so macOS and Linux close behavior is
+  // unchanged, and a failed icon load falls back to plain close-quits.
+  assert.match(
+    main,
+    /function createTray\(\): Tray \| undefined \{[\s\S]*?process\.platform !== 'win32'[\s\S]*?return undefined[\s\S]*?const icon = trayIconImage\(\)[\s\S]*?if \(icon === undefined\) return undefined/,
+  )
+  assert.match(
+    main,
+    /function trayIconImage\(\): NativeImage \| undefined \{[\s\S]*?nativeImage\.createFromPath\(path\)[\s\S]*?image\.isEmpty\(\)/,
+  )
+})
+
+test('desktop tray menu restores the window and stays bilingual', () => {
+  const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
+
+  // Tray click and the tray menu's first item both reveal the main window;
+  // the dock/activate path shares the same reveal.
+  assert.match(main, /function revealMainWindow\(\): void \{[\s\S]*?mainWindow\.show\(\)[\s\S]*?mainWindow\.focus\(\)/)
+  assert.match(main, /trayInstance\.on\('click', \(\) => \{ revealMainWindow\(\) \}\)/)
+  assert.match(
+    main,
+    /function buildTrayMenu\(\): Menu \{[\s\S]*?\{ label: text\.show, click: \(\) => \{ revealMainWindow\(\) \} \}[\s\S]*?\{ label: text\.quit, click: \(\) => \{ app\.quit\(\) \} \}/,
+  )
+  assert.match(main, /app\.on\('activate', \(\) => \{ revealMainWindow\(\) \}\)/)
+  // A second launch re-focuses the hidden window instead of a new one.
+  assert.match(
+    main,
+    /app\.on\('second-instance',[\s\S]*?mainWindow\.show\(\)[\s\S]*?mainWindow\.focus\(\)/,
+  )
+
+  // The tray follows the application menu locale, rebuilt on every rebuild.
+  assert.match(main, /tray\?\.setContextMenu\(buildTrayMenu\(\)\)/)
+  assert.match(main, /const text = labels\(menuLocale\)/)
+  assert.match(main, /show: '显示主窗口'/)
+  assert.match(main, /show: 'Show Main Window'/)
+  assert.match(main, /trayNotice: 'Oh-DSH 仍在系统托盘中运行/)
+  assert.match(main, /trayNotice: 'Oh-DSH keeps running in the system tray/)
+  assert.match(main, /setToolTip\(PRODUCT_NAME\)/)
+
+  // User-facing docs describe the behavior in both languages.
+  const usage = readFileSync(new URL('../docs/usage.md', import.meta.url), 'utf8')
+  const usageZh = readFileSync(new URL('../docs/usage.zh.md', import.meta.url), 'utf8')
+  assert.match(usage, /Closing the window minimizes Oh-DSH Desktop to the system tray/)
+  assert.match(usageZh, /关闭窗口会将 Oh-DSH Desktop 最小化到系统托盘/)
+})


### PR DESCRIPTION
## Summary

- Closing the main window on Windows now hides it to the system tray
  instead of quitting the app. The tray icon (single click, or the menu
  item "Show Main Window") restores the window; Quit exits as before.
- The tray is win32-only and lives entirely in the Electron main
  process. The renderer, preload, and `DesktopBridge` contracts are
  untouched — the titlebar × still goes through the existing
  `desktop:window-close` IPC, and Electron alone owns the hide-or-quit
  decision.
- Quit paths are preserved: application-menu Quit, tray Quit, and
  update installs (install-now / install-on-quit) bypass the
  interception through the existing `quitting` gates, and `will-quit`
  destroys the tray so no orphan icon survives the process.
- The first hide of a session shows one balloon notice explaining that
  the app keeps running in the tray.
- If the tray icon cannot be loaded, `createTray()` returns undefined
  and close falls back to the previous close-quits behavior instead of
  trapping a hidden window.
- The tray menu follows the application menu locale (zh/en), rebuilt
  whenever the menu is rebuilt.
- macOS and Linux behavior is unchanged: the close interception, the
  `window-all-closed` branch, and tray creation are all gated on
  win32 / tray existence. (One inert touchpoint: the
macOS Dock-activate reveal now also focuses the window, matching
the second-instance reveal on Windows.)

## Why

On Windows, every close gesture (titlebar ×, menu Close Window) ran
`window.close()` to completion, so `window-all-closed` fired and the
whole application quit, taking the supervised DSH runtime and every
live session with it — one mis-click on × destroyed the workbench
state, with nothing telling the user that closing the window meant
exiting the process tree.

macOS already gives this app the safer model: the close button never
quits there — the window closes, the app stays alive in the Dock, and
quitting always goes through an explicit menu action. This change
brings Windows to the same semantics, with the system tray as the
Windows equivalent of the Dock. Linux keeps its existing close-quits
behavior, so only Windows changes.

Design decisions and rejected alternatives are recorded in the
Agent Note:
`.agents/notes/implemented/feature/2026-08-26-win32-close-to-tray.md`

## Verification

- `pnpm run typecheck` — pass.
- `node --test tests/desktop-tray.test.ts` — pass; the new
  static-assert regression pins the interception gate, quit paths,
  icon fallback, and the bilingual tray menu.
- `node --test tests/desktop-tray.test.ts tests/desktop-titlebar.test.ts`
  — 5/5 pass (existing titlebar contracts unaffected).
- `pnpm run build` — pass.
- Bilingual pairing sidecars re-recorded with
  `verify-translation-pairing --write` for the Agent Note and
  `docs/usage.md`; the Agent Note format and classification gates
  report no findings for the new note.
- Launched the dev build on Windows (`bin/ohdsh desktop`) and
  confirmed startup in the main-process log (application start, DSH
  runtime serving). Interactive tray gestures (close-to-tray, balloon
  notice, tray-click restore, tray quit) are left for smoke testing.