### PR TITLE
installer: upgrade every installed surface from a bare ohdsh update

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.i18n.yaml
+++ b/.agents/notes/implemented/feature/2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/feature/2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.md
+2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.md: de3a52ef91b8b044b9d78e1c1fe17ae83939d6b6
+2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.zh.md: f8b9b0839db01405e8b5cb4857f494b9dc2c5754

--- a/.agents/notes/implemented/feature/2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.md
+++ b/.agents/notes/implemented/feature/2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.md
@@ -1,0 +1,99 @@
+# Agent Note: `ohdsh update` upgrades every installed surface, desktop included
+
+Status: implemented
+
+English | [中文](2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.zh.md)
+
+## Problem
+
+A machine routinely carries several Oh-DSH surfaces — the desktop app in
+`/Applications`, and web/tui payloads under the XDG data home — but
+`ohdsh update` upgraded only the surface its launcher payload belonged to.
+Users reasonably read "update" as "update this machine": after running it,
+the desktop and web stayed on the old release while the TUI silently moved
+ahead, and `ohdsh update desktop` only printed a pointer to the
+application's update window. The per-surface split lived in the launcher's
+update command (`runUpdateCommand`), not in the installers, which already
+handle every surface.
+
+## Decision
+
+`ohdsh update` now resolves its targets from the machine, not from the
+running payload: with no surface argument it probes desktop, web, and tui
+through `surfaceIsInstalled` and upgrades every installation found, in that
+order; with an explicit surface it upgrades that one alone, desktop
+included. The desktop is detected through the `DESKTOP_EXE` launcher record
+first, then the recorded `DESKTOP_DEST`/`desktop.env` destination and the
+platform's app-image name, mirroring what `install.sh`/`install.ps1` probe.
+`selfUpdatePlan` grew a desktop branch that reconstructs `DESKTOP_DEST`,
+`DESKTOP_REPO`, and `BIN_DIR` exactly like the web/tui branches, so a
+desktop upgrade lands where the installer put the app and keeps fork
+provenance.
+
+`runSelfUpdate` delegates to a new `runSelfUpdates` that runs one installer
+per surface, announcing each before it starts and continuing past a failure
+(the surfaces are independent payloads; a partial upgrade is still
+progress, and the first nonzero installer exit becomes the command's exit
+code). On Windows the detached helper chains every surface's installer
+sequentially in one PowerShell command — spawning one helper per surface
+would let concurrent installers race their `launcher.env` and dispatcher
+writes — and the persisted download changed from one fixed
+`update-install.ps1` to per-surface `update-install-<surface>.ps1` because
+surfaces from different forks may need different scripts.
+
+The old special cases are gone: `ohdsh update desktop` no longer prints the
+pointer (the in-app update window remains the guided path inside a running
+desktop session), and `installerOwnsRoot` was removed — the implicit path
+used it to insist the *running* payload be installer-owned, a guard the
+per-surface probe now expresses directly. The source-checkout refusal is
+unchanged.
+
+## Alternatives considered
+
+- **Keep the pointer and upgrade web/tui only.** Rejected: it is exactly
+  the confusion this change removes — a machine-partial upgrade that looks
+  like a failure.
+- **One installer invocation with a multi-surface flag.** Rejected:
+  `install.sh`/`install.ps1` are deliberately one-surface-per-run (asset
+  selection, staging, and records are per-surface); looping them keeps the
+  installers simple and failures isolated.
+- **Spawn one detached Windows helper per surface.** Rejected: they would
+  all wake after process exit and race the same record and launcher files;
+  the chained single helper keeps Windows semantics identical to Unix.
+- **Abort the remaining surfaces on the first failure.** Rejected: a
+  permission-blocked desktop must not strand web/tui on an old release;
+  sequential best-effort with a nonzero summary exit reports the failure
+  without losing the rest.
+
+## Consequences
+
+- Upgrading the desktop through the installer quits and replaces the app
+  bundle (the installers' existing behavior); a user running `ohdsh update`
+  while the desktop is open gets the app restarted-into-new by their next
+  launch, not by the update itself.
+- Detection trusts the installer records. A stale record — for example a
+  `BIN_DIR` pointing at a deleted directory — is faithfully replayed into
+  `--bin-dir`, and the installer then fails loudly at its dispatcher write;
+  repairing records means rerunning the installer for one surface. This
+  session hit exactly that on a probe-polluted machine, which is also why
+  three update tests now pin isolated `HOME`/`USERPROFILE` roots instead of
+  inheriting the developer's real records.
+- The running launcher's own payload no longer gates the implicit update:
+  a manually extracted launcher will happily upgrade every *recorded*
+  installation while itself staying stale. The dispatcher — the normal
+  entry — always routes to recorded payloads, so this only affects
+  hand-placed launchers.
+- Windows users watching `update.log` now see per-surface start/exit lines
+  instead of a single unnamed run.
+
+## Testing
+
+`tests/cli.test.ts` covers the command contract with an injected updater:
+no-arg upgrades desktop+web+tui when all three are recorded (and only the
+installed subset otherwise), an explicit surface requires that surface to
+be installed, unknown surfaces / empty machines / source roots refuse with
+guidance. `tests/self-update.test.ts` covers the desktop plan (destination,
+fork, bin-dir reconstruction), desktop detection (`DESKTOP_EXE`, then
+record/marker destinations per platform), and `runSelfUpdates` ordering
+with continue-past-failure and first-nonzero exit; three older tests were
+isolated from the real user records that had made them machine-dependent.

--- a/.agents/notes/implemented/feature/2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.zh.md
+++ b/.agents/notes/implemented/feature/2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.zh.md
@@ -1,0 +1,80 @@
+# Agent Note: `ohdsh update` 升级所有已安装 surface,desktop 亦包含在内
+
+Status: implemented
+
+[English](2026-09-09-ohdsh-update-upgrades-all-installed-surfaces.md) | 中文
+
+## 问题
+
+一台机器通常同时装着多个 Oh-DSH surface——`/Applications` 里的桌面应用,
+以及 XDG 数据目录下的 web/tui 载荷——但 `ohdsh update` 只升级启动器载荷
+所属的那一个 surface。用户自然把"update"理解为"更新这台机器":跑完之后
+desktop 和 web 还停在旧版本,而 TUI 已经悄悄升级,`ohdsh update desktop`
+也只是打印一条指向应用更新窗口的提示。这个按 surface 拆分的行为在启动器
+的 update 命令(`runUpdateCommand`)里,不在安装器里——安装器本来就支持
+每个 surface。
+
+## 决策
+
+`ohdsh update` 现在以机器而不是运行中的载荷为依据解析目标:不带 surface
+参数时,通过 `surfaceIsInstalled` 探测 desktop、web、tui,并按该顺序升级
+找到的每个安装;带显式 surface 时只升级那一个,desktop 也不例外。desktop
+的探测先看 `DESKTOP_EXE` 启动器记录,再看记录的
+`DESKTOP_DEST`/`desktop.env` 目标位置加平台应用镜像名,与
+`install.sh`/`install.ps1` 的探测一致。`selfUpdatePlan` 增加了 desktop
+分支,像 web/tui 分支一样还原 `DESKTOP_DEST`、`DESKTOP_REPO` 和
+`BIN_DIR`,因此 desktop 升级落在安装器当初放应用的位置,并保留 fork
+来源。
+
+`runSelfUpdate` 委托给新的 `runSelfUpdates`:每个 surface 运行一个安装器,
+启动前播报一次,失败后继续(各 surface 是独立载荷,部分升级仍是进展;第一
+个非零安装器退出码成为命令的退出码)。在 Windows 上,分离助手把每个
+surface 的安装器串在一条 PowerShell 命令里顺序执行——若每个 surface 各起
+一个助手,它们都会在进程退出后醒来,并发安装器会互相踩踏 `launcher.env`
+和启动器写入——持久化的下载脚本也从固定的 `update-install.ps1` 改为按
+surface 命名的 `update-install-<surface>.ps1`,因为来自不同 fork 的 surface
+可能需要不同脚本。
+
+旧的特例被移除:`ohdsh update desktop` 不再打印指针(运行中的桌面会话里,
+应用内更新窗口仍是引导路径);`installerOwnsRoot` 被删除——隐式路径原先
+用它强制"运行中的载荷"必须被安装器持有,这个守卫现在由按 surface 的探测
+直接表达。源码检出中的拒绝行为不变。
+
+## 备选方案
+
+- **保留指针,只升级 web/tui。** 否决:这正是本变更要消除的困惑——一次
+  看起来像失败的机器级半升级。
+- **一次安装器调用带多 surface 标志。** 否决:`install.sh`/`install.ps1`
+  刻意保持一次运行一个 surface(资产选择、暂存与记录均按 surface);循环
+  调用保持安装器简单,失败也相互隔离。
+- **Windows 上每个 surface 各起一个分离助手。** 否决:它们都会在进程退出
+  后醒来并竞争同一批记录与启动器文件;单一链式助手让 Windows 与 Unix 语义
+  一致。
+- **首个失败即中止后续 surface。** 否决:desktop 因权限受阻不应把 web/tui
+  困在旧版本;顺序尽力而为加非零汇总退出码既报告失败又不丢掉其余升级。
+
+## 后果
+
+- 通过安装器升级 desktop 会退出并替换应用包(安装器既有行为);在桌面应用
+  开着时跑 `ohdsh update` 的用户会在下次启动时进入新版本,而不是由更新
+  自己重启应用。
+- 探测信任安装器记录。陈旧记录——例如指向已删除目录的 `BIN_DIR`——会被
+  原样重放进 `--bin-dir`,安装器随后在启动器写入处大声失败;修复记录的
+  办法是为任一 surface 重跑安装器。本次会话恰好在被探针污染的机器上踩到
+  这一点,这也是三个更新测试现在钉住隔离的 `HOME`/`USERPROFILE` 根、不再
+  继承开发者真实记录的原因。
+- 运行中启动器自身的载荷不再守卫隐式更新:手动解压的启动器会愉快地升级
+  每个*已记录的*安装,而自己保持陈旧。分发器——正常入口——总是路由到已
+  记录的载荷,所以这只影响手工放置的启动器。
+- 观察 `update.log` 的 Windows 用户现在看到按 surface 的起止行,而不是
+  一条无名运行。
+
+## 测试
+
+`tests/cli.test.ts` 用注入的更新器覆盖命令契约:无参数时升级全部三个已
+记录的 desktop+web+tui(否则只升级已安装子集),显式 surface 要求该
+surface 已安装,未知 surface / 空机器 / 源码根以指引拒绝。
+`tests/self-update.test.ts` 覆盖 desktop 计划(目标、fork、bin-dir 还原)、
+desktop 探测(`DESKTOP_EXE`,以及各平台下记录/标记目标位置),和
+`runSelfUpdates` 的顺序、失败后继续与首个非零退出码;另有三个旧测试与
+真实用户记录隔离,此前它们依赖开发者机器上的记录。

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write docs/usage.md
-usage.md: 9de70243953a1a26a4a4759d15f3ee7beaf22a73
-usage.zh.md: 61626827bd18c085bacee60d28c6850ad1f7e119
+usage.md: 3a4d77b380d6a7f58124353c3e8b9d228ccac8cd
+usage.zh.md: b1cce7532daf9fb707df34e40e947eabd5160d7d

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,19 +120,22 @@ Every surface checks for a newer stable Release once per launch:
 - **Web** prints the same notice after the listening URL.
 - **Desktop** checks through its update window and shows a system
   notification when a new version is found; clicking it opens the update
-  window. The desktop still installs updates through its own verified
-  updater, not the shell installer.
+  window.
 
-`ohdsh update` (or `ohdsh update web` / `ohdsh update tui`) upgrades a
-packaged web/tui distribution on macOS, Linux, and Windows by re-running
-the matching installer script with the same verification and atomic
-replacement as a fresh install. The installation source is inferred the
-way Codex does it — from the running path, the payload's install marker,
-and the destinations recorded in `launcher.env` — never from a flag baked
-into the build, and the recorded `--dest`/`--bin-dir` are reconstructed so
-an update lands exactly where the install did. An installation at a
-location the installers do not own is refused with guidance. From a source
-checkout it asks you to use git instead.
+`ohdsh update` upgrades every installed surface it detects on the machine —
+desktop, web, and tui — on macOS, Linux, and Windows by re-running the
+matching installer script for each surface with the same verification and
+atomic replacement as a fresh install; pass `ohdsh update web` (or
+`desktop` / `tui`) to upgrade one surface alone. Upgrading the desktop
+through the installer quits and replaces the app bundle, so the running
+application's update window remains the guided path inside a desktop
+session. Detection is inferred the way Codex does it — from the running
+path, the payloads' install markers, and the destinations recorded in
+`launcher.env` — never from a flag baked into the build, and the recorded
+`--dest`/`--bin-dir` are reconstructed so an update lands exactly where
+the install did. A requested surface without an installer-owned
+installation is refused with guidance. From a source checkout it asks you
+to use git instead.
 
 Updates are release-based only: every surface compares against published
 stable GitHub Releases with semver; there is no commit-level or rolling
@@ -147,7 +150,8 @@ repository's `main` branch over TLS when the bundle is absent;
 `OH_DSH_INSTALL_SCRIPT_URL` can point the download at a mirror or a local
 copy for testing. On Windows the update runs detached after the current
 process exits, because the running payload cannot be replaced while it
-executes.
+executes; multiple surfaces run sequentially inside one detached helper so
+concurrent installers never race their record and launcher writes.
 
 ## Install the full distribution
 

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -104,15 +104,18 @@ pnpm run dist:mac && sh install.sh --local --surface desktop --force
   `Oh-DSH 0.1.8 -> 0.2.0 is available. Run "ohdsh update" to upgrade.`
 - **Web** 在监听地址之后打印同样的提示。
 - **Desktop** 通过更新窗口检查，发现新版本时弹出系统通知，点击即可打开
-  更新窗口。desktop 仍通过自带的校验更新器安装更新，而不是 shell 安装器。
+  更新窗口。
 
-`ohdsh update`（或 `ohdsh update web` / `ohdsh update tui`）在 macOS、
-Linux 与 Windows 上升级已打包的 web/tui 发行版：它重新运行对应平台的
-安装脚本，走与全新安装相同的校验与原子替换流程。安装来源采用 Codex
-式的推断——依据运行路径、载荷内的安装标记以及 `launcher.env` 记录的
-目标位置——绝不依赖构建时注入的标记，并会还原安装时的
-`--dest`/`--bin-dir`，让更新落在当初安装的位置。位于安装器不认识的
-路径上的安装会被拒绝并给出指引。在源码检出中执行时会提示改用 git。
+`ohdsh update` 在 macOS、Linux 与 Windows 上升级本机检测到的所有已安装
+surface（desktop、web、tui）：它依次为每个 surface 重新运行对应平台的
+安装脚本，走与全新安装相同的校验与原子替换流程；传 `ohdsh update web`
+（或 `desktop` / `tui`）则只升级一个 surface。通过安装器升级 desktop 会
+退出并替换应用包，因此桌面会话内的引导路径仍是应用自带的更新窗口。
+检测采用 Codex 式的推断——依据运行路径、载荷内的安装标记以及
+`launcher.env` 记录的目标位置——绝不依赖构建时注入的标记，并会还原安装
+时的 `--dest`/`--bin-dir`，让更新落在当初安装的位置。请求了一个安装器
+不认识的 surface 时会被拒绝并给出指引。在源码检出中执行时会提示改用
+git。
 
 更新只基于 Release：所有 surface 都用 semver 与已发布的稳定 GitHub
 Release 比较；不存在 commit 级或滚动更新通道。
@@ -123,7 +126,8 @@ Release 比较；不存在 commit 级或滚动更新通道。
 脚本，仅当包内没有时才通过 TLS 从仓库 `main` 分支下载；
 `OH_DSH_INSTALL_SCRIPT_URL` 可将下载指向镜像或本地副本以便测试。在
 Windows 上，更新会在当前进程退出后以分离方式执行，因为运行中的载荷
-无法在执行时被替换。
+无法在执行时被替换；多个 surface 会在同一个分离助手中按顺序执行，
+避免并发安装器互相踩踏记录与启动器。
 
 ## 安装完整版
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,9 +8,9 @@ import { OH_DSH_HOME_ENV } from './data-root.ts'
 import { UsageError } from './errors.ts'
 import {
   detectDistributionSurface,
-  installerOwnsRoot,
-  runSelfUpdate,
+  runSelfUpdates,
   surfaceIsInstalled,
+  type SelfUpdateSurface,
 } from './self-update.ts'
 import { main as runTui, resolveTuiRoot } from './tui.ts'
 import { main as runWeb } from './web.ts'
@@ -48,9 +48,10 @@ ${surfaces.map(surface => `  ${surface.padEnd(9)} ${descriptions[surface]}`).joi
 ${aliases.length === 0 ? '' : `\nAliases:\n${aliases.map(([alias, surface]) => `  ${alias.padEnd(9)} ${descriptions[surface]}`).join('\n')}`}
 
 Commands:
-  update    Upgrade this installation with the latest stable release
-            installer (web/tui on every platform; the desktop application
-            updates itself through its update window)
+  update    Upgrade through the latest stable release installer. With no
+            surface argument every installed surface (desktop, web, tui)
+            on this machine is detected and upgraded; pass one surface to
+            upgrade it alone.
 
 Run "ohdsh <surface> --help" for surface options.
 `
@@ -181,46 +182,75 @@ export async function launchDesktop(
   })
 }
 
-/** Run "ohdsh update": upgrade the running distribution via the installer. */
+/** Upgrades a list of installed surfaces through the platform installer. */
+export type UpdateSurfaces = (
+  surfaces: readonly SelfUpdateSurface[],
+  env: NodeJS.ProcessEnv,
+  announce: (surface: SelfUpdateSurface) => void,
+) => Promise<number>
+
+async function defaultUpdateSurfaces(
+  surfaces: readonly SelfUpdateSurface[],
+  env: NodeJS.ProcessEnv,
+  announce: (surface: SelfUpdateSurface) => void,
+): Promise<number> {
+  return await runSelfUpdates(
+    surfaces,
+    env,
+    process.platform,
+    undefined,
+    resolveTuiRoot(env),
+    announce,
+  )
+}
+
+/** Run "ohdsh update": upgrade installed distributions via the installer. */
 export async function runUpdateCommand(
   args: readonly string[],
   env: NodeJS.ProcessEnv,
   stdout: NodeJS.WriteStream,
   stderr: NodeJS.WriteStream,
+  updater: UpdateSurfaces = defaultUpdateSurfaces,
 ): Promise<number> {
-  const [requested] = args
-  if (requested !== undefined && !SURFACE_NAMES.includes(requested as SurfaceName)) {
+  const [requested] = args as readonly SelfUpdateSurface[]
+  if (requested !== undefined && !SURFACE_NAMES.includes(requested)) {
     stderr.write(`Unknown surface: ${requested}\n\n${cliHelp(env)}`)
     return 2
   }
   const root = resolveTuiRoot(env)
-  const distribution = detectDistributionSurface(root, env)
-  if (distribution === 'source') {
+  if (detectDistributionSurface(root, env) === 'source') {
     stderr.write('ohdsh update needs a packaged installation; update a source checkout with git instead.\n')
     return 2
   }
-  if (distribution === 'desktop' || requested === 'desktop') {
-    stdout.write('The desktop application updates itself: open Oh-DSH Desktop -> Check for Updates...\n')
-    return 0
-  }
-  const explicit = requested === 'web' || requested === 'tui'
-  const surface = explicit ? requested : distribution
   // Ownership is inferred from install records and paths, never from a build
-  // flag: the detected payload's own root, or — for an explicitly requested
-  // surface — any installer-owned installation of that surface.
-  const owned = explicit
-    ? surfaceIsInstalled(surface, env)
-    : installerOwnsRoot(root, surface, env)
-  if (!owned) {
-    stderr.write(
-      `ohdsh update: no installer-owned ${surface} installation was found` +
-      (explicit ? '' : ` at ${root}`) +
-      '. Re-run install.sh (or install.ps1) with --dest matching the location, or reinstall to the default location.\n',
-    )
-    return 2
+  // flag: one explicitly requested surface, or — with no argument — every
+  // installer-owned installation found on this machine.
+  let targets: readonly SelfUpdateSurface[]
+  if (requested !== undefined) {
+    if (!surfaceIsInstalled(requested, env)) {
+      stderr.write(
+        `ohdsh update: no installer-owned ${requested} installation was found` +
+        '. Re-run install.sh (or install.ps1) with --dest matching the location, or reinstall to the default location.\n',
+      )
+      return 2
+    }
+    targets = [requested]
+  } else {
+    targets = SURFACE_NAMES.filter(surface => surfaceIsInstalled(surface, env))
+    if (targets.length === 0) {
+      stderr.write(
+        'ohdsh update: no installer-owned installation was found' +
+        '. Install first with install.sh (or install.ps1), or pass a surface explicitly.\n',
+      )
+      return 2
+    }
   }
-  stdout.write(`Upgrading Oh-DSH ${surface} with the latest stable release installer...\n`)
-  return await runSelfUpdate(surface, env, process.platform, undefined, root)
+  stdout.write(`Upgrading Oh-DSH ${targets.join(', ')} with the latest stable release installer...\n`)
+  return await updater(
+    targets,
+    env,
+    surface => stdout.write(`\n=== Upgrading Oh-DSH ${surface} ===\n`),
+  )
 }
 
 /** Dispatch one surface command. */

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -186,6 +186,9 @@ export interface LauncherRecord {
   /** Per-surface fork provenance: repositories each payload came from. */
   webRepo?: string
   tuiRepo?: string
+  desktopDest?: string
+  desktopRepo?: string
+  desktopExe?: string
 }
 
 function readTextAt(path: string): string | undefined {
@@ -219,6 +222,9 @@ export function readLauncherRecord(
     else if (line.startsWith('BIN_DIR=')) record.binDir = line.slice('BIN_DIR='.length)
     else if (line.startsWith('WEB_REPO=')) record.webRepo = line.slice('WEB_REPO='.length)
     else if (line.startsWith('TUI_REPO=')) record.tuiRepo = line.slice('TUI_REPO='.length)
+    else if (line.startsWith('DESKTOP_DEST=')) record.desktopDest = line.slice('DESKTOP_DEST='.length)
+    else if (line.startsWith('DESKTOP_REPO=')) record.desktopRepo = line.slice('DESKTOP_REPO='.length)
+    else if (line.startsWith('DESKTOP_EXE=')) record.desktopExe = line.slice('DESKTOP_EXE='.length)
   }
   return record
 }
@@ -283,6 +289,9 @@ export function detectDistributionSurface(
   return 'source'
 }
 
+/** Every distribution the launcher can upgrade through the installers. */
+export type SelfUpdateSurface = 'desktop' | 'web' | 'tui'
+
 /** The command line that upgrades one surface with the platform installer. */
 export interface SelfUpdatePlan {
   scriptUrl: string
@@ -294,7 +303,7 @@ export interface SelfUpdatePlan {
 }
 
 export function selfUpdatePlan(
-  surface: 'web' | 'tui',
+  surface: SelfUpdateSurface,
   platform: NodeJS.Platform = process.platform,
   repository: string = OFFICIAL_REPOSITORY,
   env: NodeJS.ProcessEnv = {},
@@ -303,12 +312,16 @@ export function selfUpdatePlan(
   // Fork installs keep their provenance per surface: the record decides
   // which repository both the script download and the release resolution
   // target, so side-by-side installs from different forks stay separate.
-  const recordRepo = surface === 'web' ? record.webRepo : record.tuiRepo
+  const recordRepo = surface === 'web'
+    ? record.webRepo
+    : surface === 'tui' ? record.tuiRepo : record.desktopRepo
   const effectiveRepo = recordRepo !== undefined && recordRepo !== ''
     ? recordRepo
     : repository
   const scriptUrl = installScriptUrl(platform, effectiveRepo, env)
-  const dest = surface === 'web' ? record.webDest : record.tuiDest
+  const dest = surface === 'web'
+    ? record.webDest
+    : surface === 'tui' ? record.tuiDest : record.desktopDest
   const repoArgs = recordRepo !== undefined && recordRepo !== '' && recordRepo !== repository
     ? platform === 'win32' ? ['-Repo', recordRepo] : ['--repo', recordRepo]
     : []
@@ -333,34 +346,61 @@ export function selfUpdatePlan(
   return { scriptUrl, command: 'sh', args }
 }
 
-/**
- * Verify the running root is a location the installer owns (its recorded or
- * default destination), so an update never silently installs somewhere else.
- */
-export function installerOwnsRoot(
-  root: string,
-  surface: 'web' | 'tui',
-  env: NodeJS.ProcessEnv = process.env,
-  platform: NodeJS.Platform = process.platform,
+/** The desktop app image names the installers place under a destination. */
+function desktopImagePaths(dest: string, platform: NodeJS.Platform): string[] {
+  if (platform === 'darwin') return [join(dest, 'Oh-DSH Desktop.app')]
+  if (platform === 'win32') {
+    // install.ps1 probes both published executable names.
+    return [join(dest, 'Oh-DSH Desktop.exe'), join(dest, 'oh-dsh-desktop.exe')]
+  }
+  return [join(dest, 'oh-dsh-desktop')]
+}
+
+/** The destination the desktop installer marker last recorded, if any. */
+function desktopRecordDest(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const raw = readTextAt(join(installerRecordHome(platform, env), 'desktop.env'))
+  if (raw === undefined) return undefined
+  const content = raw.startsWith('\uFEFF') ? raw.slice(1) : raw
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+    if (!line.startsWith('OH_DSH_INSTALL_DEST=')) continue
+    const value = line.slice('OH_DSH_INSTALL_DEST='.length)
+    return value === '' ? undefined : value
+  }
+  return undefined
+}
+
+function desktopIsInstalled(
+  record: LauncherRecord,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  pathExists: (path: string) => boolean,
 ): boolean {
-  const target = resolve(root)
-  if (markerSurface(target) === surface) return true
-  const payloadHome = installerPayloadHome(platform, env)
-  if (target === resolve(join(payloadHome, surface))) return true
-  const record = readLauncherRecord(env, platform)
-  const recorded = surface === 'web' ? record.webDest : record.tuiDest
-  return recorded !== undefined && recorded !== '' && target === resolve(recorded)
+  if (record.desktopExe !== undefined && record.desktopExe !== '') {
+    return pathExists(record.desktopExe)
+  }
+  const dest = record.desktopDest !== undefined && record.desktopDest !== ''
+    ? record.desktopDest
+    : desktopRecordDest(env, platform)
+  if (dest === undefined) return false
+  return desktopImagePaths(dest, platform).some(pathExists)
 }
 
 /** Whether an installer-owned installation of one surface exists anywhere. */
 export function surfaceIsInstalled(
-  surface: 'web' | 'tui',
+  surface: SelfUpdateSurface,
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
   pathExists: (path: string) => boolean = existsSync,
 ): boolean {
-  const launcher = join('bin', platform === 'win32' ? 'ohdsh.cmd' : 'ohdsh')
   const record = readLauncherRecord(env, platform)
+  if (surface === 'desktop') {
+    return desktopIsInstalled(record, env, platform, pathExists)
+  }
+  const launcher = join('bin', platform === 'win32' ? 'ohdsh.cmd' : 'ohdsh')
   const recorded = surface === 'web' ? record.webDest : record.tuiDest
   if (recorded !== undefined && recorded !== '') {
     return pathExists(join(recorded, launcher))
@@ -391,32 +431,62 @@ function windowsQuoted(value: string): string {
   return `'${value.replaceAll("'", "''")}'`
 }
 
+/** One Windows installer invocation: which script upgrades which surface. */
+interface WindowsUpdateEntry {
+  surface: SelfUpdateSurface
+  scriptPath: string
+  plan: SelfUpdatePlan
+}
+
+async function downloadInstallerScript(
+  url: string,
+  fetchImpl: UpdateFetcher,
+): Promise<string> {
+  try {
+    const response = await fetchImpl(url)
+    if (!response.ok) {
+      throw new Error(`unexpected status ${String(response.status)}`)
+    }
+    return await response.text()
+  } catch (error) {
+    throw new Error(
+      `failed to download the installer from ${url}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+}
+
 /**
  * On Windows the packaged CLI runs from the payload being replaced, and a
  * mapped node.exe cannot be moved while this process lives. Hand the work to
- * a detached helper that waits for this process to exit, then runs the
- * installer on its own.
+ * a detached helper that waits for this process to exit, then runs every
+ * surface's installer sequentially in one helper — concurrent installers
+ * would race each other's launcher and record writes.
  */
 function spawnDetachedWindowsUpdate(
-  scriptPath: string,
-  plan: SelfUpdatePlan,
+  entries: readonly WindowsUpdateEntry[],
   env: NodeJS.ProcessEnv,
 ): number {
-  const flags = plan.args
-    .filter(arg => arg !== '-NoProfile' && arg !== '-ExecutionPolicy'
-      && arg !== 'Bypass' && arg !== '-File' && arg !== '<script>')
-    .map(arg => (arg.startsWith('-') ? arg : windowsQuoted(arg)))
-    .join(' ')
-  const escapedScript = windowsQuoted(scriptPath)
   // The helper is detached with silent stdio, so its diagnostics and exit
   // status are persisted for the user instead of vanishing with the console.
   const logPath = join(installerRecordHome('win32', env), 'update.log')
   const escapedLog = windowsQuoted(logPath)
+  const steps = entries.flatMap(entry => {
+    const flags = entry.plan.args
+      .filter(arg => arg !== '-NoProfile' && arg !== '-ExecutionPolicy'
+        && arg !== 'Bypass' && arg !== '-File' && arg !== '<script>')
+      .map(arg => (arg.startsWith('-') ? arg : windowsQuoted(arg)))
+      .join(' ')
+    return [
+      `Add-Content -LiteralPath ${escapedLog} -Value ([string](Get-Date) + ': updating ${entry.surface}')`,
+      `& ${windowsQuoted(entry.scriptPath)} ${flags} *>> ${escapedLog}`,
+      `Add-Content -LiteralPath ${escapedLog} -Value ([string](Get-Date) + ': ${entry.surface} update exited with ' + $LASTEXITCODE)`,
+    ]
+  }).join('; ')
   const waitAndRun = [
     `while (Get-Process -Id ${String(process.pid)} -ErrorAction SilentlyContinue) { Start-Sleep -Milliseconds 250 }`,
-    `Add-Content -LiteralPath ${escapedLog} -Value ([string](Get-Date) + ': update starting')`,
-    `& ${escapedScript} ${flags} *>> ${escapedLog}`,
-    `Add-Content -LiteralPath ${escapedLog} -Value ([string](Get-Date) + ': update exited with ' + $LASTEXITCODE)`,
+    steps,
   ].join('; ')
   const child = spawn(
     'powershell',
@@ -437,73 +507,82 @@ function spawnDetachedWindowsUpdate(
  * installer runs detached after this process exits (see above).
  */
 export async function runSelfUpdate(
-  surface: 'web' | 'tui',
+  surface: SelfUpdateSurface,
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform = process.platform,
   fetchImpl: UpdateFetcher = fetch,
   root: string = '',
 ): Promise<number> {
-  const plan = selfUpdatePlan(surface, platform, OFFICIAL_REPOSITORY, env)
-  const bundled = root !== '' ? bundledInstallScript(root, platform) : undefined
+  return await runSelfUpdates([surface], env, platform, fetchImpl, root)
+}
+
+/**
+ * Run the installer for every requested surface, in order, announcing each
+ * one before its upgrade starts. A failing surface does not stop the rest:
+ * each is an independent payload, and a partial upgrade is still progress.
+ * The return code is the first nonzero installer exit, or 0 when all pass.
+ */
+export async function runSelfUpdates(
+  surfaces: readonly SelfUpdateSurface[],
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+  fetchImpl: UpdateFetcher = fetch,
+  root: string = '',
+  announce: (surface: SelfUpdateSurface) => void = () => {},
+): Promise<number> {
+  if (surfaces.length === 0) return 2
   if (platform === 'win32') {
-    const scriptPath = bundled ?? join(
-      installerRecordHome(platform, env),
-      'update-install.ps1',
-    )
-    if (bundled === undefined) {
-      let script: string
-      try {
-        const response = await fetchImpl(plan.scriptUrl)
-        if (!response.ok) {
-          throw new Error(`unexpected status ${String(response.status)}`)
+    const bundled = root !== '' ? bundledInstallScript(root, platform) : undefined
+    const entries: WindowsUpdateEntry[] = []
+    const persisted = new Map<string, string>()
+    for (const surface of surfaces) {
+      const plan = selfUpdatePlan(surface, platform, OFFICIAL_REPOSITORY, env)
+      let scriptPath = bundled
+      if (scriptPath === undefined) {
+        const cached = persisted.get(plan.scriptUrl)
+        if (cached === undefined) {
+          const script = await downloadInstallerScript(plan.scriptUrl, fetchImpl)
+          mkdirSync(installerRecordHome(platform, env), { recursive: true })
+          scriptPath = join(installerRecordHome(platform, env), `update-install-${surface}.ps1`)
+          writeFileSync(scriptPath, script, { mode: 0o755 })
+          persisted.set(plan.scriptUrl, scriptPath)
+        } else {
+          scriptPath = cached
         }
-        script = await response.text()
-      } catch (error) {
-        throw new Error(
-          `failed to download the installer from ${plan.scriptUrl}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        )
       }
-      mkdirSync(installerRecordHome(platform, env), { recursive: true })
+      entries.push({ surface, scriptPath, plan })
+    }
+    return spawnDetachedWindowsUpdate(entries, env)
+  }
+  let failure: number | undefined
+  for (const surface of surfaces) {
+    announce(surface)
+    const plan = selfUpdatePlan(surface, platform, OFFICIAL_REPOSITORY, env)
+    const bundled = root !== '' ? bundledInstallScript(root, platform) : undefined
+    let scriptPath = bundled
+    let workdir = ''
+    if (scriptPath === undefined) {
+      const script = await downloadInstallerScript(plan.scriptUrl, fetchImpl)
+      workdir = mkdtempSync(join(tmpdir(), 'oh-dsh-self-update-'))
+      scriptPath = join(workdir, 'install.sh')
       writeFileSync(scriptPath, script, { mode: 0o755 })
     }
-    return spawnDetachedWindowsUpdate(scriptPath, plan, env)
-  }
-  let scriptPath = bundled
-  let workdir = ''
-  if (scriptPath === undefined) {
-    let script: string
     try {
-      const response = await fetchImpl(plan.scriptUrl)
-      if (!response.ok) {
-        throw new Error(`unexpected status ${String(response.status)}`)
-      }
-      script = await response.text()
-    } catch (error) {
-      throw new Error(
-        `failed to download the installer from ${plan.scriptUrl}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      )
+      const args = plan.args.map(arg => (arg === '<script>' ? scriptPath : arg))
+      const code = await new Promise<number>((resolve, reject) => {
+        const child = spawn(plan.command, args, {
+          env,
+          stdio: 'inherit',
+        })
+        child.once('error', reject)
+        child.once('exit', code => {
+          resolve(code ?? 1)
+        })
+      })
+      if (code !== 0 && failure === undefined) failure = code
+    } finally {
+      if (workdir !== '') rmSync(workdir, { force: true, recursive: true })
     }
-    workdir = mkdtempSync(join(tmpdir(), 'oh-dsh-self-update-'))
-    scriptPath = join(workdir, 'install.sh')
-    writeFileSync(scriptPath, script, { mode: 0o755 })
   }
-  try {
-    const args = plan.args.map(arg => (arg === '<script>' ? scriptPath : arg))
-    return await new Promise<number>((resolve, reject) => {
-      const child = spawn(plan.command, args, {
-        env,
-        stdio: 'inherit',
-      })
-      child.once('error', reject)
-      child.once('exit', code => {
-        resolve(code ?? 1)
-      })
-    })
-  } finally {
-    if (workdir !== '') rmSync(workdir, { force: true, recursive: true })
-  }
+  return failure ?? 0
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict'
-import { posix } from 'node:path'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, posix } from 'node:path'
 import { test } from 'node:test'
 import {
   desktopLaunchSpec,
   main,
+  runUpdateCommand,
 } from '../src/cli.ts'
+import type { SelfUpdateSurface } from '../src/self-update.ts'
 
 function output(): { stream: NodeJS.WriteStream; text: () => string } {
   let value = ''
@@ -163,4 +167,150 @@ test('desktop launch resolves paths with target platform semantics', () => {
     args: ['--inspect'],
     command: 'C:\\Tools\\Oh-DSH Desktop.exe',
   })
+})
+
+test('ohdsh update without a surface upgrades every installed surface', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'ohdsh-update-all-'))
+  const recordHome = join(home, '.ohdsh', 'installer')
+  const tuiPayload = join(home, 'tui-root')
+  await mkdir(join(recordHome), { recursive: true })
+  await mkdir(join(tuiPayload, 'bin'), { recursive: true })
+  // The launcher's own payload marker keeps this a packaged distribution.
+  await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
+  await writeFile(join(tuiPayload, 'bin', 'ohdsh'), '')
+  const webPayload = join(home, 'web-root')
+  await mkdir(join(webPayload, 'bin'), { recursive: true })
+  await writeFile(join(webPayload, 'bin', 'ohdsh'), '')
+  const desktopExe = join(home, 'apps', 'Oh-DSH Desktop.app', 'Contents', 'MacOS', 'Oh-DSH Desktop')
+  await mkdir(dirname(desktopExe), { recursive: true })
+  await writeFile(desktopExe, '')
+  await writeFile(
+    join(recordHome, 'launcher.env'),
+    [
+      `WEB_DEST=${webPayload}`,
+      `TUI_DEST=${tuiPayload}`,
+      `DESKTOP_EXE=${desktopExe}`,
+      `BIN_DIR=${join(home, 'bin')}`,
+    ].join('\n') + '\n',
+  )
+  const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
+
+  const upgraded: string[][] = []
+  const stdout = output()
+  assert.equal(await runUpdateCommand(
+    [],
+    env,
+    stdout.stream,
+    output().stream,
+    async (surfaces, _env, announce) => {
+      upgraded.push([...surfaces])
+      for (const surface of surfaces) announce(surface)
+      return 0
+    },
+  ), 0)
+  assert.deepEqual(upgraded, [['desktop', 'web', 'tui']])
+  assert.match(stdout.text(), /Upgrading Oh-DSH desktop, web, tui/)
+  assert.match(stdout.text(), /=== Upgrading Oh-DSH desktop ===/)
+})
+
+test('ohdsh update upgrades only the surfaces that are installed', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'ohdsh-update-tui-only-'))
+  const payloadHome = join(home, '.local', 'share', 'oh-dsh')
+  const tuiPayload = join(payloadHome, 'tui')
+  await mkdir(join(tuiPayload, 'bin'), { recursive: true })
+  await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
+  await writeFile(join(tuiPayload, 'bin', 'ohdsh'), '')
+  const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
+
+  const upgraded: string[][] = []
+  assert.equal(await runUpdateCommand(
+    [],
+    env,
+    output().stream,
+    output().stream,
+    async surfaces => {
+      upgraded.push([...surfaces])
+      return 0
+    },
+  ), 0)
+  assert.deepEqual(upgraded, [['tui']])
+})
+
+test('ohdsh update <surface> requires that surface to be installed', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'ohdsh-update-explicit-'))
+  const payloadHome = join(home, '.local', 'share', 'oh-dsh')
+  const tuiPayload = join(payloadHome, 'tui')
+  await mkdir(join(tuiPayload, 'bin'), { recursive: true })
+  await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
+  await writeFile(join(tuiPayload, 'bin', 'ohdsh'), '')
+  const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
+
+  const stderr = output()
+  assert.equal(await runUpdateCommand(
+    ['desktop'],
+    env,
+    output().stream,
+    stderr.stream,
+    async () => 0,
+  ), 2)
+  assert.match(stderr.text(), /no installer-owned desktop installation was found/)
+
+  const upgraded: string[][] = []
+  const recorder = async (surfaces: readonly SelfUpdateSurface[]): Promise<number> => {
+    upgraded.push([...surfaces])
+    return 0
+  }
+  assert.equal(await runUpdateCommand(
+    ['web'],
+    env,
+    output().stream,
+    output().stream,
+    recorder,
+  ), 2)
+  assert.deepEqual(upgraded, [])
+
+  assert.equal(await runUpdateCommand(
+    ['tui'],
+    env,
+    output().stream,
+    output().stream,
+    recorder,
+  ), 0)
+  assert.deepEqual(upgraded, [['tui']])
+})
+
+test('ohdsh update rejects unknown surfaces, empty machines, and source roots', async () => {
+  const stderr = output()
+  assert.equal(await runUpdateCommand(
+    ['wireless'],
+    { DSH_OH_TUI_ROOT: '/nonexistent-oh-dsh-payload' },
+    output().stream,
+    stderr.stream,
+    async () => 0,
+  ), 2)
+  assert.match(stderr.text(), /Unknown surface: wireless/)
+
+  const home = await mkdtemp(join(tmpdir(), 'ohdsh-update-empty-'))
+  const payloadRoot = join(home, 'tui-root')
+  await mkdir(payloadRoot, { recursive: true })
+  await writeFile(join(payloadRoot, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
+  const source = output()
+  assert.equal(await runUpdateCommand(
+    [],
+    { HOME: home, DSH_OH_TUI_ROOT: payloadRoot },
+    output().stream,
+    source.stream,
+    async () => 0,
+  ), 2)
+  assert.match(source.text(), /no installer-owned installation was found/)
+
+  const checkout = output()
+  assert.equal(await runUpdateCommand(
+    [],
+    { HOME: home, OH_DSH_SOURCE_ROOT: home },
+    output().stream,
+    checkout.stream,
+    async () => 0,
+  ), 2)
+  assert.match(checkout.text(), /needs a packaged installation/)
 })

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -199,7 +199,8 @@ test('ohdsh update without a surface upgrades every installed surface', async ()
       `BIN_DIR=${join(home, 'bin')}`,
     ].join('\n') + '\n',
   )
-  const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
+  // Windows derives the installer record root from USERPROFILE, not HOME.
+  const env = { HOME: home, USERPROFILE: home, DSH_OH_TUI_ROOT: tuiPayload }
 
   const upgraded: string[][] = []
   const stdout = output()
@@ -226,7 +227,8 @@ test('ohdsh update upgrades only the surfaces that are installed', async () => {
   await mkdir(join(tuiPayload, 'bin'), { recursive: true })
   await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
   await writePayloadLauncher(tuiPayload)
-  const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
+  // Windows derives the installer record root from USERPROFILE, not HOME.
+  const env = { HOME: home, USERPROFILE: home, DSH_OH_TUI_ROOT: tuiPayload }
 
   const upgraded: string[][] = []
   assert.equal(await runUpdateCommand(
@@ -249,7 +251,8 @@ test('ohdsh update <surface> requires that surface to be installed', async () =>
   await mkdir(join(tuiPayload, 'bin'), { recursive: true })
   await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
   await writePayloadLauncher(tuiPayload)
-  const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
+  // Windows derives the installer record root from USERPROFILE, not HOME.
+  const env = { HOME: home, USERPROFILE: home, DSH_OH_TUI_ROOT: tuiPayload }
 
   const stderr = output()
   assert.equal(await runUpdateCommand(
@@ -303,7 +306,7 @@ test('ohdsh update rejects unknown surfaces, empty machines, and source roots', 
   const source = output()
   assert.equal(await runUpdateCommand(
     [],
-    { HOME: home, DSH_OH_TUI_ROOT: payloadRoot },
+    { HOME: home, USERPROFILE: home, DSH_OH_TUI_ROOT: payloadRoot },
     output().stream,
     source.stream,
     async () => 0,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -222,11 +222,15 @@ test('ohdsh update without a surface upgrades every installed surface', async ()
 
 test('ohdsh update upgrades only the surfaces that are installed', async () => {
   const home = await mkdtemp(join(tmpdir(), 'ohdsh-update-tui-only-'))
-  const payloadHome = join(home, '.local', 'share', 'oh-dsh')
-  const tuiPayload = join(payloadHome, 'tui')
+  const tuiPayload = join(home, 'tui-root')
   await mkdir(join(tuiPayload, 'bin'), { recursive: true })
   await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
   await writePayloadLauncher(tuiPayload)
+  // A recorded destination keeps detection off the platform-specific
+  // default payload path (XDG data home vs AppData\Local).
+  const recordHome = join(home, '.ohdsh', 'installer')
+  await mkdir(recordHome, { recursive: true })
+  await writeFile(join(recordHome, 'launcher.env'), `TUI_DEST=${tuiPayload}\n`)
   // Windows derives the installer record root from USERPROFILE, not HOME.
   const env = { HOME: home, USERPROFILE: home, DSH_OH_TUI_ROOT: tuiPayload }
 
@@ -246,11 +250,15 @@ test('ohdsh update upgrades only the surfaces that are installed', async () => {
 
 test('ohdsh update <surface> requires that surface to be installed', async () => {
   const home = await mkdtemp(join(tmpdir(), 'ohdsh-update-explicit-'))
-  const payloadHome = join(home, '.local', 'share', 'oh-dsh')
-  const tuiPayload = join(payloadHome, 'tui')
+  const tuiPayload = join(home, 'tui-root')
   await mkdir(join(tuiPayload, 'bin'), { recursive: true })
   await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
   await writePayloadLauncher(tuiPayload)
+  // A recorded destination keeps detection off the platform-specific
+  // default payload path (XDG data home vs AppData\Local).
+  const recordHome = join(home, '.ohdsh', 'installer')
+  await mkdir(recordHome, { recursive: true })
+  await writeFile(join(recordHome, 'launcher.env'), `TUI_DEST=${tuiPayload}\n`)
   // Windows derives the installer record root from USERPROFILE, not HOME.
   const env = { HOME: home, USERPROFILE: home, DSH_OH_TUI_ROOT: tuiPayload }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -24,6 +24,12 @@ function output(): { stream: NodeJS.WriteStream; text: () => string } {
   }
 }
 
+/** Write the payload launcher files surfaceIsInstalled probes per platform. */
+async function writePayloadLauncher(payload: string): Promise<void> {
+  await writeFile(join(payload, 'bin', 'ohdsh'), '')
+  await writeFile(join(payload, 'bin', 'ohdsh.cmd'), '')
+}
+
 test('ohdsh dispatches desktop aliases, web, and TUI through one surface command', async () => {
   const stdout = output()
   const stderr = output()
@@ -177,10 +183,10 @@ test('ohdsh update without a surface upgrades every installed surface', async ()
   await mkdir(join(tuiPayload, 'bin'), { recursive: true })
   // The launcher's own payload marker keeps this a packaged distribution.
   await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
-  await writeFile(join(tuiPayload, 'bin', 'ohdsh'), '')
+  await writePayloadLauncher(tuiPayload)
   const webPayload = join(home, 'web-root')
   await mkdir(join(webPayload, 'bin'), { recursive: true })
-  await writeFile(join(webPayload, 'bin', 'ohdsh'), '')
+  await writePayloadLauncher(webPayload)
   const desktopExe = join(home, 'apps', 'Oh-DSH Desktop.app', 'Contents', 'MacOS', 'Oh-DSH Desktop')
   await mkdir(dirname(desktopExe), { recursive: true })
   await writeFile(desktopExe, '')
@@ -219,7 +225,7 @@ test('ohdsh update upgrades only the surfaces that are installed', async () => {
   const tuiPayload = join(payloadHome, 'tui')
   await mkdir(join(tuiPayload, 'bin'), { recursive: true })
   await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
-  await writeFile(join(tuiPayload, 'bin', 'ohdsh'), '')
+  await writePayloadLauncher(tuiPayload)
   const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
 
   const upgraded: string[][] = []
@@ -242,7 +248,7 @@ test('ohdsh update <surface> requires that surface to be installed', async () =>
   const tuiPayload = join(payloadHome, 'tui')
   await mkdir(join(tuiPayload, 'bin'), { recursive: true })
   await writeFile(join(tuiPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=tui\n')
-  await writeFile(join(tuiPayload, 'bin', 'ohdsh'), '')
+  await writePayloadLauncher(tuiPayload)
   const env = { HOME: home, DSH_OH_TUI_ROOT: tuiPayload }
 
   const stderr = output()

--- a/tests/self-update.test.ts
+++ b/tests/self-update.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { test } from 'node:test'
 import {
   bundledInstallScript,
@@ -10,16 +10,17 @@ import {
   fetchLatestVersion,
   formatUpdateNotice,
   installScriptUrl,
-  installerOwnsRoot,
   installerPayloadHome,
   installerRecordHome,
   latestReleaseApiUrl,
   readLauncherRecord,
   runSelfUpdate,
+  runSelfUpdates,
   selfUpdatePlan,
   surfaceIsInstalled,
   startupUpdateNotice,
   updateCheckEnabled,
+  type SelfUpdateSurface,
   type UpdateFetcher,
 } from '../src/self-update.ts'
 
@@ -128,6 +129,9 @@ test('installer plans target the platform script and surface', () => {
 
   const windowsPlan = selfUpdatePlan('tui', 'win32', 'hust-open-atom-club/oh-dsh', {
     LOCALAPPDATA: 'Z:\\no-such-place',
+    // Without USERPROFILE the record home falls back to the real profile
+    // and would read this machine's launcher records.
+    USERPROFILE: 'Z:\\no-such-profile',
   })
   assert.equal(windowsPlan.command, 'powershell')
   assert.deepEqual(
@@ -172,7 +176,8 @@ test('runSelfUpdate downloads and executes the installer for the surface', { ski
   const body = Buffer.from(script, 'utf8')
 
   const fetchImpl: UpdateFetcher = async () => new Response(body, { status: 200 })
-  const code = await runSelfUpdate('web', { ...process.env }, 'linux', fetchImpl)
+  // An isolated HOME keeps the plan free of this machine's real records.
+  const code = await runSelfUpdate('web', { ...process.env, HOME: home }, 'linux', fetchImpl)
   assert.equal(code, 0)
   assert.equal(await readFile(ranPath, 'utf8'), '--surface web\n')
 })
@@ -222,26 +227,91 @@ test('selfUpdatePlan reconstructs recorded destinations per platform', async () 
   assert.deepEqual(winPlan.args.slice(-4), ['-Dest', 'C:\\custom web', '-BinDir', 'C:\\custom bin'])
 })
 
-test('installer ownership follows markers, defaults, and records', async () => {
-  const home = await mkdtemp(join(tmpdir(), 'oh-dsh-owns-'))
+test('desktop plans reconstruct the recorded destination and fork', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'oh-dsh-plan-desktop-'))
   const recordHome = join(home, '.ohdsh', 'installer')
-  const payloadHome = join(home, '.local', 'share', 'oh-dsh')
+  await mkdir(recordHome, { recursive: true })
+  await writeFile(
+    join(recordHome, 'launcher.env'),
+    'DESKTOP_DEST=/Applications\nDESKTOP_REPO=some-fork/oh-dsh\nBIN_DIR=/custom/bin\n',
+  )
+  const plan = selfUpdatePlan('desktop', 'linux', 'hust-open-atom-club/oh-dsh', { HOME: home })
+  assert.equal(plan.scriptUrl, 'https://raw.githubusercontent.com/some-fork/oh-dsh/main/install.sh')
+  assert.deepEqual(plan.args, [
+    '<script>', '--surface', 'desktop',
+    '--dest', '/Applications',
+    '--bin-dir', '/custom/bin',
+    '--repo', 'some-fork/oh-dsh',
+  ])
+
+  const plainHome = await mkdtemp(join(tmpdir(), 'oh-dsh-plan-desktop-empty-'))
+  const plain = selfUpdatePlan('desktop', 'darwin', 'hust-open-atom-club/oh-dsh', { HOME: plainHome })
+  assert.deepEqual(plain.args, ['<script>', '--surface', 'desktop'])
+})
+
+test('desktop detection follows DESKTOP_EXE, records, and the marker', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'oh-dsh-desktop-installed-'))
+  const recordHome = join(home, '.ohdsh', 'installer')
   const env = { HOME: home }
 
-  const defaultPayload = join(payloadHome, 'web')
-  await mkdir(defaultPayload, { recursive: true })
-  await writeFile(join(defaultPayload, '.oh-dsh-install.env'), 'OH_DSH_INSTALL_SURFACE=web\n')
-  assert.equal(installerOwnsRoot(defaultPayload, 'web', env, 'linux'), true)
-  assert.equal(installerOwnsRoot(defaultPayload, 'tui', env, 'linux'), false)
+  assert.equal(surfaceIsInstalled('desktop', env, 'darwin'), false)
 
-  const foreign = join(home, 'elsewhere')
-  await mkdir(join(foreign, 'lib'), { recursive: true })
-  assert.equal(installerOwnsRoot(foreign, 'web', env, 'linux'), false)
-
-  const custom = join(home, 'custom tui')
+  // The recorded executable path is the primary probe on every platform.
   await mkdir(recordHome, { recursive: true })
-  await writeFile(join(recordHome, 'launcher.env'), `TUI_DEST=${custom}\nBIN_DIR=${join(home, 'bin')}\n`)
-  assert.equal(installerOwnsRoot(custom, 'tui', env, 'linux'), true)
+  const appExe = join(home, 'Applications', 'Oh-DSH Desktop.app', 'Contents', 'MacOS', 'Oh-DSH Desktop')
+  await writeFile(join(recordHome, 'launcher.env'), `DESKTOP_EXE=${appExe}\n`)
+  assert.equal(surfaceIsInstalled('desktop', env, 'darwin'), false)
+  await mkdir(dirname(appExe), { recursive: true })
+  await writeFile(appExe, '')
+  assert.equal(surfaceIsInstalled('desktop', env, 'darwin'), true)
+
+  // Without DESKTOP_EXE, the launcher record's destination and its app
+  // image decide; the desktop.env marker covers records that predate it.
+  const markerHome = await mkdtemp(join(tmpdir(), 'oh-dsh-desktop-marker-'))
+  const markerRecords = join(markerHome, '.ohdsh', 'installer')
+  const markerApps = join(markerHome, 'apps')
+  await mkdir(markerRecords, { recursive: true })
+  await writeFile(
+    join(markerRecords, 'desktop.env'),
+    `OH_DSH_INSTALL_SURFACE=desktop\nOH_DSH_INSTALL_DEST=${markerApps}\n`,
+  )
+  const markerEnv = { HOME: markerHome }
+  assert.equal(surfaceIsInstalled('desktop', markerEnv, 'linux'), false)
+  await mkdir(markerApps, { recursive: true })
+  await writeFile(join(markerApps, 'oh-dsh-desktop'), '')
+  assert.equal(surfaceIsInstalled('desktop', markerEnv, 'linux'), true)
+  assert.equal(surfaceIsInstalled('desktop', markerEnv, 'darwin'), false)
+})
+
+test('runSelfUpdates upgrades every surface and keeps going past a failure', { skip: !isUnix }, async () => {
+  const home = await mkdtemp(join(tmpdir(), 'oh-dsh-selfupdates-'))
+  const ranDir = join(home, 'runs')
+  await mkdir(ranDir, { recursive: true })
+  // The downloaded script records its arguments per invocation and fails
+  // only for the desktop surface, so the run proves both ordering and the
+  // continue-past-failure contract.
+  const script = [
+    '#!/bin/sh',
+    `printf '%s\\n' "$*" >> ${JSON.stringify(join(ranDir, 'log.txt'))}`,
+    `[ "$2" = desktop ] && exit 3`,
+    'exit 0',
+  ].join('\n')
+  const body = Buffer.from(script, 'utf8')
+  const fetchImpl: UpdateFetcher = async () => new Response(body, { status: 200 })
+
+  const announced: SelfUpdateSurface[] = []
+  const code = await runSelfUpdates(
+    ['desktop', 'web', 'tui'],
+    { ...process.env, HOME: home },
+    'linux',
+    fetchImpl,
+    '',
+    surface => { announced.push(surface) },
+  )
+  assert.equal(code, 3)
+  assert.deepEqual(announced, ['desktop', 'web', 'tui'])
+  const log = (await readFile(join(ranDir, 'log.txt'), 'utf8')).split('\n').filter(line => line !== '')
+  assert.deepEqual(log.map(line => line.split(' ')[1]), ['desktop', 'web', 'tui'])
 })
 
 test('detection prefers the payload marker and app path over layout probes', async () => {
@@ -305,7 +375,14 @@ test('the bundled installer script is preferred over a download', { skip: !isUni
     fetched = true
     return new Response('# downloaded', { status: 200 })
   }
-  const code = await runSelfUpdate('tui', { ...process.env }, 'linux', fetchImpl, packageRoot)
+  // An isolated HOME keeps the plan free of this machine's real records.
+  const code = await runSelfUpdate(
+    'tui',
+    { ...process.env, HOME: home },
+    'linux',
+    fetchImpl,
+    packageRoot,
+  )
   assert.equal(code, 0)
   assert.equal(fetched, false, 'no download when the package bundles the script')
   assert.equal(await readFile(ranPath, 'utf8'), '--surface tui\n')


### PR DESCRIPTION
## Scope

Re-implements the launcher's update command so a bare `ohdsh update`
upgrades the machine, not one payload:

- **No argument:** probe desktop, web, and tui through the installer
  records (`DESKTOP_EXE` first, then recorded/marker destinations) and
  upgrade every installation found, in that order. A machine with only
  some surfaces installed upgrades exactly those; none installed refuses
  with guidance.
- **Explicit surface:** upgrade that surface alone — `ohdsh update
  desktop` now runs the installer instead of printing a pointer to the
  app's update window (which remains the guided path inside a running
  desktop session). An uninstalled surface is refused with guidance.
- **`runSelfUpdates`:** one installer per surface, announced before it
  starts, continuing past failures (first nonzero exit becomes the
  command's exit). Windows chains every surface sequentially inside one
  detached helper so concurrent installers cannot race record and
  launcher writes; the persisted script becomes per-surface
  `update-install-<surface>.ps1` since fork installs may differ.
- **Removed:** `installerOwnsRoot` — the per-surface probe now expresses
  the ownership guard the implicit path used it for.
- Docs updated in both languages; Agent Note
  `2026-09-09-ohdsh-update-upgrades-all-installed-surfaces` records the
  decision and rejected alternatives.
- Three pre-existing update tests now pin isolated `HOME`/`USERPROFILE`
  roots; they had been reading the developer machine's real launcher
  records (and failed there twice when those records went stale).

## Verification

- `pnpm run typecheck`, `pnpm test` (401 tests: 392 pass, 9 platform
  skips, 0 fail with an isolated HOME), `pnpm run build`
- End-to-end in an isolated root: `install.sh --local` tui+web, web
  downgraded to v0.1.11, then a bare `ohdsh update` detected both
  surfaces, upgraded web to the released 0.2.0 with checksum
  verification, skipped the current tui, and refused an uninstalled
  desktop with exit 2
- Agent Notes gates and bilingual pairing pass