### PR TITLE
marketplace: keep bundle dependencies alive across the sources rename

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.md
+2026-09-07-marketplace-bundle-hoisted-layout.md: 77a69d4dbc0d8245fd93fa6b90ba44a32b5faf8c
+2026-09-07-marketplace-bundle-hoisted-layout.zh.md: 61c06cecb5227a41fba60422f2a8e1396929961d

--- a/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.md
-2026-09-07-marketplace-bundle-hoisted-layout.md: 77a69d4dbc0d8245fd93fa6b90ba44a32b5faf8c
-2026-09-07-marketplace-bundle-hoisted-layout.zh.md: 61c06cecb5227a41fba60422f2a8e1396929961d
+2026-09-07-marketplace-bundle-hoisted-layout.md: 873d7195af72030bd82022fb049e2ad64343ae32
+2026-09-07-marketplace-bundle-hoisted-layout.zh.md: c12b40a06d078dcc074adc59f6a3b1222cd19e74

--- a/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.md
@@ -61,10 +61,11 @@ failure was ours — the rename is Oh-DSH's own transaction step.
 
 ## Consequences
 
-Scripted bundle installs are slightly larger on disk (real directories
-instead of store links) and lose pnpm's cross-project store hard-linking
-inside the checkout; the preview-scoped `.pnpm-store` keeps the download
-cache local to the transaction either way. Plugins whose build scripts
+Scripted bundle installs keep the same disk footprint as the default
+isolated layout: pnpm hard-links package files from the store under both
+linkers, so hoisted's top-level entries are hard links rather than copies.
+The preview-scoped `.pnpm-store` keeps the download cache local to the
+transaction either way. Plugins whose build scripts
 themselves run `pnpm install` without the flag (or `npm ci`) can still
 rebuild their `node_modules` into a layout that dangles after the rename;
 that is now a plugin bug rather than a marketplace default, and the

--- a/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.md
@@ -1,0 +1,82 @@
+# Agent Note: marketplace bundle builds pin pnpm's hoisted layout
+
+Status: implemented
+
+English | [中文](2026-09-07-marketplace-bundle-hoisted-layout.zh.md)
+
+## Problem
+
+Installing the marketplace plugin `dsh-web-tools` on Windows failed with
+`DSH runtime exited before readiness (code=1, signal=null)`. The preview
+runtime's log showed the real error: the plugin entry imported `linkedom`
+from its managed source directory and Node resolved
+`ERR_MODULE_NOT_FOUND`. The dependencies had been installed minutes
+earlier — by the marketplace bundle build — but did not survive the trip
+from the build directory into the applied profile.
+
+The marketplace transaction builds a scripted plugin checkout in a
+disposable `bundle-builds/` directory (`pnpm install` plus only the
+reviewed lifecycle scripts), then `renameSync`s the finished tree into
+the profile's `.oh-dsh/sources/`. On Windows, pnpm's default isolated
+layout links every installed package with an absolute junction into the
+checkout's own `node_modules/.pnpm` tree. A directory rename rewrites the
+path of the tree itself but not the junction targets inside it, so every
+link dangles after the move and the plugin boots with no dependencies.
+
+Worse, pinning `--config.node-linker=hoisted` on the install command
+alone was not enough: pnpm's hoisted install materializes real
+directories, but the subsequent `pnpm run prepack` re-reads
+`.modules.yaml`, sees no linker override, and rebuilds the top-level
+entries as absolute junctions again — reintroducing the failure right
+before the rename.
+
+## Decision
+
+Every pnpm invocation in `ProductionMarketplacePlatform.buildBundle` —
+the `install` and each reviewed lifecycle `run` — now passes
+`--config.node-linker=hoisted`. The hoisted layout writes plain
+directories inside the checkout, which travel with the tree across the
+rename on every platform. This is the same layout dsh profiles
+(`pnpm-workspace.yaml` `nodeLinker: hoisted`) and Windows package
+staging (`installWindowsPackageDependencies`) already use, so third-party
+bundles land in the dependency topology the rest of the runtime expects.
+
+## Alternatives considered
+
+**Copy instead of rename.** `cpSync` dereferences Windows junctions into
+real directories, and a copy kept resolution working in a probe. It was
+rejected because it doubles I/O for every install, and it silently
+depends on copy semantics that differ per platform (`dereference` is not
+the default everywhere) — the linker flag fixes the cause instead of
+papering over one symptom.
+
+**Rewrite junction targets after the move.** Rejected: patching
+`.modules.yaml` and every link means reimplementing pnpm's layout logic
+in the marketplace host, with per-platform symlink rules, for a problem
+the package manager already knows how to avoid.
+
+**Require plugin authors to ship a `pnpm-workspace.yaml`.** Rejected:
+the marketplace catalog cannot police third-party repo layout, and the
+failure was ours — the rename is Oh-DSH's own transaction step.
+
+## Consequences
+
+Scripted bundle installs are slightly larger on disk (real directories
+instead of store links) and lose pnpm's cross-project store hard-linking
+inside the checkout; the preview-scoped `.pnpm-store` keeps the download
+cache local to the transaction either way. Plugins whose build scripts
+themselves run `pnpm install` without the flag (or `npm ci`) can still
+rebuild their `node_modules` into a layout that dangles after the rename;
+that is now a plugin bug rather than a marketplace default, and the
+regression test catches the marketplace-side contract.
+`tests/plugin-marketplace.test.ts` pins the behavior end to end: build a
+fixture with a dependency, run a lifecycle script, rename the tree, and
+require that the dependency still resolves.
+
+## Testing
+
+`pnpm test` runs the new regression on all platforms; on Windows it
+exercises the actual junction semantics that used to break. Verified
+against the real plugin: previewing and applying `dsh-web-tools` from the
+Desktop marketplace now boots the preview runtime (`dsh web:` readiness
+line), and the applied profile's source tree resolves `linkedom`.

--- a/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.zh.md
@@ -52,9 +52,9 @@ symlink 规则,而包管理器本身就有现成的规避方式。
 
 ## 后果
 
-带脚本的 bundle 安装在磁盘上略大(真实目录而非 store 链接),
-也失去了 checkout 内部 pnpm 跨项目 store 硬链接的节省;不过事务局部的
-`.pnpm-store` 反正把下载缓存留在事务目录里。如果插件自己的构建脚本
+带脚本的 bundle 安装与默认 isolated 布局的磁盘占用相当:两种 linker 都
+以硬链接从 store 引用包文件,hoisted 的顶层条目是硬链接目录项而非拷贝。
+事务局部的 `.pnpm-store` 反正把下载缓存留在事务目录里。如果插件自己的构建脚本
 不带旗标地运行 `pnpm install`(或 `npm ci`),仍可能把 `node_modules`
 重建成 rename 后悬空的布局;这如今属于插件侧的问题而非市场默认行为,
 回归测试守住的是市场侧的契约。`tests/plugin-marketplace.test.ts`

