### PR TITLE
desktop: keep marketplace available in read-only viewer

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-26-desktop-marketplace-read-only.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-26-desktop-marketplace-read-only.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-26-desktop-marketplace-read-only.md
+2026-08-26-desktop-marketplace-read-only.md: a09241c1f077c34ae9d50a46d2855ab782d7c7ea
+2026-08-26-desktop-marketplace-read-only.zh.md: 9a0423c32c00c2b25035e6f1ab26c4f5baec2f28

--- a/.agents/notes/implemented/bug-fix/2026-08-26-desktop-marketplace-read-only.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-26-desktop-marketplace-read-only.md
@@ -1,0 +1,42 @@
+# Agent Note: Desktop Marketplace keeps a read-only viewer
+
+Status: implemented
+
+English | [中文](2026-08-26-desktop-marketplace-read-only.zh.md)
+
+## Problem
+
+Desktop shares `~/.ohdsh` with Web or TUI surfaces. When another surface owns the
+runtime lock, Desktop enters read-only viewer mode. The renderer still exposes the
+Marketplace entry, but Desktop previously omitted its transaction manager, so
+Marketplace IPC failed with `plugin marketplace is not initialized` instead of
+serving a catalog viewer.
+
+## Decision
+
+Desktop creates the same `PluginMarketplaceManager` in read-only mode that Web and
+TUI use. The manager can load and refresh the public catalog and read the shared
+profile, but it does not create preview or rollback directories, does not write the
+catalog cache, and returns a read-only error for every mutating command. Desktop
+only creates the Marketplace working directory and ensures the profile when it owns
+the runtime lock.
+
+## Alternatives considered
+
+**Keep Desktop Marketplace disabled while read-only** — rejected because the
+renderer bridge remains present and the UI must either expose a working read-only
+viewer or hide the entry. Keeping the shared viewer contract makes the lock
+contention behavior consistent across surfaces and avoids an IPC initialization
+failure.
+
+**Allow Desktop to mutate the shared profile without the lock** — rejected because
+it would violate the single-writer runtime contract and could corrupt session or
+profile state while another surface is active.
+
+## Consequences
+
+A Desktop started while Web or TUI owns the shared data root can browse the
+Marketplace and receive an explicit read-only response for install, update,
+enable, disable, preview, apply, discard, and undo actions. Catalog refresh remains
+subject to the existing network and cache-read behavior. Once Desktop owns the
+lock, its existing writable Marketplace setup is unchanged.

--- a/.agents/notes/implemented/bug-fix/2026-08-26-desktop-marketplace-read-only.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-26-desktop-marketplace-read-only.zh.md
@@ -1,0 +1,35 @@
+# Agent Note: Desktop Marketplace 保留只读查看器
+
+Status: implemented
+
+[English](2026-08-26-desktop-marketplace-read-only.md) | 中文
+
+## 问题
+
+Desktop 与 Web 或 TUI 共享 `~/.ohdsh`。当其他 surface 持有运行时锁时，Desktop
+进入只读查看器模式。renderer 仍然暴露 Marketplace 入口，但 Desktop 之前没有
+创建事务管理器，因此 Marketplace IPC 报告 `plugin marketplace is not initialized`，
+而不是提供 catalog 查看器。
+
+## 决定
+
+Desktop 与 Web、TUI 一样创建只读模式的 `PluginMarketplaceManager`。管理器可以
+加载和刷新公开 catalog，也可以读取共享 profile，但不会创建 preview 或 rollback
+目录，不会写入 catalog cache，并会对所有修改命令返回只读错误。只有在 Desktop
+持有运行时锁时，才创建 Marketplace 工作目录并确保 profile 存在。
+
+## 曾考虑的替代方案
+
+**只读时继续禁用 Desktop Marketplace**：不采纳，因为 renderer bridge 仍然存在，
+UI 要么提供可用的只读查看器，要么隐藏入口。保留共享查看器契约可以让锁竞争行为
+在各 surface 之间一致，也能避免 IPC 初始化错误。
+
+**没有运行时锁时允许 Desktop 修改共享 profile**：不采纳，因为这会违反单写入者运行时
+契约，并可能在其他 surface 活跃时破坏 session 或 profile 状态。
+
+## 影响
+
+当 Web 或 TUI 持有共享数据目录时启动 Desktop，Desktop 仍可浏览 Marketplace；安装、
+更新、启用、禁用、preview、apply、discard 和 undo 等修改操作会收到明确的只读响应。
+Catalog 刷新仍受现有网络和只读缓存行为约束。Desktop 持有锁时，原有可写
+Marketplace 配置不变。

