### PR TITLE
desktop: keep the image lightbox clear of the titlebar row

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.md
+2026-08-31-portal-dialog-close-clears-titlebar.md: 6707dd170bf35bb56e42c34ce8ab9216f7d25e0e
+2026-08-31-portal-dialog-close-clears-titlebar.zh.md: 0d17b3154955fd6e2d6b10b117cbe392cf1f7c32

--- a/.agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.md
@@ -1,0 +1,143 @@
+# Agent Note: Portal dialog close buttons clear the reserved titlebar row
+
+Status: implemented
+
+English | [中文](2026-08-31-portal-dialog-close-clears-titlebar.zh.md)
+
+## Problem
+
+Opening an image preview ("view original") in a session portals the pinned
+DSH runtime's image lightbox to `document.body`. The lightbox is a bare
+`role='dialog'` whose close control is a 36px circular `position: fixed`
+button parked at `top: 20px; right: 20px` — geometry written for a plain
+browser viewport with nothing reserved at the top. On macOS and Windows the
+Desktop surface reserves a 40px in-page titlebar row and paints it as an
+opaque `body::before` strip at `z-index: 2147483645`, far above the
+lightbox's own `z-index: 1000`. The strip covered the button's upper half:
+the lightbox looked broken, showing half a white circle with the bottom tips
+of an ✕ below the menu row, and the click target shrank to the visible
+sliver.
+
+The lightbox backdrop is off-balance in the same band. It centers the image
+with a symmetric 40px padding against the whole viewport, so on a platform
+that reserves the row the image's top edge sits 40px (reserved) + 40px
+(padding) from the screen top while its bottom keeps only the 40px padding
+— the preview touches the strip above and floats below. Its image ceiling
+has the same viewport-only assumption: `max-height: calc(100vh - 80px)`
+accounts for padding that the reserved row invalidates. Linux keeps its
+native frame and reserves nothing, and Web never loads the chrome
+stylesheet, so neither surface can produce either defect.
+
+## Decision
+
+The Desktop chrome stylesheet restores the lightbox's gutter symmetry below
+the reserved row on the platforms that reserve it: the backdrop starts at
+the strip's edge and keeps upstream's own 40px gutter width on all four
+sides — the strip replaces the top gutter the viewport used to provide —
+the image ceiling shrinks by the row plus the gutters, and the close button
+rides the gutter grid at its corner:
+
+```css
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'],
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] {
+  top: var(--oh-dsh-titlebar-height, 40px) !important;
+  padding: 40px !important;
+}
+
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > img,
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > img {
+  max-height: calc(100vh - var(--oh-dsh-titlebar-height, 40px) - 80px) !important;
+}
+
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > button,
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > button {
+  top: calc(var(--oh-dsh-titlebar-height, 40px) + 8px) !important;
+  right: 8px !important;
+}
+```
+
+The selectors are contracts about document structure, not about names: a
+`role='dialog'` that is a direct child of `body` (a portal overlay), with
+its close button and image as direct children. The pinned runtime is
+rebuilt with hashed CSS-module class names (`fNh4Da_close` today, something
+else next release), so class selectors would break on every upstream
+update. The rules are platform-scoped to darwin and win32 — the only
+surfaces that reserve the row — so Linux and Web keep upstream's own
+geometry untouched. They carry `!important` because the pinned runtime's
+stylesheet is injected after the chrome sheet and would win ties at equal
+specificity; `!important` already carries the dialog demotion rules in the
+same sheet.
+
+The backdrop keeps upstream's 40px gutter width instead of introducing a
+new Oh-DSH gutter size: the frame the user sees is the same 40px on all
+four sides upstream designed, just relocated into the region below the
+strip, with the strip standing in for the top gutter. The `max-height`
+ceiling (`100vh - titlebar - 80px`) tracks the smaller content region — the
+80px is the two vertical gutters plus nothing else — so tall previews
+cannot re-overflow behind the strip.
+
+`body::before` and the menubar remain the single owners of the reserved
+row: the overlay moves instead of the strip lowering its guard, because
+window dragging, the merged menu row, and the window actions all live in
+that band.
+
+The DSH `Modal` primitive is deliberately unaffected: its close button sits
+inside a `[role='presentation']` wrapper rather than directly under body,
+so the structure selector misses it, and its centered layout never enters
+the titlebar band.
+
+## Alternatives considered
+
+**Patch the pinned runtime package in `cordis.patch.yml`.** Rejected: a
+patch pins one upstream version's stylesheet and must be re-derived on every
+runtime bump, and the change would still be a CSS override — carrying it in
+the surface that owns the titlebar reservation keeps one owner for the row.
+
+**Key the rule on the runtime's class name (`fNh4Da_close`).** Rejected:
+CSS-module hashes change per build, so the fix would silently die on the
+next pinned update; structure is the only stable contract available.
+
+**Scope by `data-oh-dsh-desktop` without the platform qualifier.** Rejected:
+Linux keeps its native frame and Web loads no chrome stylesheet, so both
+would take an 8px+40px offset for no reason, drifting the button off the
+corner it is designed for.
+
+**Push the lightbox under the strip by lowering `body::before`'s z-index or
+making it non-opaque.** Rejected: the strip guards window dragging, the
+merged menu row, and the Windows window actions; letting portal overlays
+paint into that band reintroduces exactly the class of overlap the guard
+exists to prevent.
+
+**Fix it upstream in DSH** (a titlebar-strip compatibility mode like Better
+Sidebar's). Right long-term home, but it does not help this surface until a
+release pins the fixed runtime, and Oh-DSH still needs a desktop-side answer
+for any pinned overlay that parks fixed chrome at the viewport top.
+
+## Consequences
+
+The titlebar reservation gains a standing exception-shaped rule: overlays
+that portal a bare dialog to `body` are re-framed into the region below the
+reserved row — upstream's own 40px gutters on every side, a shrunken image
+ceiling, and the close button anchored to the gutter grid — on macOS and
+Windows. The rules are deliberately narrow — direct-child structure only —
+so future pinned overlays with different inner structure (a header wrapper
+around the close button, an image nested in a stage element) will need the
+pattern extended, and these selectors are the single place to do it. The
+`!important` ties the chrome sheet's authority to the reservation: upstream
+restyling the lightbox does not silently reclaim the band, though a future
+upstream lightbox redesign that changes its gutter width will need the
+literal here updated. The contract test below pins the rules themselves,
+while the visual check stays manual because the affected geometry belongs
+to the pinned runtime's release cadence.
+
+## Testing
+
+`tests/desktop-titlebar.test.ts` asserts the darwin/win32-scoped structure
+selectors: the backdrop's `top` at the reserved row with `padding: 40px`,
+the image ceiling `calc(100vh - titlebar - 80px)`, the close button's
+`calc(titlebar + 8px)` offset with `right: 8px`, and it rejects the
+unscoped desktop-wide variant. On a packaged Windows build, opening an
+image lightbox in a session shows the preview framed by upstream's 40px
+gutter on all four sides below the menu row, tall previews staying inside
+that frame, and the circular close button fully visible in the top-right
+gutter with the strip and window actions still clickable.

--- a/.agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.zh.md
@@ -1,0 +1,113 @@
+# Agent Note: Portal 对话框的关闭按钮让出预留标题栏行
+
+Status: implemented
+
+[English](2026-08-31-portal-dialog-close-clears-titlebar.md) | 中文
+
+## Problem
+
+在会话中点击"查看原图"时，钉住的 DSH 运行时会把图片灯箱（image lightbox）
+portal 到 `document.body`。这个灯箱是一个裸的 `role='dialog'`，其关闭控件是
+一颗 36px 的圆形 `position: fixed` 按钮，固定在 `top: 20px; right: 20px` ——
+这是为"顶部不保留任何空间的原生浏览器视口"写的几何。而 macOS 与 Windows 的
+Desktop 表面预留了 40px 的页内标题栏行，并用 `z-index: 2147483645` 的不透明
+`body::before` 条绘制它，远高于灯箱自身的 `z-index: 1000`。标题栏条盖住了
+按钮的上半段：灯箱看起来像坏了 —— 菜单行下方只露出半个白色圆和 ✕ 的下尖端，
+可点击区域也缩小到可见的那一小条。
+
+灯箱的背板本身在同一条带里也是失衡的：它用上下对称的 40px 内边距让图片相对
+整个视口居中，于是在预留标题栏行的平台上，图片上缘距屏幕顶部是 40px（预留）
+加 40px（内边距），下缘却只有 40px 内边距 —— 预览图上方贴住标题栏条、下方悬空。
+图片的高度上限也是同一个"只看视口"的假设：`max-height: calc(100vh - 80px)`
+算的正是被预留行作废的那份内边距。Linux 保留原生窗口框架、不预留任何空间，
+Web 从不加载 chrome 样式表，这两个表面都不可能产生上述任一缺陷。
+
+## Decision
+
+Desktop chrome 样式表在预留行的平台上恢复灯箱留白的对称性：背板从标题栏条
+下缘开始，四边沿用上游自己的 40px 留白宽度 —— 由标题栏条顶替视口原本提供
+的那条顶部留白；图片高度上限随预留行和留白收缩；关闭按钮贴着留白网格落在
+角落：
+
+```css
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'],
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] {
+  top: var(--oh-dsh-titlebar-height, 40px) !important;
+  padding: 40px !important;
+}
+
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > img,
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > img {
+  max-height: calc(100vh - var(--oh-dsh-titlebar-height, 40px) - 80px) !important;
+}
+
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > button,
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > button {
+  top: calc(var(--oh-dsh-titlebar-height, 40px) + 8px) !important;
+  right: 8px !important;
+}
+```
+
+这些选择器约定的是文档结构，而不是类名：`role='dialog'` 且是 `body` 的直接
+子元素（portal 覆盖层），关闭按钮和图片都是它的直接子元素。钉住的运行时
+每次构建都会重新生成 CSS-module 哈希类名（今天是 `fNh4Da_close`，下个版本
+就不是了），按类名选择会在每次上游更新时静默失效，结构是唯一稳定的契约。
+规则限定在 darwin 和 win32 —— 仅这两个表面预留标题栏行 —— Linux 与 Web
+保留上游自身的几何不受影响。规则带 `!important`，因为钉住运行时的样式表在
+chrome 样式表之后注入、同等优先级时会胜出；同一张样式表里的对话框降级规则
+本来就在用 `!important`。
+
+背板沿用上游 40px 的留白宽度，而不是另设一个 Oh-DSH 的留白尺寸：用户看到的
+边框仍是上游设计的四边 40px，只是整体移入标题栏条之下的区域，由标题栏条
+顶替原来的顶部留白。`max-height` 上限（`100vh - 标题栏 - 80px`）跟随变小
+的内容区域 —— 80px 正是上下两条留白 —— 高图不会再从标题栏条后面溢出。
+
+`body::before` 和菜单栏仍是预留行的唯一所有者：我们挪走覆盖层，而不是放松
+标题栏条本身的防护，因为窗口拖拽、合并菜单行和窗口控制按钮都住在那条带里。
+
+DSH 的 `Modal` 原语刻意不受影响：它的关闭按钮位于 `[role='presentation']`
+包裹层内、不是 body 的直接子层，结构选择器不会命中它；它的居中布局也从不
+进入标题栏带。
+
+## Alternatives considered
+
+**在 `cordis.patch.yml` 里给钉住的运行时包打补丁。** 否决：补丁把某个上游
+版本的样式表钉死，运行时每次升级都要重新推导；而且它本质仍是一条 CSS 覆盖，
+放在拥有标题栏预留权的表面里才保持该行的单一所有者。
+
+**按运行时的类名（`fNh4Da_close`）选择。** 否决：CSS-module 哈希随每次构建
+变化，修复会在下一次钉住更新时静默死亡；结构是唯一可用的稳定契约。
+
+**只用 `data-oh-dsh-desktop` 限定、不带平台限定。** 否决：Linux 保留原生
+框架、Web 不加载 chrome 样式表，两者都会无缘无故吃到 8px+40px 的偏移，
+让按钮偏离它设计所在的角落。
+
+**降低 `body::before` 的 z-index 或改成半透明，让灯箱压到标题栏条之下。**
+否决：标题栏条守护着窗口拖拽、合并菜单行和 Windows 窗口控制按钮；允许
+portal 覆盖层画进那条带，等于重新引入这条防护本来就要阻止的那类重叠。
+
+**在上游 DSH 修复**（像 Better Sidebar 那样的标题栏条兼容模式）。长期来看
+是正确的归宿，但在某个发布版钉入修复的运行时之前对本表面没有帮助；而且对
+任何把固定控件停在视口顶部的钉住覆盖层，Oh-DSH 仍然需要一个桌面侧的答案。
+
+## Consequences
+
+标题栏预留多了一条常备的"例外形"规则：把裸对话框 portal 到 `body` 的覆盖层，
+在 macOS 与 Windows 上会被重排进预留行之下的区域 —— 沿用上游的四边 40px
+留白、图片上限随之收缩、关闭按钮贴着留白网格锚定。规则刻意收窄 —— 只匹配
+直接子层结构 —— 因此未来钉住的覆盖层若换了内部结构（比如关闭按钮外面套一层
+header 包裹、或图片嵌在 stage 元素里），需要扩展这一模式，而这些选择器就是
+唯一的扩展点。规则的 `!important` 把 chrome 样式表的权威与预留绑定：上游
+重排灯箱不会静默夺回那条带，但上游若改动自己的留白宽度，这里的字面量需要
+同步更新。下面的契约测试钉住的是规则本身，视觉检查仍需手动进行，因为受影响
+的几何属于钉住运行时的发布节奏。
+
+## Testing
+
+`tests/desktop-titlebar.test.ts` 断言限定 darwin/win32 的结构选择器：背板
+`top` 落在预留行、`padding: 40px`，图片上限
+`calc(100vh - 标题栏 - 80px)`，关闭按钮 `calc(标题栏 + 8px)` 与
+`right: 8px`，并拒绝不加平台限定的 desktop 全局变体。在打包的 Windows
+构建上，会话内打开图片灯箱时，预览图在菜单行之下被四边 40px 的留白
+框住，高图不会越出这个边框，圆形关闭按钮完整显示在右上留白里，标题栏条
+与窗口控制按钮仍然可点。

--- a/src/client.ts
+++ b/src/client.ts
@@ -341,6 +341,41 @@ html[data-oh-dsh-desktop='true']:has(
   position: relative;
 }
 
+/* Portal overlays that hand the document a bare top-level dialog own their
+   own fixed chrome, and pinned upstream UI parks its lightbox close button
+   20px below the viewport top — inside the in-page titlebar row this surface
+   reserves on macOS and Windows, where the opaque strip paints over anything
+   below its z-index and half the control disappears. Structure, not classes:
+   the pinned runtime is hashed per build, so the contract is "a body-level
+   modal dialog's direct close button". macOS shares the reserved row; Linux
+   keeps its native frame and Web never loads the chrome stylesheet.
+
+   The lightbox backdrop keeps upstream's 40px gutter width but restores
+   its symmetry below the reserved row: uniform 40px on all four sides,
+   laid out inside the region under the strip (the strip replaces the top
+   gutter the viewport used to provide), and the image's own 100vh-based
+   ceiling shrinks by the titlebar and the gutters so tall previews never
+   re-overflow behind the strip. The close button rides the same gutter
+   grid at its corner. Upstream styles load after this sheet and win ties
+   at equal specificity, so the rules carry !important — the same
+   authority the sheet's dialog demotion rules already rely on. */
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'],
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] {
+  top: var(--oh-dsh-titlebar-height, 40px) !important;
+  padding: 40px !important;
+}
+
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > img,
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > img {
+  max-height: calc(100vh - var(--oh-dsh-titlebar-height, 40px) - 80px) !important;
+}
+
+html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > button,
+html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > button {
+  top: calc(var(--oh-dsh-titlebar-height, 40px) + 8px) !important;
+  right: 8px !important;
+}
+
 `
 
 /** Wait for the DSH services used by native menu commands. */

--- a/tests/desktop-titlebar.test.ts
+++ b/tests/desktop-titlebar.test.ts
@@ -111,6 +111,27 @@ test('desktop chrome keeps platform title bars and panel controls distinct', () 
   assert.match(client, /data-oh-dsh-desktop-platform='darwin'\] \.oh-dsh-panel-toolbar \{[\s\S]*?right: 8px/)
   assert.match(client, /data-oh-dsh-desktop-platform='win32'\] \.oh-dsh-panel-toolbar \{[\s\S]*?right: 154px/)
   assert.match(client, /\.oh-dsh-window-actions \{[\s\S]*?height: var\(--oh-dsh-titlebar-height\)/)
+  // Portal overlays with a bare top-level dialog (the pinned runtime's image
+  // lightbox) park their fixed close button 20px below the viewport top —
+  // under the opaque titlebar strip. On the platforms that reserve the row,
+  // the backdrop keeps upstream's 40px gutter width but restores its
+  // symmetry below the reserved row: uniform 40px on all four sides, the
+  // image's 100vh-based ceiling shrinks by the reserved row plus the two
+  // vertical gutters, and the close button rides the gutter grid at the
+  // top-right corner.
+  assert.match(
+    client,
+    /data-oh-dsh-desktop-platform='darwin'\] body > \[role='dialog'\]\[aria-modal='true'\],[\s\S]*?data-oh-dsh-desktop-platform='win32'\] body > \[role='dialog'\]\[aria-modal='true'\] \{[\s\S]*?top: var\(--oh-dsh-titlebar-height, 40px\) !important;[\s\S]*?padding: 40px !important/,
+  )
+  assert.match(
+    client,
+    /data-oh-dsh-desktop-platform='darwin'\] body > \[role='dialog'\]\[aria-modal='true'\] > img,[\s\S]*?data-oh-dsh-desktop-platform='win32'\] body > \[role='dialog'\]\[aria-modal='true'\] > img \{[\s\S]*?max-height: calc\(100vh - var\(--oh-dsh-titlebar-height, 40px\) - 80px\) !important/,
+  )
+  assert.match(
+    client,
+    /data-oh-dsh-desktop-platform='darwin'\] body > \[role='dialog'\]\[aria-modal='true'\] > button,[\s\S]*?data-oh-dsh-desktop-platform='win32'\] body > \[role='dialog'\]\[aria-modal='true'\] > button \{[\s\S]*?top: calc\(var\(--oh-dsh-titlebar-height, 40px\) \+ 8px\) !important;[\s\S]*?right: 8px !important/,
+  )
+  assert.doesNotMatch(client, /data-oh-dsh-desktop='true'\] body > \[role='dialog'\]\[aria-modal='true'\] > button/)
   assert.match(client, /body\[data-ds-dark-theme\] \.oh-dsh-menubar-brand img[\s\S]*?filter: brightness\(0\) invert\(1\)/)
   assert.match(client, /body::before \{[\s\S]*?z-index: 2147483645[\s\S]*?pointer-events: none/)
   assert.match(client, /\.oh-dsh-menubar \{[\s\S]*?z-index: 2147483646/)


### PR DESCRIPTION
## Problem

Clicking "view original" on a session image portals the pinned DSH runtime's
image lightbox to `document.body`. The lightbox is a bare `role='dialog'`
laid out for a plain browser viewport with nothing reserved at the top: a
36px circular close button fixed at `top: 20px; right: 20px`, and a backdrop
centering the image with a symmetric 40px padding and an image ceiling keyed
to the whole viewport (`max-height: calc(100vh - 80px)`).

Windows Desktop reserves a 40px in-page titlebar row and paints it as an
opaque `body::before` strip at `z-index: 2147483645`, far above the
lightbox's `z-index: 1000`. Two defects result, both reproduced and
pixel-measured on a Windows build (150% display scale):

1. The strip covered the close button's upper half — half a white circle
   with the bottom tips of an ✕ below the menu row, and the click target
   shrank to the visible sliver.
2. The preview image sat flush against the strip above (40px reserved +
   40px padding) while keeping a full 40px of air at the bottom — top
   flush, bottom loose.

macOS reserves the same row through one shared darwin+win32 selector reading
the same `DESKTOP_TITLEBAR_HEIGHT = 40` (`titleBarStyle: 'hiddenInset'`
needs the row for its traffic lights and drag region), and the lightbox is
the same pinned bundle on every platform, so both defects are expected
there too. Linux keeps its native frame and Web never loads the chrome
stylesheet, so neither is touched.

## What changed

The Desktop chrome stylesheet re-frames the lightbox on the platforms that
reserve the row, through one structure-based contract — a `role='dialog'`
that is a direct child of `body` (a portal overlay), its close button and
image as direct children. The pinned runtime is rebuilt with hashed
CSS-module class names on every update, so document structure is the only
stable selector:

```css
html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'],
html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] {
  top: var(--oh-dsh-titlebar-height, 40px) !important;
  padding: 40px !important;
}