--- a/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-marketplace-bundle-hoisted-layout.zh.md
@@ -1,0 +1,69 @@
+# Agent Note: 市场插件构建固定 pnpm hoisted 布局
+
+Status: implemented
+
+[English](2026-09-07-marketplace-bundle-hoisted-layout.md) | 中文
+
+## 问题
+
+在 Windows 上从市场安装插件 `dsh-web-tools` 时报
+`DSH runtime exited before readiness (code=1, signal=null)`。预览运行时日志里有真正的错误:
+插件入口从它的托管源码目录 import `linkedom` 时,Node 抛出
+`ERR_MODULE_NOT_FOUND`。依赖明明在几分钟前刚由市场 bundle 构建装好,
+却没能活过从构建目录到已应用 profile 的那次搬迁。
+
+市场事务的流程是:在一次性 `bundle-builds/` 目录里构建带脚本的插件
+checkout(先 `pnpm install`,再只跑已审查的生命周期脚本),然后用
+`renameSync` 把成品树挪进 profile 的 `.oh-dsh/sources/`。在 Windows 上,
+pnpm 默认的 isolated 布局用指向 checkout 自己 `node_modules/.pnpm` 的
+**绝对 junction** 链接每个安装包。目录改名会改写树自身的路径,
+却不会改写树内部的 junction 目标——搬完之后所有链接全部悬空,
+插件一启动就找不到依赖。
+
+更隐蔽的是,只在 install 命令上加 `--config.node-linker=hoisted`
+并不够:pnpm 的 hoisted install 确实落盘真实目录,但随后的
+`pnpm run prepack` 会重新读取 `.modules.yaml`,发现没有 linker 覆盖,
+又把顶层条目重建为绝对 junction——在 rename 前一刻把故障请回来。
+
+## 决策
+
+`ProductionMarketplacePlatform.buildBundle` 里的每一条 pnpm 命令——
+`install` 和每条已审查的生命周期 `run`——现在都带
+`--config.node-linker=hoisted`。hoisted 布局在 checkout 内写的是普通
+目录,在所有平台上都能随树一起通过 rename。这与 dsh profile
+(`pnpm-workspace.yaml` 的 `nodeLinker: hoisted`)和 Windows 包暂存
+(`installWindowsPackageDependencies`)已经采用的布局一致,
+第三方 bundle 落地的依赖拓扑与其余运行时预期相同。
+
+## 已否决的替代方案
+
+**用 copy 代替 rename。** `cpSync` 会把 Windows junction 解引用成真实
+目录,探针里 copy 之后解析正常。否决:每次安装的 I/O 翻倍,而且静默
+依赖各平台不一致的拷贝语义(`dereference` 并非处处默认开启)——
+linker 旗标修的是因,拷贝只是遮症状。
+
+**搬家之后重写 junction 目标。** 否决:修补 `.modules.yaml` 和每条
+链接等于在市场宿主里重新实现一遍 pnpm 的布局逻辑,还要处理各平台的
+symlink 规则,而包管理器本身就有现成的规避方式。
+
+**要求插件作者自带 `pnpm-workspace.yaml`。** 否决:市场目录管不了
+第三方仓库的布局,而且这是我们的过错——rename 是 Oh-DSH 自己的
+事务步骤。
+
+## 后果
+
+带脚本的 bundle 安装在磁盘上略大(真实目录而非 store 链接),
+也失去了 checkout 内部 pnpm 跨项目 store 硬链接的节省;不过事务局部的
+`.pnpm-store` 反正把下载缓存留在事务目录里。如果插件自己的构建脚本
+不带旗标地运行 `pnpm install`(或 `npm ci`),仍可能把 `node_modules`
+重建成 rename 后悬空的布局;这如今属于插件侧的问题而非市场默认行为,
+回归测试守住的是市场侧的契约。`tests/plugin-marketplace.test.ts`
+端到端钉死了该行为:构建一个带依赖的 fixture、跑一次生命周期脚本、
+rename 整棵树、然后要求依赖仍然可解析。
+
+## 测试
+
+`pnpm test` 在所有平台运行新回归;在 Windows 上它踩的正是过去出错的
+junction 语义。已用真实插件验证:从 Desktop 市场预览并应用
+`dsh-web-tools`,预览运行时正常启动(出现 `dsh web:` 就绪行),
+应用后的 profile 源码树能解析 `linkedom`。

--- a/.agents/notes/implemented/bug-fix/2026-09-07-npm-pnpm-forwarding-shims.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-npm-pnpm-forwarding-shims.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-09-07-npm-pnpm-forwarding-shims.md
+2026-09-07-npm-pnpm-forwarding-shims.md: 35a32757307544ccfadd8cfb63f6bc5d3f201a7d
+2026-09-07-npm-pnpm-forwarding-shims.zh.md: 60c7b3d2c5f3f0f27c826906c0eb19fa567c4a4e

