### PR TITLE
docs: 修正推荐项目表中 DeepSeek Harness 的 404 链接

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -242,7 +242,7 @@ or only TUI with `pnpm run dist:tui`.
 
 | Recommended project | Description |
 | --- | --- |
-| [DeepSeek Harness](https://github.com/deepseek-harness/deepseek-harness) | DSH runtime, sessions, and plugin loader |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | DSH runtime, sessions, and plugin loader |
 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | **Direct upstream plugin for Oh-DSH TUI**, providing terminal rendering, interaction, and commands |
 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | Git review, files, and PTY host capabilities |
 | [dsh-vision](https://github.com/william-jin-cmu/dsh-vision) | Reference for the cross-surface `view_image` vision tool |

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Web 使用 `pnpm run dist:web`；只打包 TUI 使用 `pnpm run dist:tui`。
 
 | 推荐项目 | 说明 |
 | --- | --- |
-| [DeepSeek Harness](https://github.com/deepseek-harness/deepseek-harness) | DSH runtime、会话与插件加载器 |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | DSH runtime、会话与插件加载器 |
 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | **Oh-DSH TUI 的直接上游插件**，提供终端渲染、交互和命令体系 |
 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | Git Review、文件与 PTY Host 能力 |
 | [dsh-vision](https://github.com/william-jin-cmu/dsh-vision) | 跨 Desktop、Web 与 TUI 的 `view_image` 视觉工具参考实现 |


### PR DESCRIPTION
## 问题
README.md 与 README.en.md 末尾「推荐项目 / Recommended project」表格中，DeepSeek Harness 的链接指向 https://github.com/deepseek-harness/deepseek-harness ，该地址不存在（HTTP 404）。

## 修改
将两处链接更正为真实上游仓库 https://github.com/deepseek-ai/deepseek-harness （HTTP 200，仓库描述 “DeepSeek Harness: Everything is a Plugin”，与表格中「DSH runtime、会话与插件加载器」的说明一致）。

仅改动这两行 Markdown 表格链接，无其它逻辑变更。

## 验证
- `grep` 确认改动后 README 中不再包含旧的 404 地址
- `curl -L` 校验：旧地址返回 404，新地址返回 200
- `git diff --check` 通过

Fixes #192