--- a/src/main.ts
+++ b/src/main.ts
@@ -812,21 +812,22 @@ async function installLocalPlugin(): Promise<void> {
   }
 }
 
-function createPluginMarketplace(): PluginMarketplaceManager | undefined {
-  if (desktopReadOnly) return undefined
+function createPluginMarketplace(): PluginMarketplaceManager {
   const info = desktopInfo()
-  ensureDesktopProfile(info.dshHome)
+  if (!desktopReadOnly) ensureDesktopProfile(info.dshHome)
   const paths = runtimePaths()
   const workingDirectory = join(info.appDataPath, 'plugin-marketplace')
-  mkdirSync(workingDirectory, { recursive: true, mode: 0o700 })
+  if (!desktopReadOnly) mkdirSync(workingDirectory, { recursive: true, mode: 0o700 })
   const environment = runtimeEnvironment(paths)
   return new PluginMarketplaceManager({
     appDataPath: info.appDataPath,
     dshHome: info.dshHome,
+    ...(desktopReadOnly ? { readOnly: true } : {}),
     onWarn: line => { appendLog('desktop', `[marketplace] ${line}`) },
     platform: new ProductionMarketplacePlatform({
+      appDataPath: info.appDataPath,
       cliEntry: paths.cliEntry,
-      cwd: workingDirectory,
+      ...(desktopReadOnly ? { cacheReadOnly: true } : { cwd: workingDirectory }),
       env: environment,
       nodeBinary: paths.nodeBinary,
       pnpmEntry: paths.pnpmEntry,

--- a/tests/desktop-titlebar.test.ts
+++ b/tests/desktop-titlebar.test.ts
@@ -68,6 +68,20 @@ test('desktop chrome keeps platform title bars and panel controls distinct', () 
   assert.match(client, /button\[data-action='close'\]::before,[\s\S]*?left: 18px[\s\S]*?width: 10px/)
 })
 
+test('desktop marketplace remains available in read-only viewer mode', () => {
+  const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
+
+  assert.match(
+    main,
+    /function createPluginMarketplace\(\): PluginMarketplaceManager \{[\s\S]*?if \(!desktopReadOnly\) ensureDesktopProfile\(info\.dshHome\)[\s\S]*?if \(!desktopReadOnly\) mkdirSync\(workingDirectory, \{ recursive: true, mode: 0o700 \}\)[\s\S]*?desktopReadOnly \? \{ readOnly: true \} : \{\}/,
+  )
+  assert.match(
+    main,
+    /desktopReadOnly \? \{ cacheReadOnly: true \} : \{ cwd: workingDirectory \}/,
+  )
+  assert.doesNotMatch(main, /function createPluginMarketplace\(\): PluginMarketplaceManager \| undefined \{[\s\S]*?if \(desktopReadOnly\) return undefined/)
+})
+
 test('desktop win32 menu bar renders in the merged row but pops the native menu', () => {
   const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
   const client = readFileSync(new URL('../src/client.ts', import.meta.url), 'utf8')


### PR DESCRIPTION
## Scope

Fixes #162.

When another Oh-DSH surface owns the shared runtime lock, Desktop now keeps a
read-only Plugin Marketplace manager instead of exposing an uninitialized IPC
bridge. Catalog reads remain available without creating writable transaction
state; mutations return the existing read-only error.

## Changes

- preserve Desktop marketplace initialization in read-only viewer mode;
- avoid creating the marketplace working directory and catalog cache there;
- add a regression assertion for the Desktop setup;
- add the bilingual implemented Agent Note.

## Verification

- `pnpm test` — 307 passed, 10 skipped;
- `pnpm run typecheck` — passed;
- `pnpm run build` — passed;
- focused marketplace/titlebar tests — 46 passed, 2 skipped;
- Agent Note format and translation pairing checks — passed;
- `git diff --check` — passed.

`pnpm run doc-sync` is unavailable because this repository has no such script.
