### PR TITLE
release: prepare v0.1.11

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-30-provider-credential-copy-follows-dsh-home.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-30-provider-credential-copy-follows-dsh-home.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-30-provider-credential-copy-follows-dsh-home.md
+2026-08-30-provider-credential-copy-follows-dsh-home.md: 73e1848ad13c88859df813c4219a8c787d672537
+2026-08-30-provider-credential-copy-follows-dsh-home.zh.md: 5ad9c6d52d642422a358602512150f1b0ba7a249

--- a/.agents/notes/implemented/bug-fix/2026-08-30-provider-credential-copy-follows-dsh-home.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-30-provider-credential-copy-follows-dsh-home.md
@@ -1,0 +1,60 @@
+# Agent Note: Keep provider credential copy aligned with DSH_HOME
+
+Status: implemented
+
+English | [中文](2026-08-30-provider-credential-copy-follows-dsh-home.zh.md)
+
+## Problem
+
+The pinned dsh-TUI `/provider` wizard displayed
+`~/.dsh/.credentials.yaml` in its API-key prompt, success summary, rollback
+diagnostic, and module comment. Oh-DSH launches the renderer with its shared
+data root as `DSH_HOME`, which defaults to `~/.ohdsh`, while the Harness
+credentials service follows that effective root. The wizard therefore named
+the wrong file and promised a file write even when a launch-time environment
+variable shadows the credential and causes the write to be skipped.
+
+## Decision
+
+The guarded compiled-renderer adapter rewrites the copied provider strings
+without modifying the pinned submodule. The API-key prompt says that the
+Harness credentials service manages the key and keeps it out of the
+transcript; it does not promise a file write. The success summary, rollback
+diagnostic, and module comment name `$DSH_HOME/.credentials.yaml`, while the
+existing environment-shadow summary continues to say that the write was
+skipped.
+
+The adapter uses exact, idempotent replacements. An upstream wording or file
+layout change fails adaptation instead of silently restoring the fixed path.
+This extends the compiled-renderer ownership established by the pinned
+[dsh-TUI upgrade](../feature/2026-08-26-upstream-tui-0.9.2-upgrade.md).
+
+## Alternatives considered
+
+**Display `~/.ohdsh/.credentials.yaml`.** Rejected because `OH_DSH_HOME` and
+`DSH_HOME` may select another shared root; another fixed path would preserve
+the same defect for configured installations.
+
+**Display the resolved absolute path.** Rejected because `$DSH_HOME` states
+the storage contract without exposing a machine-specific home path and stays
+accurate for every supported override.
+
+**Edit or fork the upstream renderer.** Rejected because the wording is an
+Oh-DSH integration concern and the pinned source stays pristine. The existing
+compiled-renderer adapter is the owned compatibility boundary.
+
+**Keep the file-write promise and only replace the path.** Rejected because a
+credential already present in the process environment intentionally skips the
+credentials document write.
+
+## Consequences
+
+- Default and custom data roots receive accurate bilingual provider guidance.
+- The input prompt no longer claims mode `0600`, because no file is necessarily
+  written at that step; file-backed success and rollback messages still name
+  the managed document.
+- The TUI adapter regression test copies the pinned compiled renderer, runs the
+  real adapter twice, and rejects both the fixed legacy path and the
+  unconditional Chinese write promise.
+- A future upstream renderer upgrade must preserve or deliberately revise this
+  adapter seam.

--- a/.agents/notes/implemented/bug-fix/2026-08-30-provider-credential-copy-follows-dsh-home.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-30-provider-credential-copy-follows-dsh-home.zh.md
@@ -1,0 +1,32 @@
+# Agent Note: 让 provider 凭据文案遵循 DSH_HOME
+
+Status: implemented
+
+[English](2026-08-30-provider-credential-copy-follows-dsh-home.md) | 中文
+
+## Problem
+
+pinned dsh-TUI 的 `/provider` 向导在 API key 提示、成功摘要、回滚诊断和模块注释中显示 `~/.dsh/.credentials.yaml`。Oh-DSH 启动渲染器时将共享数据根目录设为 `DSH_HOME`，其默认值是 `~/.ohdsh`，Harness 凭据服务则遵循这个有效根目录。因此，向导显示了错误的文件；当启动环境中的同名变量遮蔽凭据并使写入被跳过时，向导仍承诺会写入文件。
+
+## Decision
+
+受保护的编译后渲染器适配器改写复制产物中的 provider 文案，不修改 pinned 子模块。API key 提示说明密钥由 Harness 凭据服务管理且不会进入 transcript，但不承诺写入文件。成功摘要、回滚诊断和模块注释使用 `$DSH_HOME/.credentials.yaml`；现有的环境变量遮蔽摘要继续说明已跳过写入。
+
+适配器使用精确且幂等的替换。上游文案或文件布局发生变化时，适配过程会失败，不会悄悄恢复固定路径。这项决定延续 pinned [dsh-TUI 升级](../feature/2026-08-26-upstream-tui-0.9.2-upgrade.md)确立的编译后渲染器所有权。
+
+## Alternatives considered
+
+**显示 `~/.ohdsh/.credentials.yaml`。** 否决，因为 `OH_DSH_HOME` 和 `DSH_HOME` 可以选择其他共享根目录；另一个固定路径仍会让自定义安装遇到同一缺陷。
+
+**显示解析后的绝对路径。** 否决，因为 `$DSH_HOME` 无需暴露机器特定的主目录路径就能表达存储约定，并对所有受支持的覆盖方式保持准确。
+
+**编辑或 fork 上游渲染器。** 否决，因为这段文案属于 Oh-DSH 集成问题，pinned 源码应保持原样。现有编译后渲染器适配器是项目拥有的兼容边界。
+
+**保留写入文件的承诺，只替换路径。** 否决，因为进程环境中已经存在凭据时，系统会按设计跳过凭据文档写入。
+
+## Consequences
+
+- 默认和自定义数据根目录都会显示准确的中英文 provider 指引。
+- 输入提示不再声称文件权限为 `0600`，因为该步骤不一定写入文件；使用文件存储时，成功和回滚文案仍会指出受管理的文档。
+- TUI 适配器回归测试会复制 pinned 编译后渲染器，运行两次真实适配器，并拒绝固定的旧路径和无条件承诺写入的中文文案。
+- 未来升级上游渲染器时，必须保留或有意调整这个适配器 seam。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH Desktop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",