--- a/.agents/notes/implemented/bug-fix/2026-09-07-npm-pnpm-forwarding-shims.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-npm-pnpm-forwarding-shims.md
@@ -1,0 +1,94 @@
+# Agent Note: npm/npx launchers forward onto the bundled pnpm
+
+Status: implemented
+
+English | [中文](2026-09-07-npm-pnpm-forwarding-shims.zh.md)
+
+## Problem
+
+Installing a third-party marketplace plugin whose lifecycle script calls
+npm (`prepack: "npm run build"`) failed with
+`Cannot find module '...\node-runtime\node_modules\npm\bin\npm-prefix.js'`
+and `...\npm-cli.js`. The staged node runtime deliberately ships pnpm only:
+`pruneNodeRuntime` removes `node_modules/npm`, and `ensureNodeRuntime`
+stages the workspace pnpm beside it. But on Windows the official Node zip
+places the `npm`/`npx`/`corepack` launchers at the distribution **root**
+(next to `node.exe`), not in `bin/` like POSIX — the prune pass only cleaned
+`bin/`, so the stock `npm.cmd` shims survived while the npm package they
+point at was deleted.
+
+The host process makes this the first `npm` on PATH: `runtimeSearchPath`
+puts the node-runtime directory first for marketplace bundle builds, so a
+plugin's `npm run build` resolves the dangling shim instead of failing
+cleanly or finding a system npm. End-user machines without a system Node
+have no fallback at all.
+
+## Decision
+
+The bundled runtime gains npm compatibility launchers that forward onto the
+staged pnpm, so the default answer to "can everything just use pnpm?" is
+yes — plugin authors do not need to change their npm-based scripts.
+
+- `scripts/stage-runtime-lib.mjs` gains `stageNpmForwardingShims()` and a
+  `stage-npm-shims` CLI subcommand (consumed by `nix/oh-dsh.nix`). It writes
+  a self-contained `npm-forward.mjs` beside the staged pnpm and installs
+  `npm`/`npx` launchers: `.cmd` + `.ps1` at the runtime root on Windows,
+  shell launchers in `bin/` on POSIX. The forwarder embeds the library's
+  `translateNpmInvocation` source verbatim via `Function.toString()`, so the
+  tested translation is the shipped translation — the function must stay
+  free of module-scope references.
+- `translateNpmInvocation` maps only invocations with a faithful pnpm
+  spelling: `run`/`install`/`test`/`exec`/`publish`/etc. pass through,
+  `ci` becomes `install --frozen-lockfile`, `i`/`t`/`uninstall`/`rm`/
+  `run-script` expand to their long forms, `npx ...` becomes
+  `pnpm exec ...` (dropping npm-only `-y`), and `--prefix` becomes
+  `--dir`. Anything else exits 1 with guidance to rewrite the script to
+  call pnpm directly.
+- `pruneNodeRuntime` in `scripts/stage-dsh.mjs` now also deletes the
+  Windows root-level `npm`/`npx`/`corepack` launchers (`''`/`.cmd`/`.ps1`
+  variants plus `install_tools.bat`) and the `corepack` module directories
+  on all platforms, then calls `stageNpmForwardingShims()` so the forwarding
+  launchers replace the stock ones after pruning.
+
+## Alternatives considered
+
+**Delete npm cleanly and require plugin authors to write pnpm.** Rejected:
+the ecosystem overwhelmingly scripts lifecycle builds against npm; without
+a forwarder every `prepack: "npm run build"` plugin fails on machines
+without a system Node, and the marketplace catalog cannot police
+third-party scripts.
+
+**Stage a real npm distribution beside pnpm.** Rejected: doubles the
+packaged runtime, needs its own update/security cadence, and reintroduces
+a second package manager into a runtime whose whole design pins one.
+
+**Shim inside the marketplace host (`platform.ts`) by rewriting PATH.**
+Rejected: the failure is not marketplace-specific — any spawned lifecycle
+script resolves `npm` through the node-runtime PATH entry — and fixing it
+at staging time covers every consumer (Desktop, Web, TUI, Nix) once.
+
+## Consequences
+
+`npm`/`npx` on a packaged Oh-DSH runtime now mean "pnpm with npm-style
+invocation translation". The passthrough table is deliberately small:
+npm-specific subcommands (`config`, `dist-tag`, ...) fail with an actionable
+message rather than silently diverging, so plugin authors hitting them get
+told to switch to pnpm instead of debugging behavioral drift. Unsupported
+npm semantics of translated subcommands (flag differences beyond
+`--prefix`) pass through verbatim and may surface as pnpm errors. The
+forwarder's embedded translation function is a structural contract: any
+future edit must keep it self-contained, which
+`tests/npm-forward.test.ts` guards alongside the translation table, the
+launcher contents on both layouts, and the replacement of a dangling stock
+`npm.cmd`.
+
+## Testing
+
+`tests/npm-forward.test.ts` covers the translation table (passthrough,
+`ci`, aliases, `npx`, `--prefix` before and after the subcommand, unknown
+subcommand errors), the staged launcher files and contents for the Windows
+and POSIX layouts, and that the embedded forwarder matches the exported
+function with no module-scope references. End-to-end, a fixture package
+with `prepack: "npm run build"` builds successfully through the staged
+runtime with the node-runtime directory first on PATH — the exact
+resolution order of a marketplace bundle build.

--- a/.agents/notes/implemented/bug-fix/2026-09-07-npm-pnpm-forwarding-shims.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-07-npm-pnpm-forwarding-shims.zh.md
@@ -1,0 +1,71 @@
+# Agent Note: npm/npx 启动器转发到内置 pnpm
+
+Status: implemented
+
+[English](2026-09-07-npm-pnpm-forwarding-shims.md) | 中文
+
+## 问题
+
+安装生命周期脚本调用 npm 的第三方市场插件（`prepack: "npm run build"`）时失败，报
+`Cannot find module '...\node-runtime\node_modules\npm\bin\npm-prefix.js'` 和
+`...\npm-cli.js`。暂存的 node 运行时有意只带 pnpm：`pruneNodeRuntime` 删除
+`node_modules/npm`，`ensureNodeRuntime` 把工作区 pnpm 暂存到旁边。但 Windows 的
+Node 官方 zip 把 `npm`/`npx`/`corepack` 启动器放在发行包**根目录**（`node.exe`
+旁边），不像 POSIX 在 `bin/` 里——而 prune 只清理了 `bin/`，于是原生的
+`npm.cmd` shim 活了下来，指向已被删除的 npm 包。
+
+宿主进程让这个 shim 成为 PATH 上的第一个 `npm`：`runtimeSearchPath` 在市场构建
+时把 node-runtime 目录排在最前，所以插件的 `npm run build` 解析到悬空 shim，
+既不能干净失败、也找不到系统 npm。没有装 Node 的终端用户机器则完全没有回退。
+
+## 决策
+
+内置运行时增加转发到暂存 pnpm 的 npm 兼容启动器，"默认都用 pnpm" 成立——插件
+作者无需修改自己的 npm 脚本。
+
+- `scripts/stage-runtime-lib.mjs` 新增 `stageNpmForwardingShims()` 与
+  `stage-npm-shims` CLI 子命令（`nix/oh-dsh.nix` 消费）。它在暂存 pnpm 旁边写入
+  自包含的 `npm-forward.mjs`，并安装 `npm`/`npx` 启动器：Windows 在运行时根目录
+  写 `.cmd` + `.ps1`，POSIX 在 `bin/` 写 shell 启动器。转发器通过
+  `Function.toString()` 逐字嵌入库里的 `translateNpmInvocation` 源码，被测的
+  转换就是发布的转换——该函数必须保持不引用模块作用域。
+- `translateNpmInvocation` 只映射有忠实 pnpm 写法的调用：
+  `run`/`install`/`test`/`exec`/`publish` 等原样透传，`ci` 变为
+  `install --frozen-lockfile`，`i`/`t`/`uninstall`/`rm`/`run-script` 展开为
+  长形式，`npx ...` 变为 `pnpm exec ...`（丢弃 npm 专属的 `-y`），`--prefix`
+  变为 `--dir`。其余调用以 1 退出并提示改为直接调用 pnpm。
+- `scripts/stage-dsh.mjs` 的 `pruneNodeRuntime` 现在也删除 Windows 根目录的
+  `npm`/`npx`/`corepack` 启动器（`''`/`.cmd`/`.ps1` 变体加
+  `install_tools.bat`）以及各平台的 `corepack` 模块目录，随后调用
+  `stageNpmForwardingShims()`，让转发启动器在 prune 之后替换原生启动器。
+
+## 备选方案
+
+**干净删掉 npm，要求插件作者写 pnpm。** 否决：生态里生命周期构建脚本几乎都按
+npm 写；没有转发器，每个 `prepack: "npm run build"` 的插件在没有系统 Node 的
+机器上都会失败，市场目录也无法约束第三方脚本。
+
+**在 pnpm 旁边暂存真正的 npm 发行版。** 否决：打包体积翻倍，需要独立的更新与
+安全节奏，还向一个设计上只钉一个包管理器的运行时重新引入第二个包管理器。
+
+**在市场宿主（`platform.ts`）内通过改写 PATH 做 shim。** 否决：该失败并非市场
+专属——任何被 spawn 的生命周期脚本都通过 node-runtime 的 PATH 条目解析 `npm`；
+在暂存阶段修复一次即可覆盖所有消费方（Desktop、Web、TUI、Nix）。
+
+## 后果
+
+打包后的 Oh-DSH 运行时上，`npm`/`npx` 现在的含义是"带 npm 调用翻译的 pnpm"。
+透传表刻意保持小：npm 专属子命令（`config`、`dist-tag`……）会带着可操作的提示
+失败，而不是悄悄偏离语义，撞上它们的插件作者会被明确告知改用 pnpm，而不是去
+调试行为漂移。被翻译子命令不支持的 npm 语义（`--prefix` 之外的 flag 差异）原样
+透传，可能以 pnpm 报错的形式暴露。转发器内嵌的转换函数是一个结构性契约：后续
+任何修改都必须保持它自包含，`tests/npm-forward.test.ts` 与转换表、两种布局的
+启动器内容、悬空 `npm.cmd` 的替换一起守护这一点。
+
+## 测试
+
+`tests/npm-forward.test.ts` 覆盖转换表（透传、`ci`、别名、`npx`、子命令前后
+位置的 `--prefix`、未知子命令报错）、Windows 与 POSIX 两种布局下暂存的启动器
+文件与内容，以及内嵌转发器与导出函数一致且无模块作用域引用。端到端验证：一个
+`prepack: "npm run build"` 的夹具包，在 node-runtime 目录排在 PATH 最前（即市
+场构建的解析顺序）时，通过暂存运行时成功完成构建。