html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > img,
html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > img {
  max-height: calc(100vh - var(--oh-dsh-titlebar-height, 40px) - 80px) !important;
}

html[data-oh-dsh-desktop-platform='darwin'] body > [role='dialog'][aria-modal='true'] > button,
html[data-oh-dsh-desktop-platform='win32'] body > [role='dialog'][aria-modal='true'] > button {
  top: calc(var(--oh-dsh-titlebar-height, 40px) + 8px) !important;
  right: 8px !important;
}
```

- **Backdrop**: starts at the strip's edge and keeps upstream's own 40px
  gutter width on all four sides — no new Oh-DSH gutter size; the strip
  stands in for the top gutter the viewport used to provide.
- **Image ceiling**: shrinks to `100vh - titlebar - 80px` (80px = the two
  vertical gutters), so tall previews stay inside the frame instead of
  re-overflowing behind the strip.
- **Close button**: anchors to the gutter grid at `titlebar + 8px`,
  `right: 8px`, fully visible in the top-right corner.
- **`!important`** on every rule: the pinned runtime's stylesheet is
  injected after the chrome sheet and wins ties at equal specificity — the
  same authority the sheet's existing dialog demotion rules rely on.
- **Unaffected by design**: the DSH `Modal` primitive (its root is a
  `[role='presentation']` wrapper, not a bare body-level dialog; a sweep of
  the pinned runtime found no other portal with this shape), Linux and Web
  (no reserved row, rules never apply), and the strip's own guard (window
  dragging, merged menu row, and window actions keep their band).

A rejected earlier iteration is worth naming: padding the backdrop by
`titlebar + 40px` on top of upstream's own padding restored symmetry
arithmetically but left a visually unbalanced frame and the unadjusted
`100vh` image ceiling, so it was replaced by the re-frame above.

## Scope

- `src/client.ts` — three structure-scoped rules appended to
  `DESKTOP_CHROME_CSS`, the existing Desktop-only chrome stylesheet; no
  other surface, loader, or plugin logic is touched.
- `tests/desktop-titlebar.test.ts` — regression contract pinning the three
  rules, their darwin/win32 scoping, and rejecting the unscoped
  desktop-wide variant.
- `.agents/notes/implemented/bug-fix/2026-08-31-portal-dialog-close-clears-titlebar.md`
  (+ `.zh.md`, + `.i18n.yaml`) — the decision record: problem, decision,
  rejected alternatives (runtime patch, hashed class names, unscoped rule,
  weakening the strip guard, Windows-only scoping, upstream-only fix), and
  trade-offs, per the repository's Agent Note policy.

## Verification

- `pnpm run typecheck` and `pnpm run build` pass.
- `tests/desktop-titlebar.test.ts` passes (4/4) with the new assertions.
- `pnpm run verify:agent-notes` (classification, format, frozen archive) and
  `pnpm run verify-translation-pairing` pass.
- Full suite: 277/333 pass; the 9 failures reproduce identically on `main`
  with this change stashed (Windows `EPERM` on `symlink` in the staging
  tests) and are unrelated.
- Windows (verified): both defects reproduced from live session screenshots;
  the measured geometry (36px button at `top: 20px; right: 20px`, backdrop
  `padding: 40px`, 150% display scale) matches the pinned runtime's styles
  exactly. Post-fix: the circular button sits fully visible in the top-right
  gutter, and the image is framed by 40px on all four sides below the menu
  row.
- macOS (not verified first-hand — no macOS device available to the author):
  expected to hold because the reservation, the strip, and the lightbox
  bundle are shared across darwin and win32 with no platform-conditional
  geometry in between; the macOS CI build exercises the same geometry
  assertions. A macOS reviewer check — open an image lightbox, confirm the
  button and the image clear the traffic-light row — would close the gap.

Assisted-by: ZCode