--- a/scripts/tui-upstream-adapter.mjs
+++ b/scripts/tui-upstream-adapter.mjs
@@ -264,6 +264,13 @@ export function adaptTuiRendererPackage(packageDir) {
   )
   replaceEvery(plugin, 'dsh-tui --resume', 'ohdsh tui --resume')
 
+  const providerWizard = join(lib, 'dsh-adapter', 'providerWizard.js')
+  replaceEvery(
+    providerWizard,
+    '`~/.dsh/.credentials.yaml`',
+    '`$DSH_HOME/.credentials.yaml`',
+  )
+
   const channel = join(lib, 'dsh-adapter', 'channel.js')
   replaceOnce(
     channel,
@@ -286,6 +293,16 @@ export function adaptTuiRendererPackage(packageDir) {
   const messages = join(lib, 'i18n.js')
   replaceEvery(messages, '~/.dsh-tui', '~/.ohdsh/tui')
   replaceEvery(messages, 'dsh-tui', 'Oh-DSH TUI')
+  replaceOnce(
+    messages,
+    "'provider-q-apikey-detail': { zh: '密钥将写入 ~/.dsh/.credentials.yaml（权限 0600），不会出现在会话记录中', en: 'The key is stored in ~/.dsh/.credentials.yaml (mode 0600) and never shown in the transcript' },",
+    "'provider-q-apikey-detail': { zh: '密钥由 Harness 凭据服务管理，不会出现在会话记录中', en: 'The key is managed by the Harness credentials service and never shown in the transcript' },",
+  )
+  replaceEvery(
+    messages,
+    '~/.dsh/.credentials.yaml',
+    '$DSH_HOME/.credentials.yaml',
+  )
 
   const customTheme = join(lib, 'customTheme.js')
   replaceEvery(customTheme, '[dsh-tui]', '[Oh-DSH TUI]')

--- a/tests/tui.test.ts
+++ b/tests/tui.test.ts
@@ -240,8 +240,20 @@ test('TUI upstream adapter removes legacy terminal branding and scopes storage',
     const messages = readFileSync(join(lib, 'i18n.js'), 'utf8')
     assert.match(messages, /~\/\.ohdsh\/tui/)
     assert.doesNotMatch(messages, /dsh-tui|~\/\.dsh-tui/)
+    assert.match(messages, /Harness credentials service/)
+    assert.match(messages, /密钥由 Harness 凭据服务管理/)
+    assert.match(messages, /\$DSH_HOME\/\.credentials\.yaml/)
+    assert.match(messages, /already in the process environment, write skipped/)
+    assert.match(messages, /进程环境已提供同名变量，跳过写入/)
+    assert.doesNotMatch(messages, /~\/\.dsh\/\.credentials\.yaml|密钥将写入/)
     assert.match(messages, /Liangshen mode/)
     assert.match(messages, /preset-liangshen-description/)
+    const providerWizard = readFileSync(
+      join(lib, 'dsh-adapter', 'providerWizard.js'),
+      'utf8',
+    )
+    assert.match(providerWizard, /\$DSH_HOME\/\.credentials\.yaml/)
+    assert.doesNotMatch(providerWizard, /~\/\.dsh\/\.credentials\.yaml/)
     const channel = readFileSync(join(lib, 'dsh-adapter', 'channel.js'), 'utf8')
     assert.match(channel, /oh-dsh-tui-export-/)
     assert.match(channel, /isOhDshLiangshen/)


### PR DESCRIPTION
## Scope

- bump the root application version from 0.1.10 to 0.1.11
- adapt the pinned TUI provider wizard so credential guidance follows `DSH_HOME`
- avoid promising a file write when the process environment supplies the key
- add guarded bilingual regression coverage and an Agent Note

Fixes #161

## Verification

- `node scripts/validate-release-tag.mjs --tag v0.1.11 --version 0.1.11`
- focused release tests
- focused TUI adapter regression: red before the fix, green after it
- `pnpm run typecheck`
- `pnpm test` with an isolated `HOME` (324 passed, 9 platform skips)
- `pnpm run build`
- `pnpm run dist:tui:quick`
- `pnpm run verify:agent-notes`
- `pnpm run verify-translation-pairing`
- `git diff --check`

## Packaging evidence

The staged TUI renderer contains the new Chinese and English credentials-service wording. Its provider dictionary and wizard module contain no `~/.dsh/.credentials.yaml` literal. The environment-shadow summary still reports that the file write was skipped.

This is a terminal TUI-only text flow, so a browser GIF cannot truthfully demonstrate it; the real staged TUI package and adapter regression are the applicable evidence.

A normal local test run inherited the existing launcher record and added `/Users/zevorn/.local/bin` to three self-update expectations. Isolating `HOME` removes that machine-local state and the complete suite passes.