--- a/nix/oh-dsh.nix
+++ b/nix/oh-dsh.nix
@@ -365,11 +365,16 @@ pkgs.stdenv.mkDerivation {
     # Stage pnpm beside the node runtime through the shared assembler:
     # bundledRuntimePaths resolves pnpmEntry at
     # node-runtime/lib/node_modules/pnpm/bin/pnpm.mjs for isolated
-    # Marketplace installs.
+    # Marketplace installs. The npm/npx forwarding launchers follow so
+    # third-party lifecycle scripts that assume npm resolve onto pnpm.
     ${pkgs.nodejs_24}/bin/node $src/scripts/stage-runtime-lib.mjs stage-pnpm \
       --source ${ohDshBundle}/lib/oh-dsh/pnpm --target $out/node-runtime
     test -f "$out/node-runtime/lib/node_modules/pnpm/bin/pnpm.mjs"
     test -f "$out/node-runtime/bin/pnpm"
+    ${pkgs.nodejs_24}/bin/node $src/scripts/stage-runtime-lib.mjs stage-npm-shims \
+      --target $out/node-runtime
+    test -f "$out/node-runtime/lib/node_modules/npm-forward.mjs"
+    test -x "$out/node-runtime/bin/npm"
 
     # Guardrail: the assembled runtime must carry exactly the official
     # surface package set; a drift in SURFACE_PACKAGE_NAMES or a missing

--- a/plugins/plugin-marketplace/src/host/platform.ts
+++ b/plugins/plugin-marketplace/src/host/platform.ts
@@ -505,10 +505,23 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
       TMPDIR: temporary,
     }, this.#ghPath)
     const requested = new Set(input.scripts)
