### PR TITLE
release: prepare Oh-DSH 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oh-dsh/desktop",
   "productName": "Oh-DSH Desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness",
   "author": "dsh-external",
   "desktopName": "oh-dsh-desktop.desktop",


### PR DESCRIPTION
## Scope

Release preparation for **v0.2.1** — shipping the reworked update
command (everything from #221):

- `package.json` → `0.2.1` (tag `v0.2.1` is created only after this PR
  merges, per the release workflow).
- No other changes; the feature shipped on main through #221: a bare
  `ohdsh update` auto-detects every installed surface (desktop, web,
  tui) and upgrades each one, explicit single-surface updates cover
  desktop too, and Windows chains all surfaces sequentially in one
  detached helper.

## Checks

- `node scripts/validate-release-tag.mjs --tag v0.2.1 --version 0.2.1` — validated
- `pnpm run typecheck` — clean
- `pnpm test` — 401 tests: 392 pass / 0 fail / 9 platform skips (isolated HOME)
- `pnpm run build` — clean
- Agent Notes gates + bilingual pairing — clean
- `git diff --check` — clean