### PR TITLE
release: prepare Oh-DSH 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH Desktop",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",

--- a/src/main.ts
+++ b/src/main.ts
@@ -493,6 +493,14 @@ async function getUpdateManager(): Promise<DesktopUpdateManager> {
   const packageType = app.isPackaged
     ? await detectPackageType(process.resourcesPath)
     : 'unsupported'
+  if (app.isPackaged) {
+    // electron-updater logs to the raw console by default, printing
+    // "Checking for update" plus full network-error stack traces into the
+    // launching terminal. The manager already routes every outcome —
+    // including the mirror fallback and network failures — through onLog
+    // and the update state, so the duplicate console channel is noise.
+    autoUpdater.logger = null
+  }
   const manager = new DesktopUpdateManager({
     currentVersion: app.getVersion(),
     appIsPackaged: app.isPackaged,


### PR DESCRIPTION
## Scope

Release preparation for **v0.1.12** — the first stable release on the DSH
0.1.2-alpha.3 runtime line (everything from #203), plus one launch fix:

- `package.json` → `0.1.12` (tag `v0.1.12` created only after this PR
  merges, per the release workflow).
- Silence `electron-updater`'s raw console logger on packaged launches:
  it printed "Checking for update" and full network-error stack traces
  (`net::ERR_EMPTY_RESPONSE` / `ERR_CONNECTION_RESET`) into the
  launching terminal. The update manager already routes every outcome —
  proxy fallback, release-mirror fallback, and network failures — through
  its own log and update state, so the console channel was pure noise.
  Verified by launching the repackaged app: stdout/stderr stay empty.

## Checks

- `node scripts/validate-release-tag.mjs --tag v0.1.12 --version 0.1.12` — validated
- `pnpm run typecheck` clean
- `node --test tests/*.test.ts` — 332 pass / 0 fail / 9 Windows-lane skips
- `pnpm run build` clean
- Agent Notes gates + bilingual pairing clean
- `git diff --check` clean
- Packaged relaunch (`install.sh --local --surface desktop`) verified silent

Assisted-by: ZCode (GLM-5.3)