+    // Every pnpm invocation in this flow must pin node-linker=hoisted. The
+    // built checkout is renamed from the disposable bundle-builds directory
+    // into the applied profile's managed sources and must keep resolving its
+    // dependencies there. pnpm's default isolated layout, and any command that
+    // re-reads .modules.yaml without an explicit linker, links packages with
+    // absolute junctions/symlinks into the checkout's .pnpm tree; on Windows
+    // those links dangle once the tree is renamed, and the plugin then fails
+    // to boot with ERR_MODULE_NOT_FOUND for its own dependencies (observed
+    // with linkedom while previewing dsh-web-tools). The hoisted layout writes
+    // real directories that travel with the checkout — the same layout dsh
+    // profiles and Windows package staging already use.
+    const linker = ['--config.node-linker=hoisted']
     const commands = [
       {
         args: [
           this.#options.pnpmEntry,
+          ...linker,
           'install',
           '--ignore-scripts',
           existsSync(join(input.checkout, 'pnpm-lock.yaml'))
@@ -524,6 +537,7 @@ export class ProductionMarketplacePlatform implements MarketplacePlatform {
         .map(script => ({
           args: [
             this.#options.pnpmEntry,
+            ...linker,
             '--config.enable-pre-post-scripts=false',
             'run',
             script,

--- a/scripts/smoke-web.mjs
+++ b/scripts/smoke-web.mjs
@@ -436,7 +436,10 @@ try {
       socket.send(JSON.stringify({ type: 'resize', cols: 80, rows: 24 }))
       // Split the marker so the echoed command line never contains it; only
       // real execution produces `OH_DSH_WEB_TERMINAL_SMOKE`.
-      socket.send("printf '%s%s\\n' OH_DSH_WEB_TERMINAL_ SMOKE; exit\r")
+      const terminalCommand = process.platform === 'win32'
+        ? "Write-Output ('OH_DSH_WEB_TERMINAL_' + 'SMOKE'); exit"
+        : "printf '%s%s\\n' OH_DSH_WEB_TERMINAL_ SMOKE; exit"
+      socket.send(`${terminalCommand}\r`)
     })
     socket.addEventListener('message', (event) => {
       output += String(event.data)

--- a/scripts/stage-dsh.mjs
+++ b/scripts/stage-dsh.mjs
@@ -179,11 +179,25 @@ function pruneNodeRuntime() {
     join(nodeRuntime, 'share'),
     join(nodeRuntime, 'lib', 'node_modules', 'npm'),
     join(nodeRuntime, 'node_modules', 'npm'),
+    join(nodeRuntime, 'lib', 'node_modules', 'corepack'),
+    join(nodeRuntime, 'node_modules', 'corepack'),
   ]
   for (const path of removable) rmSync(path, { recursive: true, force: true })
   for (const name of ['corepack', 'npm', 'npx']) {
     rmSync(join(nodeRuntime, 'bin', name), { recursive: true, force: true })
   }
+  if (isWindowsNode) {
+    // Windows distributions place the npm/npx/corepack launchers at the
+    // runtime root beside node.exe rather than in bin/; prune them too or
+    // they dangle onto the removed node_modules/npm package.
+    for (const name of ['npm', 'npx', 'corepack']) {
+      for (const extension of ['', '.cmd', '.ps1']) {
+        rmSync(join(nodeRuntime, name + extension), { force: true })
+      }
+    }
+    rmSync(join(nodeRuntime, 'install_tools.bat'), { force: true })
+  }
+  staging.stageNpmForwardingShims()
   console.log('Pruned Node runtime development files and npm')
 }
 

--- a/scripts/stage-runtime-lib.d.mts
+++ b/scripts/stage-runtime-lib.d.mts
@@ -39,6 +39,8 @@ export interface StageRuntimeContext {
 export interface StageRuntime {
   installDesktopPackages(surface?: string): void
   stagePnpmIntoNodeRuntime(options: { pnpmSource: string }): void
+  stageNpmForwardingShims(): void
+  translateNpmInvocation(args: readonly string[], mode?: 'npm' | 'npx'): string[]
   restoreExecutableHelpers(): void
   installCompiledPackageDependencies(sourceManifestPath: string, packageDir: string): void
   installCompiledPackageHostDependencies(sourceManifestPath: string, packageDir: string): void

--- a/scripts/stage-runtime-lib.mjs
+++ b/scripts/stage-runtime-lib.mjs
@@ -1241,6 +1241,102 @@ function ensureLinuxLandlockLauncher() {
 }
 
 
+// npm invocations that map onto the same pnpm subcommand verbatim. Kept
+// conservative on purpose: anything outside this table fails with guidance
+// instead of silently diverging from npm semantics. The subcommand table
+// lives inside translateNpmInvocation because the staged forwarder embeds
+// the function source verbatim and it must stay self-contained.
+/**
+ * Translate an npm/nx invocation onto the bundled pnpm CLI. `args` excludes
+ * the npm/npx token itself; `mode` is 'npm' or 'npx'. Throws on invocations
+ * with no faithful pnpm translation so callers fail with guidance instead of
+ * silently diverging from npm behavior. Must stay self-contained: the staged
+ * npm-forward.mjs embeds this function's source verbatim.
+ */
+function translateNpmInvocation(args, mode = 'npm') {
+  const passthrough = new Set([
+    'run', 'install', 'add', 'test', 'start', 'stop', 'restart', 'exec',
+    'pack', 'publish', 'rebuild', 'link', 'unlink', 'update', 'audit',
+    'ls', 'list', 'outdated', 'init', 'version', 'help',
+    '--version', '-v', '--help',
+  ])
+  if (mode === 'npx') {
+    // -y/--yes is npm-only; pnpm exec installs nothing to confirm.
+    return ['exec', ...args.filter(argument => argument !== '-y' && argument !== '--yes')]
+  }
+  if (args.length === 0) {
+    throw new Error('npm invoked without a subcommand; the bundled Oh-DSH runtime ships pnpm only')
+  }
+  // npm accepts global flags before the subcommand; only --prefix has a
+  // pnpm spelling (--dir), so hoist it out before dispatching.
+  const hoisted = []
+  const positioned = []
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--prefix' && index + 1 < args.length) {
+      hoisted.push('--dir', args[index + 1])
+      index += 1
+    } else if (argument.startsWith('--prefix=')) {
+      hoisted.push('--dir=' + argument.slice('--prefix='.length))
+    } else {
+      positioned.push(argument)
+    }
+  }
+  if (positioned.length === 0) {
+    throw new Error('npm invoked without a subcommand; the bundled Oh-DSH runtime ships pnpm only')
+  }
+  const [subcommand, ...rest] = positioned
+  let forwarded
+  if (subcommand === 'ci') {
+    forwarded = ['install', '--frozen-lockfile', ...rest]
+  } else if (subcommand === 'i') {
+    forwarded = ['install', ...rest]
+  } else if (subcommand === 't') {
+    forwarded = ['test', ...rest]
+  } else if (subcommand === 'uninstall' || subcommand === 'rm' || subcommand === 'r') {
+    forwarded = ['remove', ...rest]
+  } else if (subcommand === 'run-script') {
+    forwarded = ['run', ...rest]
+  } else if (passthrough.has(subcommand)) {
+    forwarded = [subcommand, ...rest]
+  } else {
+    throw new Error(
+      `npm ${subcommand} has no bundled translation; the Oh-DSH runtime ships pnpm only — rewrite the script to call pnpm directly`,
+    )
+  }
+  return [...hoisted, ...forwarded]
+}
+
+function npmForwarderSource() {
+  return [
+    '#!/usr/bin/env node',
+    '// Oh-DSH npm compatibility forwarder: lifecycle scripts in third-party',
+    '// marketplace plugins invoke npm/npx, but the bundled runtime ships pnpm',
+    '// only. This shim translates the common invocations onto the sibling pnpm',
+    '// package and fails with guidance for npm-specific behavior.',
+    "import { spawn } from 'node:child_process'",
+    "import { dirname, join } from 'node:path'",
+    "import { fileURLToPath } from 'node:url'",
+    '',
+    `const translateNpmInvocation = ${translateNpmInvocation.toString()}`,
+    '',
+    "const [invocation, ...args] = process.argv.slice(2)",
+    "const pnpmEntry = join(dirname(fileURLToPath(import.meta.url)), 'pnpm', 'bin', 'pnpm.mjs')",
+    'let translated',
+    'try {',
+    '  translated = translateNpmInvocation(args, invocation)',
+    '} catch (error) {',
+    "  console.error(`npm: ${error instanceof Error ? error.message : String(error)}`)",
+    '  process.exit(1)',
+    '}',
+    'const child = spawn(process.execPath, [pnpmEntry, ...translated], { stdio: \'inherit\' })',
+    "child.on('error', error => { console.error(error); process.exit(1) })",
+    "child.on('close', code => { process.exit(code ?? 1) })",
+    '',
+  ].join('\n')
+}
+
+
 /**
  * Stage a complete, self-contained pnpm distribution beside the node
  * runtime. Scripted Marketplace previews resolve this entry through
@@ -1280,6 +1376,53 @@ function stagePnpmIntoNodeRuntime({ pnpmSource }) {
   }
 }
 
+/**
+ * Stage npm/npx launchers that forward onto the bundled pnpm distribution
+ * installed by stagePnpmIntoNodeRuntime. Third-party marketplace lifecycle
+ * scripts overwhelmingly assume npm is on PATH; the host process puts the
+ * node-runtime directory first, so these launchers make `npm run build`
+ * resolve to pnpm instead of a dangling stock shim (Windows distributions
+ * drop npm.cmd/npx.cmd at the runtime root, which pruneNodeRuntime deletes).
+ * Run this after pruning so the forwarding launchers replace the stock ones.
+ */
+function stageNpmForwardingShims() {
+  const modules = isWindowsNode ? join(nodeRuntime, 'node_modules') : join(nodeRuntime, 'lib', 'node_modules')
+  mkdirSync(modules, { recursive: true })
+  writeFileSync(join(modules, 'npm-forward.mjs'), npmForwarderSource())
+  if (isWindowsNode) {
+    for (const name of ['npm', 'npx']) {
+      writeFileSync(
+        join(nodeRuntime, `${name}.cmd`),
+        `@ECHO off\r\n"%~dp0node.exe" "%~dp0node_modules\\npm-forward.mjs" ${name} %*\r\n`,
+      )
+      writeFileSync(
+        join(nodeRuntime, `${name}.ps1`),
+        [
+          '$exe = if ($MyInvocation.MyCommand -is [string]) { $MyInvocation.MyCommand } else { $MyInvocation.MyCommand.Path }',
+          '$root = Split-Path -Parent $exe',
+          '& (Join-Path $root "node.exe") (Join-Path $root "node_modules\\npm-forward.mjs") ' + name + ' @args',
+          'exit $LASTEXITCODE',
+          '',
+        ].join('\r\n'),
+      )
+      rmSync(join(nodeRuntime, name), { force: true })
+    }
+  } else {
+    mkdirSync(join(nodeRuntime, 'bin'), { recursive: true })
+    for (const name of ['npm', 'npx']) {
+      const launcher = join(nodeRuntime, 'bin', name)
+      rmSync(launcher, { force: true })
+      writeFileSync(launcher, [
+        '#!/bin/sh',
+        'dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)',
+        'exec "$dir/bin/node" "$dir/lib/node_modules/npm-forward.mjs" ' + name + ' "$@"',
+        '',
+      ].join('\n'))
+      chmodSync(launcher, 0o755)
+    }
+  }
+}
+
   return {
     portableSymlink,
     exposeHoistedPackages,
@@ -1312,6 +1455,8 @@ function stagePnpmIntoNodeRuntime({ pnpmSource }) {
     ensureLinuxLandlockLauncher,
     pruneRuntimeDevelopmentFiles,
     stagePnpmIntoNodeRuntime,
+    stageNpmForwardingShims,
+    translateNpmInvocation,
   }
 }
 
@@ -1369,6 +1514,20 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === libPath) {
       npmRelease: true,
       run: cliRun,
     }).stagePnpmIntoNodeRuntime({ pnpmSource: source })
+  } else if (command === 'stage-npm-shims') {
+    const nodeRuntime = resolve(cliOption(args, '--target'))
+    createStageRuntime({
+      root: nodeRuntime,
+      stage: join(nodeRuntime, '.stage'),
+      runtime: nodeRuntime,
+      nodeRuntime,
+      dshSource: nodeRuntime,
+      isWindowsNode: args.includes('--is-windows'),
+      nodePlatform: 'linux',
+      nodeArch: 'x64',
+      npmRelease: true,
+      run: cliRun,
+    }).stageNpmForwardingShims()
   } else if (command === 'restore-executable-helpers') {
     const runtime = resolve(cliOption(args, '--runtime'))
     createStageRuntime({
@@ -1385,7 +1544,7 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === libPath) {
     }).restoreExecutableHelpers()
   } else {
     throw new Error(
-      `unknown stage-runtime command: ${String(command)} (expected install-packages, stage-pnpm, or restore-executable-helpers)`,
+      `unknown stage-runtime command: ${String(command)} (expected install-packages, stage-pnpm, stage-npm-shims, or restore-executable-helpers)`,
     )
   }
 }

--- a/tests/npm-forward.test.ts
+++ b/tests/npm-forward.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import {
+  createStageRuntime,
+} from '../scripts/stage-runtime-lib.mjs'
+
+function writeManifest(directory: string, manifest: object): void {
+  mkdirSync(directory, { recursive: true })
+  writeFileSync(join(directory, 'package.json'), JSON.stringify(manifest))
+}
+
+function buildStaging(nodeRuntime: string, isWindowsNode: boolean) {
+  const staging = createStageRuntime({
+    root: nodeRuntime,
+    stage: join(nodeRuntime, '.stage'),
+    runtime: nodeRuntime,
+    nodeRuntime,
+    dshSource: nodeRuntime,
+    isWindowsNode,
+    nodePlatform: isWindowsNode ? 'win' : 'linux',
+    nodeArch: 'x64',
+    npmRelease: true,
+    run: () => {
+      throw new Error('unexpected run')
+    },
+  })
+  return { staging, translateNpmInvocation: staging.translateNpmInvocation }
+}
+
+function translation() {
+  const { staging: { translateNpmInvocation } } = buildStaging(join(tmpdir(), 'oh-dsh-npm-forward-standalone'), false)
+  return translateNpmInvocation
+}
+
+test('translateNpmInvocation maps common npm subcommands onto pnpm', () => {
+  const translateNpmInvocation = translation()
+  assert.deepEqual(translateNpmInvocation(['run', 'build']), ['run', 'build'])
+  assert.deepEqual(translateNpmInvocation(['run', 'build', '--', '--watch']), [
+    'run', 'build', '--', '--watch',
+  ])
+  assert.deepEqual(translateNpmInvocation(['install']), ['install'])
+  assert.deepEqual(translateNpmInvocation(['ci']), ['install', '--frozen-lockfile'])
+  assert.deepEqual(translateNpmInvocation(['ci', '--omit=dev']), [
+    'install', '--frozen-lockfile', '--omit=dev',
+  ])
+  assert.deepEqual(translateNpmInvocation(['test']), ['test'])
+  assert.deepEqual(translateNpmInvocation(['i', 'left-pad']), ['install', 'left-pad'])
+  assert.deepEqual(translateNpmInvocation(['t']), ['test'])
+  assert.deepEqual(translateNpmInvocation(['uninstall', 'left-pad']), ['remove', 'left-pad'])
+  assert.deepEqual(translateNpmInvocation(['rm', 'left-pad']), ['remove', 'left-pad'])
+  assert.deepEqual(translateNpmInvocation(['run-script', 'build']), ['run', 'build'])
+  assert.deepEqual(translateNpmInvocation(['exec', '--', 'tsc']), ['exec', '--', 'tsc'])
+  assert.deepEqual(translateNpmInvocation(['--version']), ['--version'])
+  assert.deepEqual(translateNpmInvocation(['publish']), ['publish'])
+})
+
+test('translateNpmInvocation translates --prefix into pnpm --dir', () => {
+  const translateNpmInvocation = translation()
+  assert.deepEqual(translateNpmInvocation(['--prefix', './pkg', 'run', 'build']), [
+    '--dir', './pkg', 'run', 'build',
+  ])
+  assert.deepEqual(translateNpmInvocation(['install', '--prefix=/target']), [
+    '--dir=/target', 'install',
+  ])
+})
+
+test('translateNpmInvocation forwards npx invocations as pnpm exec', () => {
+  const translateNpmInvocation = translation()
+  assert.deepEqual(translateNpmInvocation(['tsc', '--noEmit'], 'npx'), [
+    'exec', 'tsc', '--noEmit',
+  ])
+  assert.deepEqual(translateNpmInvocation(['-y', 'tsc'], 'npx'), ['exec', 'tsc'])
+  assert.deepEqual(translateNpmInvocation(['--yes', 'tsc'], 'npx'), ['exec', 'tsc'])
+})
+
+test('translateNpmInvocation fails with guidance for npm-only invocations', () => {
+  const translateNpmInvocation = translation()
+  assert.throws(() => translateNpmInvocation([]), /without a subcommand/)
+  assert.throws(() => translateNpmInvocation(['config', 'set', 'foo', 'bar']), /no bundled translation/)
+  assert.throws(() => translateNpmInvocation(['dist-tag']), /no bundled translation/)
+})
+
+test('stageNpmForwardingShims installs Windows launchers beside node.exe', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'oh-dsh-npm-forward-'))
+  const nodeRuntime = join(fixture, 'node-runtime')
+  try {
+    mkdirSync(nodeRuntime, { recursive: true })
+    const { staging, translateNpmInvocation } = buildStaging(nodeRuntime, true)
+    staging.stageNpmForwardingShims()
+
+    const forwarder = join(nodeRuntime, 'node_modules', 'npm-forward.mjs')
+    assert.equal(existsSync(forwarder), true, 'forwarder staged')
+    const source = readFileSync(forwarder, 'utf8')
+    assert.match(source, /import \{ spawn \} from 'node:child_process'/)
+    assert.match(source, /pnpm\.mjs/)
+    // The staged forwarder embeds the same translation the library exports,
+    // so the tested logic is the shipped logic.
+    const embedded = /const translateNpmInvocation = ([\s\S]*?)\n\nconst \[invocation/.exec(source)
+    assert.ok(embedded !== null, 'translation function embedded')
+    assert.ok(embedded[1] !== undefined)
+    assert.equal(embedded[1].trim(), translateNpmInvocation.toString().trim())
+    // The embedded function must not reference module scope: it executes
+    // standalone inside the staged runtime.
+    assert.doesNotMatch(embedded[1], /\bNPM_PASSTHROUGH_SUBCOMMANDS\b/)
+
+    for (const name of ['npm', 'npx']) {
+      const cmd = readFileSync(join(nodeRuntime, `${name}.cmd`), 'utf8')
+      assert.match(cmd, new RegExp(`node_modules\\\\npm-forward\\.mjs" ${name} %\\*`))
+      assert.equal(existsSync(join(nodeRuntime, `${name}.ps1`)), true, `${name}.ps1 staged`)
+    }
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('stageNpmForwardingShims installs POSIX launchers in bin', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'oh-dsh-npm-forward-'))
+  const nodeRuntime = join(fixture, 'node-runtime')
+  try {
+    mkdirSync(nodeRuntime, { recursive: true })
+    buildStaging(nodeRuntime, false).staging.stageNpmForwardingShims()
+
+    assert.equal(existsSync(join(nodeRuntime, 'lib', 'node_modules', 'npm-forward.mjs')), true)
+    for (const name of ['npm', 'npx']) {
+      const launcher = readFileSync(join(nodeRuntime, 'bin', name), 'utf8')
+      assert.match(launcher, /^#!\/bin\/sh\n/)
+      assert.match(launcher, new RegExp(`npm-forward\\.mjs" ${name} "\\$@"`))
+    }
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('stageNpmForwardingShims replaces a dangling stock Windows npm.cmd', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'oh-dsh-npm-forward-'))
+  const nodeRuntime = join(fixture, 'node-runtime')
+  try {
+    mkdirSync(nodeRuntime, { recursive: true })
+    writeFileSync(
+      join(nodeRuntime, 'npm.cmd'),
+      '@ECHO off\r\n"%~dp0\node_modules\\npm\\bin\\npm-cli.js" %*\r\n',
+    )
+    buildStaging(nodeRuntime, true).staging.stageNpmForwardingShims()
+    const cmd = readFileSync(join(nodeRuntime, 'npm.cmd'), 'utf8')
+    assert.doesNotMatch(cmd, /npm-cli\.js/)
+    assert.match(cmd, /npm-forward\.mjs/)
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})

--- a/tests/plugin-marketplace.test.ts
+++ b/tests/plugin-marketplace.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
+import { spawnSync } from 'node:child_process'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import { parseMarketplaceCatalog } from '../plugins/plugin-marketplace/src/catalog.ts'
@@ -765,6 +766,70 @@ test('production bundle build runs approved hooks in its own workspace', {
     assert.equal(existsSync(join(checkout, 'unexpected-prepack')), false)
     assert.equal(existsSync(join(helper, 'unexpected-prepare')), false)
     assert.equal(existsSync(join(candidateProfile, 'profile-built')), false)
+  } finally {
+    rmSync(sandboxRoot, { recursive: true, force: true })
+  }
+})
+
+test('bundle build dependencies survive the move into managed sources', async () => {
+  // The transaction manager renames a scripted checkout from the disposable
+  // bundle-builds directory into the profile's managed sources before the
+  // preview boots. pnpm's default isolated layout links dependencies with
+  // absolute paths into the preview's store, so those links dangle after the
+  // rename and the plugin fails to import them (observed as ERR_MODULE_NOT_FOUND
+  // for linkedom when previewing dsh-web-tools on Windows). buildBundle must
+  // therefore install with the hoisted layout, whose real directories travel
+  // with the checkout.
+  const sandboxRoot = mkdtempSync(join(tmpdir(), 'oh-dsh-bundle-move-'))
+  const checkout = join(sandboxRoot, 'bundle-builds', 'move-fixture')
+  const sources = join(sandboxRoot, 'sources')
+  const moved = join(sources, 'move-fixture')
+  mkdirSync(checkout, { recursive: true })
+  writeFileSync(join(checkout, 'package.json'), JSON.stringify({
+    name: 'move-fixture',
+    private: true,
+    type: 'module',
+    dependencies: { 'is-odd': '3.0.1' },
+    scripts: { prepack: 'node prepack.mjs' },
+    version: '1.0.0',
+  }))
+  writeFileSync(join(checkout, 'prepack.mjs'), [
+    "import { writeFileSync } from 'node:fs'",
+    "import isOdd from 'is-odd'",
+    "writeFileSync(new URL('./prepacked', import.meta.url), `${isOdd(1)}\\n`)",
+    '',
+  ].join('\n'))
+  writeFileSync(join(checkout, 'resolve.mjs'), [
+    "import isOdd from 'is-odd'",
+    "process.stdout.write(String(isOdd(3)))",
+    '',
+  ].join('\n'))
+
+  try {
+    const platform = new ProductionMarketplacePlatform({
+      cliEntry: '/unused/dsh.mjs',
+      cwd: checkout,
+      env: process.env,
+      nodeBinary: process.execPath,
+      pnpmEntry: fileURLToPath(new URL('../node_modules/pnpm/bin/pnpm.mjs', import.meta.url)),
+    })
+    await platform.buildBundle({
+      checkout,
+      sandboxRoot,
+      scripts: ['prepack'],
+      // Windows has no write-restricted preview launcher; the dependency
+      // contract under test lives in the pnpm invocation, not confinement.
+      sandboxed: false,
+    })
+    assert.equal(readFileSync(join(checkout, 'prepacked'), 'utf8'), 'true\n')
+    // The rename is the production step the transaction manager performs.
+    mkdirSync(sources, { recursive: true })
+    renameSync(checkout, moved)
+    const resolution = spawnSync(process.execPath, [
+      join(moved, 'resolve.mjs'),
+    ], { cwd: moved, encoding: 'utf8' })
+    assert.equal(resolution.status, 0, resolution.stderr)
+    assert.equal(resolution.stdout.trim(), 'true')
   } finally {
     rmSync(sandboxRoot, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

Installing a scripted marketplace plugin on Windows failed with
`DSH runtime exited before readiness (code=1, signal=null)`. The
preview runtime log showed the real failure: the plugin could not
import its own dependencies (`Cannot find package 'linkedom'`) from
its managed source directory.

Root cause: the marketplace transaction builds scripted plugin
checkouts in a disposable `bundle-builds/` directory, then renames the
finished tree into the profile's managed sources (introduced in
c65c14a). pnpm's default isolated layout links packages with absolute
junctions/symlinks into the checkout's own `.pnpm` tree; on Windows a
rename moves the tree but not the junction targets inside it, so every
dependency dangles after the move. A subtler trap: pinning
`--config.node-linker=hoisted` on the install alone is not enough,
because the subsequent `pnpm run <script>` re-reads `.modules.yaml`
without the flag and rebuilds the top-level entries as absolute
junctions right before the rename.

Related issue: none on record; first observed while installing
dsh-web-tools (A3Boy/dsh-web-tools) on Windows.

## What Changed

- `marketplace`: `ProductionMarketplacePlatform.buildBundle` passes
  `--config.node-linker=hoisted` on every pnpm invocation — the
  install and each reviewed lifecycle `run` — so the built checkout
  carries real directories that survive the rename into managed
  sources. This matches the layout dsh profiles and Windows package
  staging already use.
- `runtime`: the staged node runtime gains npm/npx forwarding shims
  (`stageNpmForwardingShims`). Third-party lifecycle scripts call npm
  (`prepack: "npm run build"`), but the bundled runtime ships pnpm
  only; the shims translate faithful npm invocations onto the staged
  pnpm and fail with guidance for npm-specific subcommands.
  `pruneNodeRuntime` also removes the Windows root-level stock
  launchers that previously dangled onto the deleted npm package.
- `web`: the terminal smoke sends a PowerShell marker spelling on
  Windows instead of `printf`, which does not exist there.
- `docs`: bilingual Agent Notes record both decisions with the
  alternatives considered and the measured disk-footprint impact
  (none: pnpm hard-links package files from the store under both
  layouts).

## Scope

- `plugins/plugin-marketplace/src/host/platform.ts` — buildBundle
  pnpm arguments (the only behavior change on the install path).
- `scripts/stage-runtime-lib.mjs`, `scripts/stage-runtime-lib.d.mts`,
  `scripts/stage-dsh.mjs`, `nix/oh-dsh.nix` — npm forwarding shims in
  the staged runtime and their Nix wiring.
- `scripts/smoke-web.mjs` — Windows terminal smoke marker.
- `tests/plugin-marketplace.test.ts` — regression: build a fixture
  with a dependency, run a lifecycle script, rename the tree, require
  the dependency to still resolve.
- `tests/npm-forward.test.ts` — translation table, launcher contents
  on both layouts, shims self-containment, and an end-to-end prepack
  build through the staged runtime.
- `.agents/notes/implemented/bug-fix/` — two bilingual notes with
  recorded i18n pairings.

No changes to sandbox policies (Seatbelt/Landlock), the preview →
apply → rollback transaction, or non-scripted plugin installs. The
npm shim semantics are deliberately narrow: untranslatable npm
subcommands exit with guidance instead of silently diverging.

## Verification

Windows 11 x64 (tested on real hardware, this is the platform the bug
is specific to):

- `pnpm run typecheck`, `pnpm run build`, `pnpm run stage:dsh` pass.
- `node --test tests/plugin-marketplace.test.ts
  tests/npm-forward.test.ts`: 58 pass, 0 fail (2 platform-gated
  skips). The new regression reproduces the Windows junction failure
  without the fix and passes with it.
- `pnpm run verify:agent-notes` and `pnpm run verify:bilingual` pass.
- End to end with a locally staged runtime from this branch:
  preview-installing dsh-web-tools builds through the npm shim, the
  preview runtime reaches readiness (`dsh web:` line, no import
  errors), and the applied profile's source tree resolves linkedom.

macOS / Linux (not run on real hardware):

- Covered by the same automated suites via CI. The regression test is
  platform-independent by design: the rename-survival contract it
  pins holds trivially on POSIX, where pnpm's isolated layout uses
  relative symlinks that travel with the tree.
- Expected behavior change is limited to layout inside scripted
  checkouts (isolated → hoisted). Per a hard-link-aware measurement,
  disk footprint is unchanged; resolution semantics for well-formed
  plugins are identical. Known edge: a plugin whose own build scripts
  run bare `pnpm install` now gets the hoisted layout where it
  previously got isolated — functionally equivalent, slightly less
  strict about phantom dependencies.
- What CI cannot cover: the Seatbelt regression for scripted builds
  only runs on macOS runners, and there is no Linux scripted-build
  end-to-end. If you have either platform available, a smoke install
  of any scripted bundle plugin (e.g. dsh-web-tools) would close the
  gap.