### PR TITLE
release: prepare Oh-DSH 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH Desktop",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",


### PR DESCRIPTION
## Scope

Release preparation for **v0.2.0** — the minor release carrying native
DeepSeek-V4.1-Flash support (everything from #218):

- `package.json` → `0.2.0` (tag `v0.2.0` is created only after this PR
  merges, per the release workflow).
- No other changes; the feature shipped on main through #218: the
  desktop, web, and TUI bundle patch layers list
  `deepseek-v4.1-flash-expires-on-0910` (text+image) in the default
  advisory model catalog beside the pinned runtime's three models,
  pinned together by `tests/model-catalog.test.ts`.

## Checks

- `node scripts/validate-release-tag.mjs --tag v0.2.0 --version 0.2.0` — validated
- `pnpm run typecheck` — clean
- `pnpm test` — 395 tests: 386 pass / 0 fail / 9 platform skips (isolated HOME)
- `pnpm run build` — clean
- Agent Notes gates + bilingual pairing — clean
- `git diff --check` — clean