### PR TITLE
runtime: add DeepSeek V4.1 Flash to the default model catalog

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-08-deepseek-v41-flash-catalog.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-09-08-deepseek-v41-flash-catalog.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-09-08-deepseek-v41-flash-catalog.md
+2026-09-08-deepseek-v41-flash-catalog.md: dfc313cc617bcc626e21618dc08d0fbef3f03494
+2026-09-08-deepseek-v41-flash-catalog.zh.md: 3de76496c6c1e43f0127f0d476d3c67c3c6c819c

--- a/.agents/notes/implemented/feature/2026-09-08-deepseek-v41-flash-catalog.md
+++ b/.agents/notes/implemented/feature/2026-09-08-deepseek-v41-flash-catalog.md
@@ -1,0 +1,92 @@
+# Agent Note: DeepSeek-V4.1-Flash in the default model catalog — a surface-patch composition row
+
+Status: implemented
+
+English | [中文](2026-09-08-deepseek-v41-flash-catalog.zh.md)
+
+## Problem
+
+DeepSeek serves a new `DeepSeek-V4.1-Flash` model (id
+`deepseek-v4.1-flash-expires-on-0910`, text+image input, retired after
+2026-09-10). It must appear in every Oh-DSH surface's model picker by default,
+with no user configuration.
+
+The default advisory catalog is compiled inside the pinned runtime plugin
+`@deepseek-ai/dsh-llm-deepseek@0.1.2-alpha.3` (`DEFAULT_MODELS`:
+deepseek-v4-flash, deepseek-v4-pro, deepseek-v4-flash-vision-exp). The
+runtime arrives as an npm tarball pinned by `dsh-source.json`; newer runtime
+releases (checked through 0.1.3-alpha.2) still ship the same three entries,
+and `upstream/` is pinned source that Oh-DSH must not edit. So the extra
+model can only come from this repository's composition layers.
+
+## Decision
+
+Give the `llm-deepseek` dsh-base row an entry config in each of the three
+surface bundle patches — the root `cordis.patch.yml` (Desktop),
+`web/cordis.patch.yml` (Web), and `plugins/tui/cordis.patch.yml` (TUI) —
+setting `config.models` to the runtime's three shipped models plus the new
+`deepseek-v4.1-flash-expires-on-0910` entry (contextWindow 1000000,
+text+image, imagePixelBudget 640000, imageMaxBytes 1048576 — the runtime's own
+vision-model image limits).
+
+This uses the layering dsh-base itself documents: a later bundle patch
+addresses the row by id and replaces its whole `config`, and the plugin layers
+its entry config under the optional `llm-deepseek:` user-settings section.
+Because settings resolution is schema defaults → entry base → user section
+(arrays replace whole), the entry list becomes the distribution's default
+catalog, a user's own `llm-deepseek.models` still overrides it live without a
+restart, and every other field of the section keeps falling back to schema
+defaults. The catalog stays advisory —
+[catalog discovery](../architecture/2026-07-15-llm-model-catalog-and-acp-selection.md)
+never validates requests, so unlisted model ids keep passing through.
+
+The existing three entries restate the runtime's ids verbatim. The incoming
+request's `deepseek-v4-flash-exp` (text+image) was read as the runtime's
+vision entry `deepseek-v4-flash-vision-exp` — the id the endpoint serves —
+rather than introducing a second near-duplicate id. The default agent model
+selection (`agent-default-model` → `deepseek-v4-flash`) is unchanged: the
+change adds a picker option, not a new default.
+
+`tests/model-catalog.test.ts` pins the three patch layers to identical
+catalogs and asserts the V4.1 entry's facts, so the deliberate 3× repetition
+(matching the existing per-surface plugin-row idiom) cannot drift silently.
+
+## Alternatives considered
+
+- **Editing the pinned runtime or `upstream/` to extend `DEFAULT_MODELS`.**
+  Rejected: `upstream/` is pinned source and the runtime ships as an npm
+  tarball; Oh-DSH adapts behavior in its own composition layers.
+- **Bumping the pinned runtime to a release that lists the model.** Rejected:
+  no published runtime release (through 0.1.3-alpha.2) contains a V4.1 entry,
+  and a runtime bump is a larger, unrelated pin change.
+- **Seeding a `llm-deepseek:` section into the user's settings.yaml on first
+  run.** Rejected: the settings document is user-owned state that the web
+  Models page reads and writes; pre-writing a section would fight that owner
+  and leave stale entries behind when the distribution catalog changes.
+- **A single shared patch fragment generated into the three layers at build
+  time.** Rejected: the patch files are hand-maintained source read by both
+  humans and the runtime loader; hidden generation adds machinery for ~25
+  lines per surface, and the drift risk is already covered by the contract
+  test.
+
+## Consequences
+
+- All three surfaces list DeepSeek-V4.1-Flash by default; the model id embeds
+  its retirement date, so after 2026-09-10 the entry should be dropped from
+  all three layers (and the contract test) in one change — the id will keep
+  passing through to the endpoint either way.
+- The entry list shadows the pinned runtime's `DEFAULT_MODELS`: a future
+  runtime release that adds or retunes its own defaults will not surface here
+  until the three rows are updated. That is the cost of a distribution-owned
+  catalog; the contract test at least keeps the three surfaces identical.
+- A user's saved `llm-deepseek.models` section (if present) still wins over
+  the distribution defaults, including hiding the new entry; nothing in this
+  change touches user state.
+
+## Testing
+
+`tests/model-catalog.test.ts` parses all three patch layers (with the TUI
+file's `!!js` expression scalars kept as raw strings) and asserts catalog
+equality across surfaces, the exact four-entry id order, catalog invariants
+the adapter enforces (unique ids; image limits only on image-capable models),
+and the V4.1 entry's name, context window, modalities, and image limits.

--- a/.agents/notes/implemented/feature/2026-09-08-deepseek-v41-flash-catalog.zh.md
+++ b/.agents/notes/implemented/feature/2026-09-08-deepseek-v41-flash-catalog.zh.md
@@ -1,0 +1,78 @@
+# Agent Note: 默认模型目录中的 DeepSeek-V4.1-Flash——surface patch 组合行
+
+Status: implemented
+
+[English](2026-09-08-deepseek-v41-flash-catalog.md) | 中文
+
+## 问题
+
+DeepSeek 上线了新的 `DeepSeek-V4.1-Flash` 模型(id 为
+`deepseek-v4.1-flash-expires-on-0910`,文本+图像输入,2026-09-10 之后下线)。
+它必须默认出现在每个 Oh-DSH surface 的模型选择器里,不需要用户做任何配置。
+
+默认 advisory 目录编译在钉版运行时插件
+`@deepseek-ai/dsh-llm-deepseek@0.1.2-alpha.3` 内部(`DEFAULT_MODELS`:
+deepseek-v4-flash、deepseek-v4-pro、deepseek-v4-flash-vision-exp)。运行时以
+npm tarball 形式由 `dsh-source.json` 钉版;更新的运行时版本(已核对至
+0.1.3-alpha.2)仍然是同样的三个条目,而且 `upstream/` 是不可修改的钉版源码。
+所以额外的模型只能来自本仓库自己的组合层。
+
+## 决策
+
+在三个 surface bundle patch——根目录 `cordis.patch.yml`(Desktop)、
+`web/cordis.patch.yml`(Web)、`plugins/tui/cordis.patch.yml`(TUI)——中为
+dsh-base 的 `llm-deepseek` 行写入条目 config,把 `config.models` 设为运行时
+已有的三个模型加上新的 `deepseek-v4.1-flash-expires-on-0910` 条目
+(contextWindow 1000000,text+image,imagePixelBudget 640000,imageMaxBytes
+1048576——即运行时自己的 vision 模型图像限额)。
+
+这沿用了 dsh-base 自己声明的分层规则:后置 bundle patch 按 id 定位该行并
+整体替换其 `config`;插件再把条目 config 垫在可选的 `llm-deepseek:` 用户
+设置节之下。设置解析顺序是 schema 默认值 → 条目 base → 用户节(数组整体
+替换),因此条目列表成为本发行版的默认目录;用户自己的
+`llm-deepseek.models` 仍然无需重启即可覆盖它;该节其余字段继续回落到 schema
+默认值。目录仍然是 advisory——[目录发现](../architecture/2026-07-15-llm-model-catalog-and-acp-selection.md)
+从不校验请求,未列出的模型 id 继续原样透传。
+
+已有三个条目逐字复述运行时的 id。需求中的 `deepseek-v4-flash-exp`
+(text+image)被解读为运行时的 vision 条目 `deepseek-v4-flash-vision-exp`——
+即端点实际服务的 id——而不是引入第二个近乎重复的 id。默认 agent 模型选择
+(`agent-default-model` → `deepseek-v4-flash`)不变:本变更加的是选择器选项,
+不是新的默认值。
+
+`tests/model-catalog.test.ts` 把三个 patch 层钉在完全相同的目录上,并断言
+V4.1 条目的事实,使这份有意的 3× 重复(与既有的每-surface 插件行惯例一致)
+不会悄悄漂移。
+
+## 备选方案
+
+- **修改钉版运行时或 `upstream/` 来扩展 `DEFAULT_MODELS`。** 否决:
+  `upstream/` 是钉版源码,运行时以 npm tarball 发布;Oh-DSH 在自己的组合层
+  适配行为。
+- **把钉版运行时升级到包含该模型的版本。** 否决:已发布的运行时版本(截至
+  0.1.3-alpha.2)都不包含 V4.1 条目,而运行时升级是一次更大的、与本题无关
+  的钉版变更。
+- **首次运行时向用户的 settings.yaml 播种 `llm-deepseek:` 节。** 否决:
+  设置文档是用户自有状态,由 web Models 页面读写;预先写入一节会与该属主
+  冲突,并在发行版目录变化后留下陈旧条目。
+- **构建期把单一共享 patch 片段生成进三个层。** 否决:patch 文件是人与运行
+  时加载器共同阅读的手维护源码;为每 surface 约 25 行引入隐藏生成步骤得不
+  偿失,漂移风险已由契约测试覆盖。
+
+## 后果
+
+- 三个 surface 默认列出 DeepSeek-V4.1-Flash;模型 id 内嵌下线日期,因此
+  2026-09-10 之后应一次性从三个层(及契约测试)删除该条目——无论如何该 id
+  都会继续向端点透传。
+- 条目列表遮蔽钉版运行时的 `DEFAULT_MODELS`:未来运行时新增或调整自己的
+  默认值时,不会在这里自动出现,直到三个行被更新。这是发行版自有目录的
+  代价;契约测试至少保证三个 surface 完全一致。
+- 用户已保存的 `llm-deepseek.models` 节(若存在)仍然优先于发行版默认值,
+  包括隐藏新条目;本变更不触碰任何用户状态。
+
+## 测试
+
+`tests/model-catalog.test.ts` 解析全部三个 patch 层(TUI 文件的 `!!js`
+表达式标量按原始字符串保留),断言各 surface 目录一致、精确的四条目 id
+顺序、适配器强制执行的目录不变量(id 唯一;图像限额只在支持图像的模型上),
+以及 V4.1 条目的名称、上下文窗口、模态与图像限额。

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -19,6 +19,36 @@
 - id: ui-layout
   disabled: true
 
+# The distribution's advisory DeepSeek model catalog: the pinned runtime's
+# three shipped models plus DeepSeek-V4.1-Flash, served through 2026-09-10.
+# A patch row replaces the dsh-base row's whole config, so this restates
+# every catalog entry; the user's `llm-deepseek:` settings section still
+# layers over this entry without a restart. The catalog is display-only:
+# requests keep accepting any model id the endpoint serves.
+- id: llm-deepseek
+  config:
+    models:
+      - id: deepseek-v4-flash
+        name: DeepSeek-V4-Flash
+        description: Fast, efficient, and economical; suited to focused, routine, or parallel tasks.
+        contextWindow: 1000000
+      - id: deepseek-v4-pro
+        name: DeepSeek-V4-Pro
+        description: Stronger agentic coding, knowledge, and difficult reasoning; suited to complex or quality-critical tasks at higher cost.
+        contextWindow: 1000000
+      - id: deepseek-v4-flash-vision-exp
+        name: DeepSeek-V4-Flash-Vision-Exp
+        contextWindow: 1000000
+        inputModalities: [text, image]
+        imagePixelBudget: 640000
+        imageMaxBytes: 1048576
+      - id: deepseek-v4.1-flash-expires-on-0910
+        name: DeepSeek-V4.1-Flash-Expires-On-0910
+        contextWindow: 1000000
+        inputModalities: [text, image]
+        imagePixelBudget: 640000
+        imageMaxBytes: 1048576
+
 - insert:
     - id: oh-desktop-frame
       name: '@oh-dsh/desktop-frame'

--- a/plugins/tui/cordis.patch.yml
+++ b/plugins/tui/cordis.patch.yml
@@ -8,6 +8,36 @@
 - id: dsh-tui
   disabled: true
 
+# The distribution's advisory DeepSeek model catalog: the pinned runtime's
+# three shipped models plus DeepSeek-V4.1-Flash, served through 2026-09-10.
+# A patch row replaces the dsh-base row's whole config, so this restates
+# every catalog entry; the user's `llm-deepseek:` settings section still
+# layers over this entry without a restart. The catalog is display-only:
+# requests keep accepting any model id the endpoint serves.
+- id: llm-deepseek
+  config:
+    models:
+      - id: deepseek-v4-flash
+        name: DeepSeek-V4-Flash
+        description: Fast, efficient, and economical; suited to focused, routine, or parallel tasks.
+        contextWindow: 1000000
+      - id: deepseek-v4-pro
+        name: DeepSeek-V4-Pro
+        description: Stronger agentic coding, knowledge, and difficult reasoning; suited to complex or quality-critical tasks at higher cost.
+        contextWindow: 1000000
+      - id: deepseek-v4-flash-vision-exp
+        name: DeepSeek-V4-Flash-Vision-Exp
+        contextWindow: 1000000
+        inputModalities: [text, image]
+        imagePixelBudget: 640000
+        imageMaxBytes: 1048576
+      - id: deepseek-v4.1-flash-expires-on-0910
+        name: DeepSeek-V4.1-Flash-Expires-On-0910
+        contextWindow: 1000000
+        inputModalities: [text, image]
+        imagePixelBudget: 640000
+        imageMaxBytes: 1048576
+
 - insert:
   - id: oh-tui
     name: '@oh-dsh/tui'

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** One advisory model-catalog entry in an `llm-deepseek` patch row. */
+interface CatalogModel {
+  id: string
+  name: string
+  description?: string
+  contextWindow: number
+  inputModalities?: string[]
+  imagePixelBudget?: number
+  imageMaxBytes?: number
+}
+
+interface PatchRow {
+  id?: string
+  config?: { models?: CatalogModel[] }
+}
+
+/** The surface patch layers copied verbatim into each distribution. */
+const SURFACE_PATCHES = [
+  'cordis.patch.yml',
+  join('web', 'cordis.patch.yml'),
+  join('plugins', 'tui', 'cordis.patch.yml'),
+] as const
+
+// The TUI layer embeds `!!js` expression scalars in other rows; keep them
+// as raw strings so the shared catalog rows still parse.
+const jsExpressionTag = { tag: 'tag:yaml.org,2002:js', resolve: (value: string) => value }
+
+function surfaceCatalogModels(path: string): CatalogModel[] {
+  const rows = parse(readFileSync(join(root, path), 'utf8'), {
+    customTags: [jsExpressionTag],
+  }) as PatchRow[]
+  const row = rows.find(entry => entry.id === 'llm-deepseek')
+  assert.notEqual(row, undefined, `${path} must configure the llm-deepseek catalog row`)
+  assert.notEqual(row?.config?.models, undefined, `${path} must set llm-deepseek config.models`)
+  return row?.config?.models ?? []
+}
+
+test('every surface patch ships the same DeepSeek advisory model catalog', () => {
+  const catalogs = SURFACE_PATCHES.map(surfaceCatalogModels)
+  for (const path of SURFACE_PATCHES.slice(1)) {
+    assert.deepEqual(
+      surfaceCatalogModels(path),
+      catalogs[0],
+      `${path} drifted from the desktop catalog`,
+    )
+  }
+})
+
+test('the default catalog adds DeepSeek-V4.1-Flash beside the pinned runtime models', () => {
+  const models = surfaceCatalogModels(SURFACE_PATCHES[0])
+  assert.deepEqual(
+    models.map(model => model.id),
+    [
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'deepseek-v4-flash-vision-exp',
+      'deepseek-v4.1-flash-expires-on-0910',
+    ],
+  )
+
+  // Catalog invariants the llm-deepseek adapter enforces at resolve time:
+  // unique ids, and image request limits only on image-capable models.
+  assert.equal(new Set(models.map(model => model.id)).size, models.length)
+  for (const model of models) {
+    const acceptsImages = model.inputModalities?.includes('image') === true
+    if (!acceptsImages) {
+      assert.equal(model.imagePixelBudget, undefined)
+      assert.equal(model.imageMaxBytes, undefined)
+    }
+  }
+
+  const v41 = models.find(model => model.id === 'deepseek-v4.1-flash-expires-on-0910')
+  assert.equal(v41?.name, 'DeepSeek-V4.1-Flash-Expires-On-0910')
+  assert.equal(v41?.contextWindow, 1000000)
+  assert.deepEqual(v41?.inputModalities, ['text', 'image'])
+  assert.equal(v41?.imagePixelBudget, 640000)
+  assert.equal(v41?.imageMaxBytes, 1048576)
+})

--- a/web/cordis.patch.yml
+++ b/web/cordis.patch.yml
@@ -15,6 +15,36 @@
 # Electron-bound desktop shell chrome stays out; the marketplace host now
 # serves its bridge through the same webServer.
 
+# The distribution's advisory DeepSeek model catalog: the pinned runtime's
+# three shipped models plus DeepSeek-V4.1-Flash, served through 2026-09-10.
+# A patch row replaces the dsh-base row's whole config, so this restates
+# every catalog entry; the user's `llm-deepseek:` settings section still
+# layers over this entry without a restart. The catalog is display-only:
+# requests keep accepting any model id the endpoint serves.
+- id: llm-deepseek
+  config:
+    models:
+      - id: deepseek-v4-flash
+        name: DeepSeek-V4-Flash
+        description: Fast, efficient, and economical; suited to focused, routine, or parallel tasks.
+        contextWindow: 1000000
+      - id: deepseek-v4-pro
+        name: DeepSeek-V4-Pro
+        description: Stronger agentic coding, knowledge, and difficult reasoning; suited to complex or quality-critical tasks at higher cost.
+        contextWindow: 1000000
+      - id: deepseek-v4-flash-vision-exp
+        name: DeepSeek-V4-Flash-Vision-Exp
+        contextWindow: 1000000
+        inputModalities: [text, image]
+        imagePixelBudget: 640000
+        imageMaxBytes: 1048576
+      - id: deepseek-v4.1-flash-expires-on-0910
+        name: DeepSeek-V4.1-Flash-Expires-On-0910
+        contextWindow: 1000000
+        inputModalities: [text, image]
+        imagePixelBudget: 640000
+        imageMaxBytes: 1048576
+
 - insert:
     - id: oh-web
       name: '@oh-dsh/web'


### PR DESCRIPTION
## Scope

Adds `DeepSeek-V4.1-Flash` (id `deepseek-v4.1-flash-expires-on-0910`,
text+image input, contextWindow 1000000, imagePixelBudget 640000,
imageMaxBytes 1048576) to the default advisory model catalog on all three
surfaces, so every model picker lists it without user configuration.

The catalog is compiled inside the pinned runtime plugin
(`@deepseek-ai/dsh-llm-deepseek@0.1.2-alpha.3`), which this repository
cannot edit; newer runtime releases (through 0.1.3-alpha.2) do not carry a
V4.1 entry either. The desktop, web, and TUI bundle patch layers therefore
give the dsh-base `llm-deepseek` row an entry `config.models` listing the
runtime's three shipped models plus the new entry — the layering dsh-base
itself documents. The user's `llm-deepseek:` settings section still layers
over the entry live, and the catalog stays advisory, so request routing,
arbitrary model-id pass-through, and any saved user catalog are unchanged.
The default agent model selection stays `deepseek-v4-flash`.

The pinned runtime names its vision entry `deepseek-v4-flash-vision-exp`;
that id is kept verbatim rather than introducing a second near-duplicate id.

- `cordis.patch.yml`, `web/cordis.patch.yml`, `plugins/tui/cordis.patch.yml`:
  the `llm-deepseek` catalog row.
- `tests/model-catalog.test.ts`: pins the three layers to identical
  catalogs and asserts the V4.1 entry's facts and catalog invariants.
- Agent Note `2026-09-08-deepseek-v41-flash-catalog` (en/zh) records the
  decision and the rejected alternatives (runtime bump, editing pinned
  upstream, seeding user settings, build-time generation).

## Verification

- `pnpm run typecheck`, `pnpm test` (395 tests: 386 pass, 9 platform
  skips), `pnpm run build`
- `pnpm run stage:dsh`, `pnpm run smoke:runtime` (desktop Electron smoke),
  `pnpm run smoke:web` — all pass against the staged runtime
- `--profile web` / `--profile tui` `--dump-config` composed trees both
  contain the new entry
- `pnpm run verify:agent-notes` and `pnpm run verify:bilingual` pass